### PR TITLE
feat: make LandingPage responsive across monitor → mobile

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -119,6 +119,8 @@
 .mac-screen {
   width: 90vw;
   height: 85vh;
+  max-width: 1500px;
+  max-height: 920px;
   background: #62dcf537;
   border: 2px solid #3b3a3a;
   display: flex;
@@ -300,7 +302,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 400px;
+  width: min(400px, calc(100vw - 48px));
   background: #ffffff;
   border: 2px solid #3b3a3a;
   box-shadow: 2px 2px 0px #3b3a3a;
@@ -411,4 +413,69 @@
   color: #ffffff;
 }
 
-/* Responsive adjustments */
+/* ==========================================================================
+   Responsive adjustments
+   The retro "screen" is a single layout across every device. We keep the
+   framed-screen identity at all sizes and only reflow the contents:
+     - monitors: the frame is capped (see .mac-screen max-width/height)
+     - tablets:  the frame grows toward the viewport edges
+     - phones:   desktop icons drop into a bottom dock and the welcome card
+                 sits centered above it, so the two never overlap
+   ========================================================================== */
+
+/* Tablet — give the framed screen more breathing room */
+@media (max-width: 768px) {
+  .mac-screen {
+    width: 94vw;
+    height: 88vh;
+    height: 88dvh;
+  }
+}
+
+/* Phone — reflow the desktop into a centered card + bottom app dock */
+@media (max-width: 600px) {
+  .mac-screen {
+    width: 96vw;
+    height: 92vh;
+    height: 92dvh;
+  }
+
+  .desktop {
+    padding: 16px;
+  }
+
+  /* App icons become a horizontal dock pinned just above the taskbar,
+     so they no longer collide with the centered welcome window. */
+  .desktop-items {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 14px;
+    right: auto;
+    top: auto;
+    left: 50%;
+    bottom: 14px;
+    transform: translateX(-50%);
+    max-width: calc(100% - 24px);
+  }
+
+  .desktop-icon .icon-image {
+    width: 46px;
+    height: 46px;
+  }
+
+  /* Lift the welcome card above the dock and let it use the full width. */
+  .welcome-window {
+    top: 44%;
+  }
+}
+
+@media (max-width: 380px) {
+  .desktop-items {
+    gap: 10px;
+  }
+
+  .welcome-window {
+    top: 42%;
+  }
+}

--- a/src/components/layout/LandingPage/LandingPage.menu.css
+++ b/src/components/layout/LandingPage/LandingPage.menu.css
@@ -1773,7 +1773,13 @@
   }
 
   .menu-item {
-    padding: 6px 9px;
+    /* Keep horizontal footprint compact so all items fit a narrow bar,
+       but give a full-height (>=44px) tap target — .menu-item is a span,
+       so use inline-flex to make min-height take effect. */
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 6px 10px;
   }
 
   /* Make .menu-bar (position: relative) the dropdown's containing block. */

--- a/src/components/layout/LandingPage/LandingPage.menu.css
+++ b/src/components/layout/LandingPage/LandingPage.menu.css
@@ -1758,3 +1758,48 @@
   /* Firefox */
   scrollbar-color: #94a3b8 rgba(243, 244, 246, 0.5);
 }
+
+/* ==========================================================================
+   Phone — keep dropdowns inside the viewport.
+   On desktop each dropdown is anchored to its menu item (which sits at an
+   arbitrary x), so on a narrow screen a left-aligned dropdown overflows the
+   right edge. We neutralize the item as the positioning context so the
+   dropdown anchors to the full-width .menu-bar instead, then pin it edge to
+   edge below the bar. This needs no JS and no per-item coordinates.
+   ========================================================================== */
+@media (max-width: 600px) {
+  .menu-bar {
+    padding: 6px 10px;
+  }
+
+  .menu-item {
+    padding: 6px 9px;
+  }
+
+  /* Make .menu-bar (position: relative) the dropdown's containing block. */
+  .menu-item-wrapper {
+    position: static;
+  }
+
+  .menu-dropdown {
+    left: 10px;
+    right: 10px;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+  }
+
+  /* The little arrow points at the item; meaningless once detached. */
+  .menu-dropdown::before {
+    display: none;
+  }
+
+  /* Inner lists must not force the dropdown wider than the screen. */
+  .menu-dropdown-pills,
+  .menu-dropdown-services,
+  .menu-dropdown-projects,
+  .menu-dropdown-project-item {
+    min-width: 0;
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
**Phase 2 of 4** — making the single `LandingPage` layout responsive. Phase 1 (#17, merged) collapsed the desktop/mobile split into one layout; that left small screens rendering an unusable desktop view. This makes the one retro-screen layout adapt across **monitor → desktop → laptop → tablet → mobile** while keeping the framed-screen identity intact.

## The problems (from a structure audit)
- `.welcome-window` had a hard `width: 400px` → overflowed any viewport < ~420px.
- Desktop icons were absolutely pinned `top-right`; the welcome card was absolutely centered → at phone width the two **overlapped**.
- Menu dropdowns were anchored to their (arbitrarily-positioned) menu item with `min-width` floors → **overflowed the right edge** on narrow screens.
- The frame (`90vw/85vh`) had no upper bound → sprawled on ultrawide monitors.

## What changed (CSS only)
- **Monitors:** cap `.mac-screen` at `max-width: 1500px / max-height: 920px` so the frame stays a deliberate centered screen.
- **Welcome window:** fluid `width: min(400px, calc(100vw - 48px))` — fixes the core overflow at every size.
- **Tablet (≤768px):** frame grows toward the viewport edges (`94vw`).
- **Phone (≤600px):** app icons reflow from a top-right vertical column into a **centered bottom dock**, welcome card lifts to `top: 44%` above it → the two never overlap. Icons shrink slightly for tap comfort.
- **Phone menus:** make `.menu-item-wrapper` `position: static` so dropdowns anchor to the **full-width `.menu-bar`** instead of the item, pinned edge-to-edge below the bar — no JS, no per-item coordinates. Inner lists no longer force widths past the screen; the now-meaningless pointer arrow is hidden.

Modals were already responsive (`svw/svh`, `clamp`, safe-area insets) — untouched.

## Verification
- `tsc --noEmit` ✅ · `next build` ✅ — home route unchanged at **39.1 kB** (CSS-only).
- **Please eyeball the Vercel preview** at phone / tablet / desktop / ultrawide widths once it deploys — this is a visual change, so the preview is the real check. Key things to confirm: welcome card never overflows, icon dock doesn't overlap the card on phones, and the About/Services/Projects dropdowns stay inside the screen on mobile.

## Remaining phases (separate PRs)
3. Aesthetic cohesion — modals → retro-Mac.
4. Role Bullets + Toolbelt content redesigns (summary-first + filter).

https://claude.ai/code/session_01PCQTWMcF9eN4mREyF6F2Ad

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCQTWMcF9eN4mREyF6F2Ad)_