### PR TITLE
fix: user journey fixes — hydration, perf, rebrand, Featured chapter, hover UX

### DIFF
--- a/src/components/features/about/AboutMeModal/AboutMeModal.css
+++ b/src/components/features/about/AboutMeModal/AboutMeModal.css
@@ -364,6 +364,157 @@
   color: rgba(43, 42, 40, 0.25);
 }
 
+/* ── Featured chapter ─────────────────────────────────── */
+
+.about-featured-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 0.35rem;
+}
+
+.about-featured-card {
+  border: 1px solid var(--about-border);
+  border-radius: 0.82rem;
+  background: var(--about-panel);
+  overflow: hidden;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.about-featured-card:hover {
+  border-color: rgba(182, 95, 56, 0.24);
+  transform: translateY(-2px);
+}
+
+.about-featured-thumbnail {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #0f0f0f;
+}
+
+.about-featured-thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.about-featured-thumb-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+  transition: background 0.2s ease;
+  cursor: pointer;
+}
+
+.about-featured-card:hover .about-featured-thumb-overlay {
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.about-featured-play-icon {
+  font-size: 2rem;
+  color: rgba(255, 255, 255, 0.9);
+  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.5));
+  transition: transform 0.2s ease;
+}
+
+.about-featured-card:hover .about-featured-play-icon {
+  transform: scale(1.12);
+}
+
+.about-featured-info {
+  padding: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.about-featured-info--full {
+  padding: 1rem;
+}
+
+.about-featured-badges {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.about-featured-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--about-border);
+  color: var(--about-muted);
+  background: var(--about-faint, rgba(43, 42, 40, 0.04));
+}
+
+.about-featured-badge--pbs {
+  background: #1569b8;
+  color: #fff;
+  border-color: transparent;
+}
+
+.about-featured-badge--sxsw {
+  background: #e94c3d;
+  color: #fff;
+  border-color: transparent;
+}
+
+.about-featured-title {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--about-text);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+.about-featured-desc {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.52;
+  color: var(--about-muted);
+}
+
+.about-featured-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  border: 1px solid var(--about-accent);
+  color: var(--about-accent);
+  background: transparent;
+  font-family: inherit;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.15s ease;
+  text-decoration: none;
+  width: fit-content;
+}
+
+.about-featured-cta:hover {
+  background: var(--about-accent);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.about-featured-cta--link {
+  /* inherits the same styles, rendered as <a> */
+}
+
 /* ── Responsive ───────────────────────────────────────── */
 
 @media (max-width: 720px) {

--- a/src/components/features/about/AboutMeModal/AboutMeModal.tsx
+++ b/src/components/features/about/AboutMeModal/AboutMeModal.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronLeft, faChevronRight, faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { faChevronLeft, faChevronRight, faArrowUpRightFromSquare, faPlay, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import Image from "next/image";
 import { aboutMePills } from "@/data/aboutMePills";
 import { AboutMePill } from "@/lib/types";
 import { ModalFrame } from "@/components/features/modal";
@@ -11,6 +12,7 @@ interface AboutMeModalProps {
   onClose: () => void;
   onOpenContact?: () => void;
   onOpenResume?: () => void;
+  onOpenDocumentary?: () => void;
 }
 
 const profileHighlights = [
@@ -62,7 +64,8 @@ const collaborationSections = [
 type Chapter =
   | { id: string; label: string; kind: "profile" }
   | { id: string; label: string; kind: "list"; sectionIndex: number }
-  | { id: string; label: string; kind: "strengths" };
+  | { id: string; label: string; kind: "strengths" }
+  | { id: string; label: string; kind: "featured" };
 
 const chapters: Chapter[] = [
   { id: "profile", label: "Profile", kind: "profile" },
@@ -70,6 +73,7 @@ const chapters: Chapter[] = [
   { id: "work", label: "How I Work", kind: "list", sectionIndex: 1 },
   { id: "collaborate", label: "How I Collaborate", kind: "list", sectionIndex: 2 },
   { id: "strengths", label: "Strengths", kind: "strengths" },
+  { id: "featured", label: "Featured", kind: "featured" },
 ];
 
 const chapterVariants = {
@@ -78,7 +82,7 @@ const chapterVariants = {
   exit: (dir: number) => ({ opacity: 0, y: dir > 0 ? -22 : 22 }),
 };
 
-const AboutMeModal: React.FC<AboutMeModalProps> = ({ onClose }) => {
+const AboutMeModal: React.FC<AboutMeModalProps> = ({ onClose, onOpenDocumentary }) => {
   const [chapterIndex, setChapterIndex] = useState(0);
   const [direction, setDirection] = useState<1 | -1>(1);
   const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
@@ -117,7 +121,80 @@ const AboutMeModal: React.FC<AboutMeModalProps> = ({ onClose }) => {
     setActiveTooltip(pill.label);
   };
 
+  const renderFeaturedChapter = () => (
+    <>
+      <p className="about-eyebrow">In The Press</p>
+      <h2 className="about-chapter-title">Featured Work</h2>
+      <p className="about-lede">
+        Selected appearances and speaking engagements.
+      </p>
+
+      <div className="about-featured-cards">
+        {/* Tech For Us — PBS Documentary */}
+        <div className="about-featured-card">
+          <div className="about-featured-thumbnail">
+            <Image
+              src="https://image.pbs.org/video-assets/5Q3iQAC-asset-mezzanine-16x9-luFIYQ7.jpg?crop=1440x810&format=auto"
+              alt="Tech For Us — Breaking Barriers on PBS"
+              width={480}
+              height={270}
+              className="about-featured-thumb-img"
+            />
+            <div className="about-featured-thumb-overlay">
+              <FontAwesomeIcon icon={faPlay} className="about-featured-play-icon" />
+            </div>
+          </div>
+          <div className="about-featured-info">
+            <div className="about-featured-badges">
+              <span className="about-featured-badge about-featured-badge--pbs">PBS</span>
+              <span className="about-featured-badge">Documentary</span>
+            </div>
+            <h3 className="about-featured-title">Tech For Us — Breaking Barriers</h3>
+            <p className="about-featured-desc">
+              Featured in a Roadtrip Nation documentary exploring technology, innovation, and career development through public interest technology stories.
+            </p>
+            <button
+              type="button"
+              className="about-featured-cta"
+              onClick={() => onOpenDocumentary?.()}
+            >
+              <FontAwesomeIcon icon={faPlay} />
+              Watch Documentary
+            </button>
+          </div>
+        </div>
+
+        {/* SXSW EDU 2025 Panel */}
+        <div className="about-featured-card">
+          <div className="about-featured-info about-featured-info--full">
+            <div className="about-featured-badges">
+              <span className="about-featured-badge about-featured-badge--sxsw">SXSW EDU</span>
+              <span className="about-featured-badge">2025 Panel</span>
+            </div>
+            <h3 className="about-featured-title">Behind the Wheel: Youth Driving Tech &amp; Media</h3>
+            <p className="about-featured-desc">
+              Panelist at SXSW EDU 2025 in Austin, TX — discussing how young people are shaping the future of technology and media.
+            </p>
+            <a
+              href="https://schedule.sxswedu.com/2025/events/PP156313"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="about-featured-cta about-featured-cta--link"
+            >
+              <FontAwesomeIcon icon={faExternalLinkAlt} />
+              View Session
+            </a>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
   const renderChapter = () => {
+    if (chapter.kind === "featured") {
+      return renderFeaturedChapter();
+    }
+
     if (chapter.kind === "profile") {
       return (
         <>

--- a/src/components/features/modal/ModalShell.tsx
+++ b/src/components/features/modal/ModalShell.tsx
@@ -125,6 +125,7 @@ const ModalShell: React.FC<ModalShellProps> = ({
         initial="initial"
         animate="animate"
         exit="exit"
+        style={{ willChange: "transform, opacity" }}
       >
         {children}
       </motion.div>

--- a/src/components/features/skills/SkillsetModal/SkillsetModal.tsx
+++ b/src/components/features/skills/SkillsetModal/SkillsetModal.tsx
@@ -168,18 +168,18 @@ const SkillsetModal: React.FC<ModalProps> = ({ onClose }) => {
 
           <a
             className="skill-studio-byline"
-            href="https://www.milehighinterface.com"
+            href="https://www.anappidea.llc"
             target="_blank"
             rel="noopener noreferrer"
           >
             <Image
               src="/logos/mhi-logo.png"
-              alt="Mile High Interface LLC"
+              alt="An App Idea, LLC"
               width={22}
               height={22}
               className="skill-studio-logo"
             />
-            <span>Mile High Interface LLC</span>
+            <span>An App Idea, LLC</span>
           </a>
         </div>
 

--- a/src/components/layout/LandingPage/LandingPage.menu.css
+++ b/src/components/layout/LandingPage/LandingPage.menu.css
@@ -37,16 +37,15 @@
 }
 
 .menu-dropdown-project-img {
-  width: 78px;
-  height: 78px;
-  object-fit: cover;
+  width: 62px;
+  height: 62px;
   border-radius: 10px;
   background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
   border: 2px solid rgba(255, 255, 255, 0.8);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
-  overflow: hidden;
+  flex-shrink: 0;
 }
 
 .menu-dropdown-project-img-icon {
@@ -54,18 +53,19 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  padding: 8px;
+  padding: 6px;
   background:
     radial-gradient(circle at 30% 22%, rgba(255, 255, 255, 0.86), transparent 64%),
     linear-gradient(145deg, rgba(248, 250, 252, 0.95), rgba(226, 232, 240, 0.84));
 }
 
 .menu-dropdown-project-img-media {
-  width: 100%;
-  height: 100%;
+  width: 50px !important;
+  height: 50px !important;
   display: block;
   object-fit: contain;
   object-position: center center;
+  border-radius: 6px;
 }
 
 .menu-dropdown-project-icon {
@@ -129,16 +129,15 @@
 
 .menu-dropdown-project-item {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 16px;
-  padding: 18px 14px;
+  padding: 12px 14px;
   border-radius: 12px;
   position: relative;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
   border: 2px solid transparent;
   background: linear-gradient(135deg, #fff 0%, #f8fafc 100%);
-  backdrop-filter: blur(6px);
   max-width: 360px;
   width: 100%;
   box-sizing: border-box;
@@ -1253,7 +1252,6 @@
   justify-content: center;
   overflow: hidden;
   transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-  backdrop-filter: blur(8px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04),
     inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 -1px 0 rgba(0, 0, 0, 0.02);
   position: relative;
@@ -1411,7 +1409,6 @@
   z-index: 2000;
   min-width: 300px;
   max-width: 400px;
-  backdrop-filter: blur(12px);
   animation: fadeInSideDropdown 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 

--- a/src/components/layout/LandingPage/LandingPage.tsx
+++ b/src/components/layout/LandingPage/LandingPage.tsx
@@ -72,8 +72,8 @@ const LandingPage = () => {
         setShowSkillset={modalActions.setShowSkillset}
         showProjects={modalState.showProjects}
         setShowProjects={modalActions.setShowProjects}
-        // showDocumentary={modalState.showDocumentary}
-        // setShowDocumentary={modalActions.setShowDocumentary}
+        showDocumentary={modalState.showDocumentary}
+        setShowDocumentary={modalActions.setShowDocumentary}
       />
     </div>
   );

--- a/src/components/layout/LandingPage/components/MenuBar.tsx
+++ b/src/components/layout/LandingPage/components/MenuBar.tsx
@@ -50,7 +50,6 @@ const MenuBar: React.FC<MenuBarProps> = ({
   TimeDisplay,
 }) => {
   const menuBarRef = useRef<HTMLDivElement>(null);
-  const [hoveredPill, setHoveredPill] = React.useState<string | null>(null);
 
   const iconMap = {
     "fas fa-briefcase icon": faBriefcase,
@@ -217,80 +216,48 @@ const MenuBar: React.FC<MenuBarProps> = ({
                 {item.key === "about" && (
                   <div>
                     <ul className="menu-dropdown-pills">
-                      {aboutMePills.map((pill) => (
-                        <li
-                          key={pill.label}
-                          className="menu-dropdown-pill-item"
-                          onMouseEnter={() => setHoveredPill(pill.label)}
-                          onMouseLeave={() => setHoveredPill(null)}
-                        >
-                          <span
-                            className={`pill-tag-mac ${pill.label === "& more..."
-                                ? "pill-tag-clickable"
-                                : ""
-                              }`}
-                            tabIndex={0}
-                            onClick={() => {
-                              if (pill.label === "& more...") {
-                                setShowAboutMe(true);
-                                setOpenDropdown(null);
-                              } else if (pill.link) {
-                                window.open(pill.link, "_blank");
-                              }
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                if (pill.label === "& more...") {
-                                  setShowAboutMe(true);
-                                  setOpenDropdown(null);
-                                } else if (pill.link) {
-                                  window.open(pill.link, "_blank");
-                                }
-                              }
-                            }}
-                            onFocus={() => setHoveredPill(pill.label)}
-                            onBlur={() => setHoveredPill(null)}
+                      {aboutMePills.map((pill) => {
+                        const handlePillAction = () => {
+                          if (pill.label === "& more...") {
+                            setShowAboutMe(true);
+                            setOpenDropdown(null);
+                          } else if (pill.link) {
+                            window.open(pill.link, "_blank");
+                          }
+                        };
+                        return (
+                          <li
+                            key={pill.label}
+                            className="menu-dropdown-pill-item"
                           >
-                            {pill.icon && (
-                              <div className="pill-tag-icon">
-                                <Image
-                                  src={pill.icon}
-                                  alt={pill.label}
-                                  width={20}
-                                  height={20}
-                                />
-                              </div>
-                            )}
-                            <span className="pill-tag-label">{pill.label}</span>
-                          </span>
-
-                          {/* Side dropdown for pill details */}
-                          {hoveredPill === pill.label && pill.tooltip && (
-                            <div className="pill-side-dropdown">
-                              <div className="pill-side-content">
-                                {pill.icon && (
-                                  <div className="pill-side-icon">
-                                    <Image
-                                      src={pill.icon}
-                                      alt={pill.label}
-                                      width={48}
-                                      height={48}
-                                    />
-                                  </div>
-                                )}
-                                <div className="pill-side-info">
-                                  <div className="pill-side-title">
-                                    {pill.label}
-                                  </div>
-                                  <div className="pill-side-description">
-                                    {pill.tooltip}
-                                  </div>
+                            <span
+                              className={`pill-tag-mac ${pill.label === "& more..."
+                                  ? "pill-tag-clickable"
+                                  : ""
+                                }`}
+                              tabIndex={0}
+                              onMouseEnter={handlePillAction}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  handlePillAction();
+                                }
+                              }}
+                            >
+                              {pill.icon && (
+                                <div className="pill-tag-icon">
+                                  <Image
+                                    src={pill.icon}
+                                    alt={pill.label}
+                                    width={20}
+                                    height={20}
+                                  />
                                 </div>
-                              </div>
-                            </div>
-                          )}
-                        </li>
-                      ))}
+                              )}
+                              <span className="pill-tag-label">{pill.label}</span>
+                            </span>
+                          </li>
+                        );
+                      })}
                     </ul>
                   </div>
                 )}
@@ -358,8 +325,8 @@ const MenuBar: React.FC<MenuBarProps> = ({
                                       src={proj.icon as string}
                                       alt={`${proj.name} icon`}
                                       className="menu-dropdown-project-img-media"
-                                      width={62}
-                                      height={62}
+                                      width={50}
+                                      height={50}
                                     />
                                   </span>
                                 );

--- a/src/components/layout/LandingPage/components/Modals.tsx
+++ b/src/components/layout/LandingPage/components/Modals.tsx
@@ -43,7 +43,6 @@ const ProjectsModal = dynamic(
   }
 );
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const DocumentaryPlayer = dynamic(
   () => import("@/components/features/media").then((m) => m.DocumentaryPlayer),
   {
@@ -63,8 +62,8 @@ interface ModalsProps {
   setShowSkillset: (show: boolean) => void;
   showProjects: boolean;
   setShowProjects: (show: boolean) => void;
-  showDocumentary?: boolean;
-  setShowDocumentary?: (show: boolean) => void;
+  showDocumentary: boolean;
+  setShowDocumentary: (show: boolean) => void;
 }
 
 const Modals: React.FC<ModalsProps> = ({
@@ -78,8 +77,8 @@ const Modals: React.FC<ModalsProps> = ({
   setShowSkillset,
   showProjects,
   setShowProjects,
-  // showDocumentary,
-  // setShowDocumentary,
+  showDocumentary,
+  setShowDocumentary,
 }) => {
   return (
     <>
@@ -95,6 +94,7 @@ const Modals: React.FC<ModalsProps> = ({
             onClose={() => setShowAboutMe(false)}
             onOpenContact={() => setShowContactForm(true)}
             onOpenResume={() => setShowResume(true)}
+            onOpenDocumentary={() => setShowDocumentary(true)}
           />
         )}
       </AnimatePresence>
@@ -113,9 +113,11 @@ const Modals: React.FC<ModalsProps> = ({
           <ProjectsModal key="projects" onClose={() => setShowProjects(false)} />
         )}
       </AnimatePresence>
-      {/* {showDocumentary && ( */}
-      {/* <DocumentaryPlayer onClose={() => setShowDocumentary(false)} /> */}
-      {/* )} */}
+      <AnimatePresence>
+        {showDocumentary && (
+          <DocumentaryPlayer key="documentary" onClose={() => setShowDocumentary(false)} />
+        )}
+      </AnimatePresence>
     </>
   );
 };

--- a/src/components/layout/LandingPage/components/TimeDisplay.tsx
+++ b/src/components/layout/LandingPage/components/TimeDisplay.tsx
@@ -4,11 +4,12 @@ import React, { useState, useEffect, useRef } from "react";
 
 // Minute-based clock component to avoid re-rendering the entire desktop each second
 const TimeDisplay: React.FC = () => {
-  const [now, setNow] = useState(new Date());
+  const [now, setNow] = useState<Date | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     const instant = new Date();
+    setNow(instant);
     const msUntilNextMinute =
       60000 - (instant.getSeconds() * 1000 + instant.getMilliseconds());
     const timeoutId = setTimeout(() => {
@@ -20,6 +21,15 @@ const TimeDisplay: React.FC = () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, []);
+
+  if (!now) {
+    return (
+      <>
+        <span className="time">&nbsp;</span>
+        <span className="date">&nbsp;</span>
+      </>
+    );
+  }
 
   const time = now.toLocaleTimeString("en-US", {
     hour: "2-digit",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -7,18 +7,17 @@ const projectData: Project[] = [
     name: "Pinpoint",
     yearRange: "2025-2026",
     description:
-      "Civic engagement platform helping people find officials, analyze policy alignment, and communicate through AI-assisted workflows.",
-    link: "https://pinpoint-flax.vercel.app/",
+      "React Native mobile app for civic engagement — find elected officials, analyze policy alignment, and communicate through AI-assisted workflows on iOS and Android.",
+    link: "https://github.com/demaceo",
     deepDiveKey: "pinpoint",
     stackPreview: ["React Native", "Expo SDK 54", "Express", "PostgreSQL"],
     highlights: [
-      "Full-stack iOS, Android, and web deployment with zero-downtime delivery.",
+      "Full-stack iOS and Android deployment with zero-downtime delivery.",
       "JWKS-based Firebase token verification without Firebase Admin SDK.",
       "Gemini SSE chat and ElevenLabs voice responses for AI official simulations.",
     ],
     icon: "/icons/projects/pinpoint.png",
-    image:
-      "https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3BqcHJydDE0OWlyaXBzbzIweTV4bjh2bzNidW1oenprMHdpaTRxbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/e9zB7dPkmU7FUBNh8A/giphy.gif",
+    image: "/icons/projects/pinpoint.png",
   },
   {
     id: 1,


### PR DESCRIPTION
## Summary

- **Fix React error #418** — `TimeDisplay` now initializes date state as `null` and populates in `useEffect`, eliminating the server/client hydration mismatch
- **Performance** — removed redundant `backdrop-filter: blur()` from individual dropdown list items (kept only on top-level containers); added `will-change: transform, opacity` to `ModalShell` dialog div for GPU layer promotion
- **Rebrand** — `SkillsetModal` byline and link updated from "Mile High Interface LLC / milehighinterface.com" to "An App Idea, LLC / anappidea.llc"
- **Projects dropdown icon clipping** — reduced container to 62×62px, removed `overflow: hidden`, switched from percentage-based to explicit pixel sizing on `<Image>` so icons no longer clip at the bottom
- **About dropdown hover UX** — pill actions (open About modal for "& more...", `window.open` for linked pills) now fire on `onMouseEnter` instead of `onClick`; keyboard (`Enter`/`Space`) still works
- **About Me modal — Featured chapter** — added a sixth chapter with two cards: PBS "Tech For Us — Breaking Barriers" documentary (triggers `DocumentaryPlayer` modal) and SXSW EDU 2025 panel ("Behind the Wheel: Youth Driving Tech & Media") with external schedule link; wired `DocumentaryPlayer` back through `Modals` and `LandingPage` state passthrough
- **Pinpoint project** — replaced animated GIF hero with the app icon PNG, updated description to emphasize React Native mobile app (iOS/Android), updated link to GitHub profile

## Test plan

- [ ] Open browser console on page load — no React hydration error #418
- [ ] Open/close modals (About, Projects, Skillset) — animations feel smooth without stutter
- [ ] Open Skillset modal → byline reads "An App Idea, LLC" linking to anappidea.llc
- [ ] Open Projects dropdown → all project icons fully visible, no bottom clipping
- [ ] Hover over About dropdown pills — "& more..." opens About Me modal immediately on hover; linked pills open in new tab on hover
- [ ] About Me modal → navigate to chapter 6 "Featured" — see PBS documentary card and SXSW EDU card; "Watch Documentary" opens player; "View Session" opens external link
- [ ] Projects modal → Pinpoint entry shows icon PNG (not GIF), description references iOS/Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJNZP3VXzngAEKtaZCKhmm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJNZP3VXzngAEKtaZCKhmm)_