### PR TITLE
feat: summary-first Role Bullets + filterable Toolbelt (Phase 4)

### DIFF
--- a/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
+++ b/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
@@ -131,12 +131,19 @@
   background: transparent;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.6rem;
   cursor: pointer;
   padding: 0;
   text-align: left;
   color: var(--resume-text);
+}
+
+.resume-role-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+  min-width: 0;
 }
 
 .resume-role-group h3 {
@@ -145,6 +152,45 @@
   font-weight: 700;
   letter-spacing: -0.01em;
   color: var(--resume-text);
+}
+
+/* One-line summary shown while the role is collapsed (summary-first view). */
+.resume-role-summary {
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--resume-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.resume-role-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* Chevron points down when collapsed, flips up when expanded. */
+.resume-role-chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--resume-faint);
+  border-bottom: 2px solid var(--resume-faint);
+  transform: rotate(45deg);
+  margin-top: 2px;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.resume-role-group-trigger:hover .resume-role-chevron {
+  border-color: var(--resume-accent);
+}
+
+.resume-role-group-trigger[aria-expanded="true"] .resume-role-chevron {
+  transform: rotate(225deg);
+  margin-top: 5px;
 }
 
 .resume-role-count {

--- a/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.tsx
+++ b/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.tsx
@@ -39,9 +39,9 @@ const ResumeHighlightsModal: React.FC<ResumeHighlightsModalProps> = ({
 }) => {
   const [activeTab, setActiveTab] =
     useState<ResumeHighlightsTab>("role-bullets");
-  const [expandedRole, setExpandedRole] = useState<string>(
-    resumeRoleBullets[0]?.role ?? "Senior Software Engineer"
-  );
+  // Start collapsed so every role reads as a scannable one-line summary;
+  // expanding a role reveals its full bullet list.
+  const [expandedRole, setExpandedRole] = useState<string>("");
   const [selectedProjectKey, setSelectedProjectKey] =
     useState<ResumeProjectKey>(() => resolveProjectKey(initialProjectKey));
 
@@ -127,7 +127,9 @@ const ResumeHighlightsModal: React.FC<ResumeHighlightsModalProps> = ({
               </p>
 
               <div className="resume-role-groups">
-                {resumeRoleBullets.map((group) => (
+                {resumeRoleBullets.map((group) => {
+                  const isExpanded = expandedRole === group.role;
+                  return (
                   <article key={group.role} className="resume-role-group">
                     <button
                       type="button"
@@ -137,15 +139,28 @@ const ResumeHighlightsModal: React.FC<ResumeHighlightsModalProps> = ({
                           current === group.role ? "" : group.role
                         )
                       }
-                      aria-expanded={expandedRole === group.role}
+                      aria-expanded={isExpanded}
                       aria-controls={`role-panel-${toDomId(group.role)}`}
                     >
-                      <h3>{group.role}</h3>
-                      <span className="resume-role-count">
-                        {group.bullets.length}
+                      <span className="resume-role-heading">
+                        <h3>{group.role}</h3>
+                        {!isExpanded && (
+                          <span className="resume-role-summary">
+                            {group.summary}
+                          </span>
+                        )}
+                      </span>
+                      <span className="resume-role-meta">
+                        <span className="resume-role-count">
+                          {group.bullets.length}
+                        </span>
+                        <span
+                          className="resume-role-chevron"
+                          aria-hidden="true"
+                        />
                       </span>
                     </button>
-                    {expandedRole === group.role && (
+                    {isExpanded && (
                       <ul id={`role-panel-${toDomId(group.role)}`}>
                         {group.bullets.map((bullet, index) => (
                           <li key={`${group.role}-${index}`}>
@@ -160,7 +175,8 @@ const ResumeHighlightsModal: React.FC<ResumeHighlightsModalProps> = ({
                       </ul>
                     )}
                   </article>
-                ))}
+                  );
+                })}
               </div>
             </motion.section>
           )}

--- a/src/data/resumeProjectHighlights.ts
+++ b/src/data/resumeProjectHighlights.ts
@@ -17,6 +17,7 @@ export interface ResumeRoleBullet {
 
 export interface ResumeRoleBulletGroup {
   role: ResumeRoleName;
+  summary: string;
   bullets: ResumeRoleBullet[];
 }
 
@@ -40,6 +41,8 @@ export interface CrossCuttingPattern {
 export const resumeRoleBullets: ResumeRoleBulletGroup[] = [
   {
     role: "Senior Software Engineer",
+    summary:
+      "Full-stack architecture across mobile and web — secure auth, real-time AI streaming, caching and rate-limiting, and zero-downtime deploys.",
     bullets: [
       {
         project: "PINPOINT",
@@ -145,6 +148,8 @@ export const resumeRoleBullets: ResumeRoleBulletGroup[] = [
   },
   {
     role: "Project Manager",
+    summary:
+      "Sole product owner across 5 concurrent production apps — moderation workflows, marketplace access flows, compliance docs, and deployment runbooks.",
     bullets: [
       {
         text: "Served as sole product owner and developer across 5 concurrent production apps in civic tech, consumer intelligence, PropTech, spatial AI, and real-time communication, all shipped within a 12-month period.",
@@ -175,6 +180,8 @@ export const resumeRoleBullets: ResumeRoleBulletGroup[] = [
   },
   {
     role: "UI/UX Designer",
+    summary:
+      "Multi-theme design systems and spatial interfaces — civic dashboards, privacy-as-identity visualizations, and procedural creation flows.",
     bullets: [
       {
         project: "PINPOINT",


### PR DESCRIPTION
**Phase 4 of 4 (finale)** — the content-UX redesign: **summary-first Role Bullets** and the **filterable Toolbelt**.

## Role Bullets → summary-first
The Resume Highlights "Role Bullets" accordion previously opened with the first role expanded into a long bullet list. Now it opens as **three scannable summary cards**:
- Added a **one-line summary** to each role group in `resumeProjectHighlights.ts` (Senior Software Engineer, Project Manager, UI/UX Designer).
- **All roles default to collapsed** — you see every role's gist at a glance.
- Each card stacks the **role title over its summary**, with the bullet **count badge** and a **chevron that flips** on expand. Expanding reveals the full bullet list.

## Toolbelt → already matches the chosen design
The selected filter UX was **category chips + search**. The Skillset "Toolbelt" proficiency wall **already implements exactly that** — a search box plus `All` + per-category filter chips, a grouped/counted wall, and a "no matching tools" empty state (`selectedCategory` + `toolQuery` → `filteredTools`). So **no change was needed there**; I verified it against the requirement rather than inventing redundant work. If you had a different/expanded filtering behavior in mind (e.g. proficiency-level filters), say the word and I'll add it.

## Verification
`tsc --noEmit` ✅ · `next build` ✅ — data + one component/CSS, no bundle impact.

**Preview check:** open **Projects → Resume Deep Dive** (or Skillset → "Full Resume Highlights"), land on the **Role Bullets** tab — confirm the three collapsed summary cards read well and expand/collapse cleanly. Then **Skillset → Toolbelt** to confirm the chips + search are what you wanted.

This is the last of the four phases (purge → responsive → light modals → content UX).

https://claude.ai/code/session_01PCQTWMcF9eN4mREyF6F2Ad

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCQTWMcF9eN4mREyF6F2Ad)_