### PR TITLE
feat: light-theme all modals (Phase 3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,22 @@
   --noir-border: rgba(220, 175, 130, 0.1);
   --noir-panel: rgba(255, 255, 255, 0.03);
   --noir-panel-strong: rgba(255, 255, 255, 0.05);
+
+  /* ===== Light modal design tokens (Phase 3 migration target) =====
+     Mirror of the noir tokens for modals re-skinned to the light desktop
+     palette. A modal opts in with <ModalFrame variant="light"> for the
+     shell; its content CSS aliases these to its own semantic names. */
+  --light-accent: #b65f38;
+  --light-accent-soft: rgba(182, 95, 56, 0.1);
+  --light-accent-line: rgba(182, 95, 56, 0.3);
+  --light-accent-glow: rgba(182, 95, 56, 0.2);
+  --light-text: #2b2a28;
+  --light-muted: #585c63;
+  --light-faint: #888d95;
+  --light-border: rgba(43, 42, 40, 0.14);
+  --light-panel: #f4f5f7;
+  --light-panel-strong: #eaecef;
+  --light-surface: #ffffff;
 }
 
 /* Strict CSS reset for html and body */

--- a/src/components/features/about/AboutMeModal/AboutMeModal.css
+++ b/src/components/features/about/AboutMeModal/AboutMeModal.css
@@ -1,14 +1,14 @@
 /* ===== ABOUT — "THE DOSSIER" / CHAPTERED NARRATIVE ===== */
 
 .about-dossier {
-  --about-accent: var(--noir-accent);
-  --about-accent-soft: var(--noir-accent-soft);
-  --about-accent-glow: var(--noir-accent-glow);
-  --about-text: var(--noir-text);
-  --about-muted: var(--noir-muted);
-  --about-faint: var(--noir-faint);
-  --about-border: var(--noir-border);
-  --about-panel: var(--noir-panel);
+  --about-accent: var(--light-accent);
+  --about-accent-soft: var(--light-accent-soft);
+  --about-accent-glow: var(--light-accent-glow);
+  --about-text: var(--light-text);
+  --about-muted: var(--light-muted);
+  --about-faint: var(--light-faint);
+  --about-border: var(--light-border);
+  --about-panel: var(--light-panel);
 
   display: grid;
   grid-template-columns: 210px 1fr;
@@ -26,7 +26,7 @@
   gap: 0.2rem;
   padding: 1rem 0.7rem;
   border-right: 1px solid var(--about-border);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--about-panel);
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -61,8 +61,8 @@
 }
 
 .about-rail-item:hover:not(.active) {
-  background: rgba(255, 255, 255, 0.03);
-  color: rgba(240, 236, 232, 0.78);
+  background: var(--about-panel);
+  color: rgba(43, 42, 40, 0.78);
 }
 
 .about-rail-item.active {
@@ -96,7 +96,7 @@
 .about-rail-item:focus-visible,
 .about-prog-arrow:focus-visible,
 .about-pill:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid rgba(182, 95, 56, 0.55);
   outline-offset: 2px;
 }
 
@@ -167,9 +167,9 @@
 }
 
 .about-highlight-card:hover {
-  border-color: rgba(212, 132, 90, 0.24);
+  border-color: rgba(182, 95, 56, 0.24);
   transform: translateY(-2px);
-  background: rgba(212, 132, 90, 0.05);
+  background: rgba(182, 95, 56, 0.05);
 }
 
 .about-highlight-card h3 {
@@ -204,7 +204,7 @@
   padding-left: 1.5rem;
   font-size: 0.92rem;
   line-height: 1.58;
-  color: rgba(240, 236, 232, 0.72);
+  color: rgba(43, 42, 40, 0.72);
 }
 
 .about-points li::before {
@@ -231,10 +231,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid rgba(220, 175, 130, 0.14);
+  border: 1px solid rgba(43, 42, 40, 0.14);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(240, 236, 232, 0.68);
+  background: var(--about-panel);
+  color: rgba(43, 42, 40, 0.68);
   font-family: inherit;
   font-size: 0.8rem;
   font-weight: 600;
@@ -245,18 +245,18 @@
 }
 
 .about-pill.clickable {
-  border-color: rgba(212, 132, 90, 0.24);
+  border-color: rgba(182, 95, 56, 0.24);
 }
 
 .about-pill:hover {
-  border-color: rgba(212, 132, 90, 0.4);
-  color: rgba(240, 236, 232, 0.9);
+  border-color: rgba(182, 95, 56, 0.4);
+  color: rgba(43, 42, 40, 0.9);
   transform: translateY(-1px);
 }
 
 .about-pill.active {
   color: #fff;
-  border-color: rgba(212, 132, 90, 0.8);
+  border-color: rgba(182, 95, 56, 0.8);
   background: var(--about-accent);
   box-shadow: 0 3px 12px var(--about-accent-glow);
 }
@@ -268,13 +268,13 @@
 
 .about-strength-detail {
   margin-top: 0.5rem;
-  border: 1px solid rgba(212, 132, 90, 0.2);
+  border: 1px solid rgba(182, 95, 56, 0.2);
   border-radius: 0.78rem;
   padding: 0.75rem 0.85rem;
   background:
-    radial-gradient(circle at 0% 0%, rgba(212, 132, 90, 0.08), transparent 60%),
+    radial-gradient(circle at 0% 0%, rgba(182, 95, 56, 0.08), transparent 60%),
     rgba(255, 255, 255, 0.03);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 8px 24px rgba(22, 20, 18, 0.12);
 }
 
 .about-strength-detail-title {
@@ -307,7 +307,7 @@
   gap: 0.85rem;
   padding: 0.6rem 1rem;
   border-top: 1px solid var(--about-border);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--about-panel);
   flex-shrink: 0;
 }
 
@@ -315,9 +315,9 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(220, 175, 130, 0.14);
-  color: rgba(240, 236, 232, 0.45);
+  background: var(--about-panel);
+  border: 1px solid rgba(43, 42, 40, 0.14);
+  color: rgba(43, 42, 40, 0.45);
   font-size: 0.72rem;
   cursor: pointer;
   display: flex;
@@ -329,8 +329,8 @@
 }
 
 .about-prog-arrow:hover:not(:disabled) {
-  background: rgba(212, 132, 90, 0.14);
-  border-color: rgba(212, 132, 90, 0.38);
+  background: rgba(182, 95, 56, 0.14);
+  border-color: rgba(182, 95, 56, 0.38);
   color: var(--about-accent);
   transform: scale(1.05);
 }
@@ -352,16 +352,16 @@
 }
 
 .about-prog-current {
-  color: rgba(212, 132, 90, 0.75);
+  color: rgba(182, 95, 56, 0.75);
 }
 
 .about-prog-sep {
-  color: rgba(240, 236, 232, 0.18);
+  color: rgba(43, 42, 40, 0.18);
   margin: 0 0.15em;
 }
 
 .about-prog-total {
-  color: rgba(240, 236, 232, 0.25);
+  color: rgba(43, 42, 40, 0.25);
 }
 
 /* ── Responsive ───────────────────────────────────────── */

--- a/src/components/features/about/AboutMeModal/AboutMeModal.tsx
+++ b/src/components/features/about/AboutMeModal/AboutMeModal.tsx
@@ -221,6 +221,7 @@ const AboutMeModal: React.FC<AboutMeModalProps> = ({ onClose }) => {
       onClose={onClose}
       title="About"
       size="lg"
+      variant="light"
       titleId="about-title"
       closeAriaLabel="Close about modal"
     >

--- a/src/components/features/contact/ContactForm/ContactForm.css
+++ b/src/components/features/contact/ContactForm/ContactForm.css
@@ -1,14 +1,14 @@
 /* ===== CONTACT — "THE INVITATION" / WARM NOIR ===== */
 
 .contact-invite {
-  --cf-accent: var(--noir-accent);
-  --cf-accent-soft: var(--noir-accent-soft);
-  --cf-accent-glow: var(--noir-accent-glow);
-  --cf-text: var(--noir-text);
-  --cf-muted: var(--noir-muted);
-  --cf-faint: var(--noir-faint);
-  --cf-border: var(--noir-border);
-  --cf-surface: var(--noir-panel);
+  --cf-accent: var(--light-accent);
+  --cf-accent-soft: var(--light-accent-soft);
+  --cf-accent-glow: var(--light-accent-glow);
+  --cf-text: var(--light-text);
+  --cf-muted: var(--light-muted);
+  --cf-faint: var(--light-faint);
+  --cf-border: var(--light-border);
+  --cf-surface: var(--light-panel);
 
   flex: 1;
   min-height: 0;
@@ -89,9 +89,9 @@
 
 .contact-door:hover {
   transform: translateY(-2px);
-  border-color: rgba(212, 132, 90, 0.42);
-  background: rgba(212, 132, 90, 0.07);
-  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.32);
+  border-color: rgba(182, 95, 56, 0.42);
+  background: rgba(182, 95, 56, 0.07);
+  box-shadow: 0 8px 26px rgba(22, 20, 18, 0.14);
 }
 
 .contact-door:active {
@@ -99,7 +99,7 @@
 }
 
 .contact-door:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.6);
+  outline: 2px solid rgba(182, 95, 56, 0.6);
   outline-offset: 2px;
 }
 
@@ -113,7 +113,7 @@
   font-size: 1rem;
   color: var(--cf-accent);
   background: var(--cf-accent-soft);
-  border: 1px solid rgba(212, 132, 90, 0.22);
+  border: 1px solid rgba(182, 95, 56, 0.22);
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
@@ -178,7 +178,7 @@
   content: "";
   height: 1px;
   flex: 1;
-  background: rgba(220, 175, 130, 0.12);
+  background: rgba(43, 42, 40, 0.12);
 }
 
 .contact-quiet-links {
@@ -205,7 +205,7 @@
 
 .quiet-link:hover {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.07);
+  background: var(--cf-surface);
 }
 
 .quiet-link.linkedin:hover {
@@ -215,11 +215,11 @@
 
 .quiet-link.email:hover {
   color: var(--cf-accent);
-  border-color: rgba(212, 132, 90, 0.36);
+  border-color: rgba(182, 95, 56, 0.36);
 }
 
 .quiet-link:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid rgba(182, 95, 56, 0.55);
   outline-offset: 2px;
 }
 
@@ -249,7 +249,7 @@
 }
 
 .contact-back:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid rgba(182, 95, 56, 0.55);
   outline-offset: 2px;
   border-radius: 6px;
 }
@@ -290,7 +290,7 @@
   font-family: inherit;
   color: var(--cf-text);
   outline: none;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.18);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   -webkit-appearance: none;
   appearance: none;
@@ -316,15 +316,15 @@
 
 .field input:focus,
 .field textarea:focus {
-  border-color: rgba(212, 132, 90, 0.5);
-  background: rgba(212, 132, 90, 0.06);
-  box-shadow: 0 0 0 3px rgba(212, 132, 90, 0.12),
-    inset 0 1px 2px rgba(0, 0, 0, 0.12);
+  border-color: rgba(182, 95, 56, 0.5);
+  background: rgba(182, 95, 56, 0.06);
+  box-shadow: 0 0 0 3px rgba(182, 95, 56, 0.12),
+    inset 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .field input:hover:not(:focus),
 .field textarea:hover:not(:focus) {
-  border-color: rgba(220, 175, 130, 0.26);
+  border-color: rgba(43, 42, 40, 0.26);
 }
 
 .field input:focus + label,
@@ -359,7 +359,7 @@
   min-height: 46px;
   padding: 0.7rem 1.4rem;
   border-radius: 11px;
-  border: 1px solid rgba(212, 132, 90, 0.85);
+  border: 1px solid rgba(182, 95, 56, 0.85);
   background: var(--cf-accent);
   color: #fff;
   font-family: inherit;
@@ -374,12 +374,12 @@
 
 .contact-send:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 6px 22px rgba(212, 132, 90, 0.38);
+  box-shadow: 0 6px 22px rgba(182, 95, 56, 0.38);
 }
 
 .contact-send:active:not(:disabled) {
   transform: translateY(0);
-  box-shadow: 0 2px 8px rgba(212, 132, 90, 0.20);
+  box-shadow: 0 2px 8px rgba(182, 95, 56, 0.20);
 }
 
 .contact-send:disabled {
@@ -389,7 +389,7 @@
 }
 
 .contact-send:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.6);
+  outline: 2px solid rgba(182, 95, 56, 0.6);
   outline-offset: 2px;
 }
 
@@ -398,15 +398,15 @@
 }
 
 .contact-send.ghost {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--cf-surface);
   border-color: var(--cf-border);
   color: var(--cf-muted);
   box-shadow: none;
 }
 
 .contact-send.ghost:hover:not(:disabled) {
-  background: rgba(212, 132, 90, 0.08);
-  border-color: rgba(212, 132, 90, 0.36);
+  background: rgba(182, 95, 56, 0.08);
+  border-color: rgba(182, 95, 56, 0.36);
   color: var(--cf-text);
 }
 
@@ -432,8 +432,8 @@
   border-radius: 50%;
   font-size: 1.5rem;
   color: #fff;
-  background: linear-gradient(135deg, #d4845a 0%, #b85f3a 100%);
-  box-shadow: 0 8px 28px rgba(212, 132, 90, 0.45);
+  background: linear-gradient(135deg, #b65f38 0%, #b85f3a 100%);
+  box-shadow: 0 8px 28px rgba(182, 95, 56, 0.45);
 }
 
 .sent-actions {

--- a/src/components/features/contact/ContactForm/ContactForm.tsx
+++ b/src/components/features/contact/ContactForm/ContactForm.tsx
@@ -124,6 +124,7 @@ const ContactForm = ({ onClose }: ModalProps) => {
       onClose={onClose}
       title="Contact"
       size="sm"
+      variant="light"
       titleId="contact-title"
       closeAriaLabel="Close contact modal"
     >

--- a/src/components/features/modal/ModalFrame.module.css
+++ b/src/components/features/modal/ModalFrame.module.css
@@ -230,3 +230,63 @@
     animation: none;
   }
 }
+
+/* ==========================================================================
+   Light variant — re-skins the shared shell to the light desktop palette.
+   Opt in via <ModalFrame variant="light">. Content CSS supplies its own
+   light colors; this only handles the overlay scrim and the window chrome.
+   ========================================================================== */
+.overlay.light {
+  background: linear-gradient(135deg,
+    rgba(40, 36, 33, 0.42) 0%,
+    rgba(40, 36, 33, 0.34) 100%);
+}
+
+.frame.light {
+  border-color: var(--light-border);
+  background: var(--light-surface);
+  box-shadow:
+    0 36px 90px rgba(22, 20, 18, 0.26),
+    0 10px 28px rgba(22, 20, 18, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.frame.light .titleBar {
+  border-bottom: 1px solid var(--light-border);
+  background: linear-gradient(180deg, #f8fafc 0%, #eef1f5 100%);
+}
+
+.frame.light .titleBar::before {
+  background: linear-gradient(90deg,
+    transparent 0%,
+    var(--light-accent-soft) 25%,
+    var(--light-accent-line) 50%,
+    var(--light-accent-soft) 75%,
+    transparent 100%);
+}
+
+.frame.light .windowTitle {
+  color: rgba(43, 42, 40, 0.55);
+}
+
+.frame.light .closeButton {
+  border-color: var(--light-border);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.frame.light .closeButton::after {
+  color: rgba(43, 42, 40, 0.5);
+}
+
+.frame.light .closeButton:hover {
+  background: var(--light-accent-soft);
+  border-color: var(--light-accent-line);
+}
+
+.frame.light .closeButton:hover::after {
+  color: var(--light-accent);
+}
+
+.frame.light .closeButton:focus-visible {
+  outline-color: var(--light-accent);
+}

--- a/src/components/features/modal/ModalFrame.tsx
+++ b/src/components/features/modal/ModalFrame.tsx
@@ -20,16 +20,18 @@ const ModalFrame: React.FC<ModalFrameProps> = ({
   headerActions,
   closeAriaLabel,
   titleId,
+  variant = "noir",
 }) => {
   const generatedId = useId().replace(/:/g, "");
   const resolvedTitleId = titleId ?? `modal-title-${generatedId}`;
+  const variantClass = variant === "light" ? styles.light : "";
 
   return (
     <ModalShell
       onClose={onClose}
       titleId={resolvedTitleId}
-      overlayClassName={styles.overlay}
-      dialogClassName={`${styles.frame} ${sizeClassMap[size]}`}
+      overlayClassName={`${styles.overlay} ${variantClass}`}
+      dialogClassName={`${styles.frame} ${sizeClassMap[size]} ${variantClass}`}
     >
       <div className={styles.titleBar}>
         <div className={styles.windowControls}>

--- a/src/components/features/portfolio/ProjectsModal/ProjectsModal.css
+++ b/src/components/features/portfolio/ProjectsModal/ProjectsModal.css
@@ -1,13 +1,17 @@
-/* ===== PROJECTS GALLERY — WARM NOIR MUSEUM AESTHETIC ===== */
+/* ===== PROJECTS GALLERY — LIGHT DESKTOP AESTHETIC ===== */
 
 .projects-gallery {
-  --gallery-accent: var(--noir-accent);
-  --gallery-accent-soft: var(--noir-accent-soft);
-  --gallery-accent-glow: var(--noir-accent-glow);
-  --gallery-text: var(--noir-text);
-  --gallery-muted: var(--noir-muted);
-  --gallery-border: var(--noir-border);
-  --gallery-panel: var(--noir-panel);
+  --gallery-accent: var(--light-accent);
+  --gallery-accent-soft: var(--light-accent-soft);
+  --gallery-accent-line: var(--light-accent-line);
+  --gallery-accent-glow: var(--light-accent-glow);
+  --gallery-text: var(--light-text);
+  --gallery-muted: var(--light-muted);
+  --gallery-faint: var(--light-faint);
+  --gallery-border: var(--light-border);
+  --gallery-panel: var(--light-panel);
+  --gallery-panel-strong: var(--light-panel-strong);
+  --gallery-surface: var(--light-surface);
 
   display: flex;
   flex-direction: column;
@@ -29,13 +33,13 @@
   padding: 0.6rem 1rem;
   border-bottom: 1px solid var(--gallery-border);
   flex-shrink: 0;
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--gallery-panel);
 }
 
 .gallery-tabs {
   display: flex;
   gap: 0.28rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--gallery-surface);
   border: 1px solid var(--gallery-border);
   border-radius: 999px;
   padding: 0.24rem;
@@ -45,7 +49,7 @@
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: rgba(240, 236, 232, 0.4);
+  color: var(--gallery-faint);
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.03em;
@@ -61,16 +65,16 @@
 }
 
 .gallery-tab:hover:not(.active) {
-  color: rgba(240, 236, 232, 0.7);
+  color: var(--gallery-text);
 }
 
 .gallery-tab:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid var(--gallery-accent);
   outline-offset: 2px;
 }
 
 .gallery-resume-btn {
-  border: 1px solid rgba(212, 132, 90, 0.22);
+  border: 1px solid var(--gallery-accent-line);
   border-radius: 999px;
   background: var(--gallery-accent-soft);
   color: var(--gallery-accent);
@@ -84,13 +88,13 @@
 }
 
 .gallery-resume-btn:hover {
-  border-color: rgba(212, 132, 90, 0.42);
-  background: rgba(212, 132, 90, 0.18);
+  border-color: var(--gallery-accent);
+  background: rgba(182, 95, 56, 0.16);
   transform: translateY(-1px);
 }
 
 .gallery-resume-btn:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid var(--gallery-accent);
   outline-offset: 2px;
 }
 
@@ -117,7 +121,7 @@
 
 .gallery-media {
   position: relative;
-  background: rgba(0, 0, 0, 0.30);
+  background: var(--gallery-panel-strong);
   border-right: 1px solid var(--gallery-border);
   overflow: hidden;
   display: flex;
@@ -131,7 +135,7 @@
   inset: 0;
   background: radial-gradient(
     ellipse at 50% 50%,
-    rgba(212, 132, 90, 0.07) 0%,
+    rgba(182, 95, 56, 0.05) 0%,
     transparent 68%
   );
   pointer-events: none;
@@ -144,7 +148,7 @@
   background: linear-gradient(
     to right,
     transparent 60%,
-    rgba(13, 10, 9, 0.45) 100%
+    rgba(255, 255, 255, 0.5) 100%
   );
   pointer-events: none;
   z-index: 2;
@@ -156,7 +160,7 @@
   object-fit: contain;
   position: relative;
   z-index: 3;
-  filter: drop-shadow(0 10px 36px rgba(212, 132, 90, 0.20));
+  filter: drop-shadow(0 10px 36px rgba(22, 20, 18, 0.18));
   transition: filter 0.3s ease;
 }
 
@@ -169,7 +173,7 @@
   position: relative;
   z-index: 3;
   font-size: 3.5rem;
-  color: rgba(212, 132, 90, 0.4);
+  color: rgba(182, 95, 56, 0.55);
 }
 
 /* ── Info panel ───────────────────────────────────────── */
@@ -193,16 +197,16 @@
 }
 
 .counter-current {
-  color: rgba(212, 132, 90, 0.7);
+  color: var(--gallery-accent);
 }
 
 .counter-sep {
-  color: rgba(240, 236, 232, 0.18);
+  color: rgba(43, 42, 40, 0.25);
   margin: 0 0.15em;
 }
 
 .counter-total {
-  color: rgba(240, 236, 232, 0.25);
+  color: rgba(43, 42, 40, 0.35);
 }
 
 .gallery-doc-tag {
@@ -212,9 +216,9 @@
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.05em;
-  color: #10b981;
-  border: 1px solid rgba(16, 185, 129, 0.28);
-  background: rgba(16, 185, 129, 0.08);
+  color: #0f9d6b;
+  border: 1px solid rgba(15, 157, 107, 0.32);
+  background: rgba(15, 157, 107, 0.08);
   border-radius: 999px;
   padding: 0.18rem 0.48rem;
   width: fit-content;
@@ -253,10 +257,10 @@
 }
 
 .gallery-stack span {
-  border: 1px solid rgba(220, 175, 130, 0.14);
+  border: 1px solid var(--gallery-border);
   border-radius: 999px;
-  background: rgba(220, 175, 130, 0.05);
-  color: rgba(240, 236, 232, 0.48);
+  background: var(--gallery-panel);
+  color: var(--gallery-muted);
   padding: 0.16rem 0.46rem;
   font-size: 0.68rem;
   font-weight: 600;
@@ -274,11 +278,11 @@
 .gallery-highlights li {
   font-size: 0.79rem;
   line-height: 1.48;
-  color: rgba(240, 236, 232, 0.46);
+  color: var(--gallery-muted);
 }
 
 .gallery-highlights li::marker {
-  color: rgba(212, 132, 90, 0.45);
+  color: var(--gallery-accent);
 }
 
 .gallery-actions {
@@ -305,37 +309,37 @@
 
 .gallery-open-btn {
   background: var(--gallery-accent);
-  border: 1px solid rgba(212, 132, 90, 0.9);
+  border: 1px solid var(--gallery-accent);
   color: #fff;
-  box-shadow: 0 4px 16px rgba(212, 132, 90, 0.28);
+  box-shadow: 0 4px 16px var(--gallery-accent-glow);
 }
 
 .gallery-open-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 22px rgba(212, 132, 90, 0.40);
+  box-shadow: 0 6px 22px rgba(182, 95, 56, 0.34);
 }
 
 .gallery-open-btn:active {
   transform: translateY(0);
-  box-shadow: 0 2px 8px rgba(212, 132, 90, 0.20);
+  box-shadow: 0 2px 8px rgba(182, 95, 56, 0.2);
 }
 
 .gallery-dive-btn {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(220, 175, 130, 0.16);
-  color: rgba(240, 236, 232, 0.62);
+  background: var(--gallery-surface);
+  border: 1px solid var(--gallery-border);
+  color: var(--gallery-text);
 }
 
 .gallery-dive-btn:hover {
-  border-color: rgba(212, 132, 90, 0.36);
-  color: rgba(240, 236, 232, 0.88);
-  background: rgba(212, 132, 90, 0.08);
+  border-color: var(--gallery-accent-line);
+  color: var(--gallery-accent);
+  background: var(--gallery-accent-soft);
   transform: translateY(-1px);
 }
 
 .gallery-open-btn:focus-visible,
 .gallery-dive-btn:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.6);
+  outline: 2px solid var(--gallery-accent);
   outline-offset: 2px;
 }
 
@@ -349,16 +353,16 @@
   padding: 0.6rem 1rem;
   border-top: 1px solid var(--gallery-border);
   flex-shrink: 0;
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--gallery-panel);
 }
 
 .gallery-nav-arrow {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(220, 175, 130, 0.14);
-  color: rgba(240, 236, 232, 0.45);
+  background: var(--gallery-surface);
+  border: 1px solid var(--gallery-border);
+  color: var(--gallery-muted);
   font-size: 0.72rem;
   cursor: pointer;
   display: flex;
@@ -369,8 +373,8 @@
 }
 
 .gallery-nav-arrow:hover:not(:disabled) {
-  background: rgba(212, 132, 90, 0.14);
-  border-color: rgba(212, 132, 90, 0.38);
+  background: var(--gallery-accent-soft);
+  border-color: var(--gallery-accent-line);
   color: var(--gallery-accent);
   transform: scale(1.05);
 }
@@ -380,12 +384,12 @@
 }
 
 .gallery-nav-arrow:disabled {
-  opacity: 0.22;
+  opacity: 0.4;
   cursor: default;
 }
 
 .gallery-nav-arrow:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid var(--gallery-accent);
   outline-offset: 2px;
 }
 
@@ -398,7 +402,7 @@
 .gallery-dot {
   height: 6px;
   border-radius: 999px;
-  background: rgba(220, 175, 130, 0.18);
+  background: rgba(43, 42, 40, 0.18);
   border: 0;
   cursor: pointer;
   transition: background 0.22s ease, width 0.22s ease;
@@ -411,11 +415,11 @@
 }
 
 .gallery-dot:hover:not(.active) {
-  background: rgba(220, 175, 130, 0.38);
+  background: rgba(43, 42, 40, 0.35);
 }
 
 .gallery-dot:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid var(--gallery-accent);
   outline-offset: 2px;
 }
 
@@ -437,7 +441,7 @@
     background: linear-gradient(
       to bottom,
       transparent 60%,
-      rgba(13, 10, 9, 0.55) 100%
+      rgba(255, 255, 255, 0.5) 100%
     );
   }
 

--- a/src/components/features/portfolio/ProjectsModal/ProjectsModal.tsx
+++ b/src/components/features/portfolio/ProjectsModal/ProjectsModal.tsx
@@ -145,6 +145,7 @@ const ProjectsModal: React.FC<ModalProps> = ({ onClose }) => {
         onClose={onClose}
         title="Projects"
         size="lg"
+        variant="light"
         titleId="projects-title"
         closeAriaLabel="Close projects modal"
       >

--- a/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
+++ b/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
@@ -1,14 +1,17 @@
-/* ===== RESUME HIGHLIGHTS — WARM NOIR GALLERY GRAMMAR ===== */
+/* ===== RESUME HIGHLIGHTS — LIGHT DESKTOP GALLERY GRAMMAR ===== */
 
 .resume-highlights-content {
-  --resume-accent: var(--noir-accent);
-  --resume-accent-soft: var(--noir-accent-soft);
-  --resume-text: var(--noir-text);
-  --resume-muted: var(--noir-muted);
-  --resume-faint: var(--noir-faint);
-  --resume-border: var(--noir-border);
-  --resume-panel: var(--noir-panel);
-  --resume-panel-strong: var(--noir-panel-strong);
+  --resume-accent: var(--light-accent);
+  --resume-accent-soft: var(--light-accent-soft);
+  --resume-accent-line: var(--light-accent-line);
+  --resume-accent-glow: var(--light-accent-glow);
+  --resume-text: var(--light-text);
+  --resume-muted: var(--light-muted);
+  --resume-faint: var(--light-faint);
+  --resume-border: var(--light-border);
+  --resume-panel: var(--light-panel);
+  --resume-panel-strong: var(--light-panel-strong);
+  --resume-surface: var(--light-surface);
 
   display: flex;
   flex-direction: column;
@@ -27,14 +30,14 @@
   gap: 0.75rem;
   padding: 0.6rem 1rem;
   border-bottom: 1px solid var(--resume-border);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--resume-panel);
   flex-shrink: 0;
 }
 
 .resume-highlights-tabs {
   display: flex;
   gap: 0.28rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--resume-surface);
   border: 1px solid var(--resume-border);
   border-radius: 999px;
   padding: 0.24rem;
@@ -44,7 +47,7 @@
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: rgba(240, 236, 232, 0.4);
+  color: var(--resume-faint);
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -55,13 +58,13 @@
 }
 
 .resume-highlights-tab:hover:not(.active) {
-  color: rgba(240, 236, 232, 0.7);
+  color: var(--resume-text);
 }
 
 .resume-highlights-tab.active {
   color: #fff;
   background: var(--resume-accent);
-  box-shadow: 0 2px 10px var(--noir-accent-glow);
+  box-shadow: 0 2px 10px var(--resume-accent-glow);
 }
 
 .resume-highlights-byline {
@@ -114,12 +117,12 @@
 }
 
 .resume-role-group:hover {
-  border-color: rgba(212, 132, 90, 0.18);
+  border-color: var(--resume-accent-line);
 }
 
 .resume-role-group:has(.resume-role-group-trigger[aria-expanded="true"]) {
   background: var(--resume-panel-strong);
-  border-color: rgba(212, 132, 90, 0.2);
+  border-color: var(--resume-accent-line);
 }
 
 .resume-role-group-trigger {
@@ -148,7 +151,7 @@
   min-width: 1.4rem;
   height: 1.4rem;
   border-radius: 999px;
-  border: 1px solid rgba(212, 132, 90, 0.24);
+  border: 1px solid var(--resume-accent-line);
   background: var(--resume-accent-soft);
   color: var(--resume-accent);
   display: grid;
@@ -168,14 +171,14 @@
 
 .resume-role-group li,
 .resume-project-section li {
-  color: rgba(240, 236, 232, 0.72);
+  color: var(--resume-muted);
   line-height: 1.5;
   font-size: 0.84rem;
 }
 
 .resume-role-group li::marker,
 .resume-project-section li::marker {
-  color: rgba(212, 132, 90, 0.45);
+  color: var(--resume-accent);
 }
 
 /* ── Bullet project tags ─────────────────────────────── */
@@ -184,8 +187,8 @@
   display: inline-block;
   margin-right: 0.4rem;
   margin-bottom: 0.16rem;
-  border: 1px solid rgba(212, 132, 90, 0.24);
-  background: rgba(212, 132, 90, 0.09);
+  border: 1px solid var(--resume-accent-line);
+  background: var(--resume-accent-soft);
   color: var(--resume-accent);
   border-radius: 999px;
   padding: 0.1rem 0.44rem;
@@ -205,10 +208,10 @@
 }
 
 .resume-project-picker-btn {
-  border: 1px solid rgba(220, 175, 130, 0.14);
+  border: 1px solid var(--resume-border);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(240, 236, 232, 0.5);
+  background: var(--resume-surface);
+  color: var(--resume-muted);
   font-size: 0.74rem;
   font-weight: 700;
   padding: 0.34rem 0.66rem;
@@ -218,16 +221,16 @@
 }
 
 .resume-project-picker-btn:hover:not(.active) {
-  border-color: rgba(212, 132, 90, 0.32);
-  color: rgba(240, 236, 232, 0.75);
+  border-color: var(--resume-accent-line);
+  color: var(--resume-text);
   transform: translateY(-1px);
 }
 
 .resume-project-picker-btn.active {
   color: #fff;
-  border-color: rgba(212, 132, 90, 0.75);
+  border-color: var(--resume-accent);
   background: var(--resume-accent);
-  box-shadow: 0 2px 10px var(--noir-accent-glow);
+  box-shadow: 0 2px 10px var(--resume-accent-glow);
 }
 
 /* ── Project detail ──────────────────────────────────── */
@@ -252,7 +255,7 @@
   background: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(212, 132, 90, 0.3) 50%,
+    var(--resume-accent-line) 50%,
     transparent 100%
   );
 }
@@ -292,10 +295,10 @@
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.72rem;
   line-height: 1.46;
-  color: rgba(240, 236, 232, 0.72);
-  border: 1px solid rgba(220, 175, 130, 0.1);
+  color: var(--resume-muted);
+  border: 1px solid var(--resume-border);
   border-radius: 0.72rem;
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--resume-surface);
   padding: 0.7rem;
 }
 
@@ -309,10 +312,10 @@
 }
 
 .resume-chip {
-  border: 1px solid rgba(220, 175, 130, 0.14);
+  border: 1px solid var(--resume-border);
   border-radius: 999px;
-  background: rgba(220, 175, 130, 0.05);
-  color: rgba(240, 236, 232, 0.62);
+  background: var(--resume-panel);
+  color: var(--resume-muted);
   font-size: 0.7rem;
   font-weight: 600;
   padding: 0.18rem 0.5rem;
@@ -339,7 +342,7 @@
   text-align: left;
   vertical-align: top;
   padding: 0.62rem 0.7rem;
-  border-bottom: 1px solid rgba(220, 175, 130, 0.08);
+  border-bottom: 1px solid var(--resume-border);
   font-size: 0.8rem;
   line-height: 1.46;
   color: var(--resume-text);
@@ -350,7 +353,7 @@
 }
 
 .resume-patterns-table-wrap tbody tr:hover td {
-  background: rgba(212, 132, 90, 0.04);
+  background: var(--resume-accent-soft);
 }
 
 .resume-patterns-table-wrap td:first-child {
@@ -364,7 +367,7 @@
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--resume-muted);
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--resume-panel-strong);
 }
 
 /* ── Focus states ────────────────────────────────────── */
@@ -372,7 +375,7 @@
 .resume-highlights-tab:focus-visible,
 .resume-role-group-trigger:focus-visible,
 .resume-project-picker-btn:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid var(--resume-accent);
   outline-offset: 2px;
   border-radius: 6px;
 }

--- a/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.tsx
+++ b/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.tsx
@@ -62,6 +62,7 @@ const ResumeHighlightsModal: React.FC<ResumeHighlightsModalProps> = ({
       onClose={onClose}
       title="Resume Highlights (2025-2026)"
       size="xl"
+      variant="light"
       titleId="resume-highlights-title"
       closeAriaLabel="Close resume highlights"
     >

--- a/src/components/features/skills/SkillsetModal/SkillsetModal.css
+++ b/src/components/features/skills/SkillsetModal/SkillsetModal.css
@@ -1,14 +1,14 @@
 /* ===== SKILLSET — WARM NOIR: PLATES + PROFICIENCY WALL ===== */
 
 .skillset {
-  --skill-accent: var(--noir-accent);
-  --skill-accent-soft: var(--noir-accent-soft);
-  --skill-accent-glow: var(--noir-accent-glow);
-  --skill-text: var(--noir-text);
-  --skill-muted: var(--noir-muted);
-  --skill-faint: var(--noir-faint);
-  --skill-border: var(--noir-border);
-  --skill-panel: var(--noir-panel);
+  --skill-accent: var(--light-accent);
+  --skill-accent-soft: var(--light-accent-soft);
+  --skill-accent-glow: var(--light-accent-glow);
+  --skill-text: var(--light-text);
+  --skill-muted: var(--light-muted);
+  --skill-faint: var(--light-faint);
+  --skill-border: var(--light-border);
+  --skill-panel: var(--light-panel);
 
   display: flex;
   flex-direction: column;
@@ -27,14 +27,14 @@
   gap: 0.75rem;
   padding: 0.6rem 1rem;
   border-bottom: 1px solid var(--skill-border);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--skill-panel);
   flex-shrink: 0;
 }
 
 .skill-tabs {
   display: flex;
   gap: 0.28rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--skill-panel);
   border: 1px solid var(--skill-border);
   border-radius: 999px;
   padding: 0.24rem;
@@ -44,7 +44,7 @@
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: rgba(240, 236, 232, 0.4);
+  color: rgba(43, 42, 40, 0.4);
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.03em;
@@ -60,7 +60,7 @@
 }
 
 .skill-tab:hover:not(.active) {
-  color: rgba(240, 236, 232, 0.7);
+  color: rgba(43, 42, 40, 0.7);
 }
 
 .skill-tab:focus-visible,
@@ -69,7 +69,7 @@
 .wall-chip:focus-visible,
 .wall-search input:focus-visible,
 .skill-studio-byline:focus-visible {
-  outline: 2px solid rgba(212, 132, 90, 0.55);
+  outline: 2px solid rgba(182, 95, 56, 0.55);
   outline-offset: 2px;
 }
 
@@ -91,13 +91,13 @@
 
 .skill-studio-byline:hover {
   color: var(--skill-accent);
-  border-color: rgba(212, 132, 90, 0.28);
+  border-color: rgba(182, 95, 56, 0.28);
   background: var(--skill-accent-soft);
 }
 
 .skill-studio-logo {
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--skill-panel);
 }
 
 /* ── Services: capability plates ──────────────────────── */
@@ -139,8 +139,8 @@
   border-radius: 50%;
   background: radial-gradient(
     circle at 50% 45%,
-    rgba(212, 132, 90, 0.18) 0%,
-    rgba(212, 132, 90, 0.05) 55%,
+    rgba(182, 95, 56, 0.18) 0%,
+    rgba(182, 95, 56, 0.05) 55%,
     transparent 72%
   );
   margin-bottom: 0.2rem;
@@ -151,14 +151,14 @@
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  border: 1px solid rgba(212, 132, 90, 0.2);
+  border: 1px solid rgba(182, 95, 56, 0.2);
 }
 
 .plate-icon {
   width: 72px;
   height: auto;
   object-fit: contain;
-  filter: drop-shadow(0 8px 24px rgba(212, 132, 90, 0.28));
+  filter: drop-shadow(0 8px 24px rgba(182, 95, 56, 0.28));
 }
 
 .plate-counter {
@@ -169,16 +169,16 @@
 }
 
 .counter-current {
-  color: rgba(212, 132, 90, 0.75);
+  color: rgba(182, 95, 56, 0.75);
 }
 
 .counter-sep {
-  color: rgba(240, 236, 232, 0.18);
+  color: rgba(43, 42, 40, 0.18);
   margin: 0 0.15em;
 }
 
 .counter-total {
-  color: rgba(240, 236, 232, 0.25);
+  color: rgba(43, 42, 40, 0.25);
 }
 
 .plate-title {
@@ -217,7 +217,7 @@
   gap: 0.85rem;
   padding: 0.6rem 1rem;
   border-top: 1px solid var(--skill-border);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--skill-panel);
   flex-shrink: 0;
 }
 
@@ -225,9 +225,9 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(220, 175, 130, 0.14);
-  color: rgba(240, 236, 232, 0.45);
+  background: var(--skill-panel);
+  border: 1px solid rgba(43, 42, 40, 0.14);
+  color: rgba(43, 42, 40, 0.45);
   font-size: 0.72rem;
   cursor: pointer;
   display: flex;
@@ -239,8 +239,8 @@
 }
 
 .plate-arrow:hover {
-  background: rgba(212, 132, 90, 0.14);
-  border-color: rgba(212, 132, 90, 0.38);
+  background: rgba(182, 95, 56, 0.14);
+  border-color: rgba(182, 95, 56, 0.38);
   color: var(--skill-accent);
   transform: scale(1.05);
 }
@@ -260,7 +260,7 @@
   height: 6px;
   width: 6px;
   border-radius: 999px;
-  background: rgba(220, 175, 130, 0.18);
+  background: rgba(43, 42, 40, 0.18);
   border: 0;
   padding: 0;
   cursor: pointer;
@@ -280,7 +280,7 @@
 }
 
 .plate-dot:hover:not(.active) {
-  background: rgba(220, 175, 130, 0.38);
+  background: rgba(43, 42, 40, 0.38);
 }
 
 /* ── Toolbelt: proficiency wall ───────────────────────── */
@@ -298,7 +298,7 @@
   gap: 0.6rem;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--skill-border);
-  background: rgba(0, 0, 0, 0.12);
+  background: var(--skill-panel);
   flex-shrink: 0;
 }
 
@@ -306,16 +306,16 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid rgba(220, 175, 130, 0.14);
+  border: 1px solid rgba(43, 42, 40, 0.14);
   border-radius: 0.66rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--skill-panel);
   padding: 0.5rem 0.7rem;
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .wall-search:focus-within {
-  border-color: rgba(212, 132, 90, 0.42);
-  background: rgba(212, 132, 90, 0.05);
+  border-color: rgba(182, 95, 56, 0.42);
+  background: rgba(182, 95, 56, 0.05);
 }
 
 .wall-search-icon {
@@ -336,7 +336,7 @@
 }
 
 .wall-search input::placeholder {
-  color: rgba(240, 236, 232, 0.28);
+  color: rgba(43, 42, 40, 0.28);
 }
 
 .wall-chips {
@@ -346,10 +346,10 @@
 }
 
 .wall-chip {
-  border: 1px solid rgba(220, 175, 130, 0.13);
+  border: 1px solid rgba(43, 42, 40, 0.13);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(240, 236, 232, 0.45);
+  background: var(--skill-panel);
+  color: rgba(43, 42, 40, 0.45);
   font-size: 0.7rem;
   font-weight: 700;
   padding: 0.3rem 0.62rem;
@@ -358,12 +358,12 @@
 }
 
 .wall-chip:hover:not(.active) {
-  border-color: rgba(212, 132, 90, 0.32);
-  color: rgba(240, 236, 232, 0.75);
+  border-color: rgba(182, 95, 56, 0.32);
+  color: rgba(43, 42, 40, 0.75);
 }
 
 .wall-chip.active {
-  border-color: rgba(212, 132, 90, 0.55);
+  border-color: rgba(182, 95, 56, 0.55);
   color: #fff;
   background: var(--skill-accent);
   box-shadow: 0 2px 8px var(--skill-accent-glow);
@@ -401,7 +401,7 @@
   content: "";
   flex: 1;
   height: 1px;
-  background: rgba(220, 175, 130, 0.1);
+  background: rgba(43, 42, 40, 0.1);
 }
 
 .wall-group-count {
@@ -409,13 +409,13 @@
   height: 1.3rem;
   padding: 0 0.35rem;
   border-radius: 999px;
-  border: 1px solid rgba(220, 175, 130, 0.14);
+  border: 1px solid rgba(43, 42, 40, 0.14);
   display: grid;
   place-items: center;
   font-size: 0.66rem;
   font-weight: 700;
   color: var(--skill-faint);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--skill-panel);
 }
 
 .wall-grid {
@@ -442,14 +442,14 @@
 
 .wall-tile:hover {
   transform: translateY(-2px);
-  border-color: rgba(212, 132, 90, 0.3);
-  background: rgba(212, 132, 90, 0.06);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+  border-color: rgba(182, 95, 56, 0.3);
+  background: rgba(182, 95, 56, 0.06);
+  box-shadow: 0 6px 18px rgba(22, 20, 18, 0.12);
 }
 
 .wall-tile-icon {
   font-size: 1.35rem;
-  color: rgba(212, 132, 90, 0.62);
+  color: rgba(182, 95, 56, 0.62);
   transition: color 0.2s ease;
 }
 
@@ -461,13 +461,13 @@
   font-size: 0.74rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: rgba(240, 236, 232, 0.62);
+  color: rgba(43, 42, 40, 0.62);
   line-height: 1.2;
 }
 
 .wall-tile.signature {
-  border-color: rgba(212, 132, 90, 0.28);
-  background: rgba(212, 132, 90, 0.07);
+  border-color: rgba(182, 95, 56, 0.28);
+  background: rgba(182, 95, 56, 0.07);
 }
 
 .wall-tile.signature .wall-tile-icon {
@@ -481,9 +481,9 @@
 /* ── Empty state ──────────────────────────────────────── */
 
 .wall-empty {
-  border: 1px dashed rgba(220, 175, 130, 0.18);
+  border: 1px dashed rgba(43, 42, 40, 0.18);
   border-radius: 0.88rem;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--skill-panel);
   padding: 1.6rem;
   text-align: center;
 }

--- a/src/components/features/skills/SkillsetModal/SkillsetModal.tsx
+++ b/src/components/features/skills/SkillsetModal/SkillsetModal.tsx
@@ -126,6 +126,7 @@ const SkillsetModal: React.FC<ModalProps> = ({ onClose }) => {
       onClose={onClose}
       title="Skillset"
       size="lg"
+      variant="light"
       titleId="skillset-title"
       closeAriaLabel="Close skillset modal"
     >

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -59,6 +59,8 @@ export interface ModalProps {
 
 export type ModalSize = "sm" | "md" | "lg" | "xl";
 
+export type ModalVariant = "noir" | "light";
+
 export interface ModalShellProps {
     onClose: () => void;
     children: ReactNode;
@@ -75,6 +77,8 @@ export interface ModalFrameProps {
     headerActions?: ReactNode;
     closeAriaLabel?: string;
     titleId?: string;
+    /** Visual theme of the shared shell. Defaults to "noir". */
+    variant?: ModalVariant;
 }
 
 export interface ModalState {


### PR DESCRIPTION
**Phase 3 of 4** — re-skinning **all modals** from the dark warm-noir palette to a clean **light** palette that harmonizes with the retro desktop (light theme, not full pixel-retro chrome). The Projects flow was reviewed first as a pilot; the same treatment is now rolled out to the rest.

## Approach (one source of truth)
- **`--light-*` design tokens** added to `globals.css`, mirroring the existing `--noir-*` set (accent `#b65f38` terracotta retained for brand warmth, charcoal text `#2b2a28`, light gray panels, white surfaces).
- **`ModalFrame` gets an opt-in `variant="light"`** that re-skins the shared shell chrome (overlay scrim, frame surface, title bar gradient, close button). Defaults to `"noir"`.
- **Each modal's content CSS** now aliases `--light-*` and maps hardcoded dark surfaces/text to the light palette (off-white text → charcoal, amber → terracotta, dark panels → light panels, heavy black card shadows softened). Layout/structure untouched.

## Modals migrated (all of them)
- ✅ Projects + Resume Highlights (the reviewed pilot)
- ✅ About (The Dossier)
- ✅ Skillset (plates + proficiency wall)
- ✅ Contact (The Invitation)

`--noir-*` tokens remain defined but are no longer referenced by any modal — easy to delete in a later cleanup.

## What to review (the Vercel preview is the real check)
Open each desktop icon / menu item — **About, Skillset, Projects, Contact** (and "Resume Deep Dive" inside Projects). Confirm legibility/contrast and that the terracotta accent feels right on light across all four. If you'd prefer a cooler/neutral accent, it's a one-line token change in `globals.css` now.

## Verification
`tsc --noEmit` ✅ · `next build` ✅ — props/CSS only, no stray `--noir-` references remain in modal CSS, home route bundle unchanged.

https://claude.ai/code/session_01PCQTWMcF9eN4mREyF6F2Ad