### PR TITLE
Redesign modals & dropdowns with liquid-glass (Dark Glass) UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,6 +47,38 @@
   --light-panel: #f4f5f7;
   --light-panel-strong: #eaecef;
   --light-surface: #ffffff;
+
+  /* ===== Noir tokens missing from the base set =====
+     Referenced by modals migrated to the dark palette (Projects,
+     ResumeHighlights) which expect an accent hairline + a surface. */
+  --noir-accent-line: rgba(212, 132, 90, 0.3);
+  --noir-surface: rgba(18, 13, 10, 0.55);
+
+  /* ===== Liquid Glass tokens (Dark Glass) =====
+     Ported from the codepenz "Liquid Glass UI Kit" (Component 02 · Dark Glass).
+     Structural only — the warm --noir-accent palette supplies the color so the
+     glass reads as part of the Warm Noir identity, not the kit's aqua/violet.
+     Surfaces use low alpha so the overlay's one-time blur and the vibrant
+     desktop wallpaper read through them.
+     NOTE: the `--lg-` prefix is deliberate. InteractiveResume.css and
+     DocumentaryPlayer.css already define component-scoped `--glass-bg` /
+     `--glass-border` / `--glass-shadow`; a distinct namespace prevents these
+     global tokens from leaking into (or being shadowed by) those. */
+  --lg-tint: rgba(18, 13, 10, 0.62);
+  --lg-tint-strong: rgba(13, 10, 9, 0.74); /* title bars, item cards over glass */
+  --lg-edge: rgba(255, 220, 180, 0.16);
+  --lg-edge-bright: rgba(255, 220, 180, 0.28);
+  --lg-sheen: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.22) 0%,
+    rgba(255, 255, 255, 0) 50%
+  );
+  --lg-blur: blur(18px) saturate(140%);
+  --lg-blur-strong: blur(32px) saturate(140%);
+  --lg-shadow: 0 8px 32px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
+  --lg-shadow-float: 0 20px 60px rgba(0, 0, 0, 0.4),
+    0 4px 16px rgba(0, 0, 0, 0.2);
 }
 
 /* Strict CSS reset for html and body */
@@ -243,5 +275,67 @@ h6 {
 @keyframes modal-loading-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+/* ==========================================================================
+   Liquid Glass — Navigation Tabs (from the codepenz "Liquid Glass UI Kit").
+   Reusable glass tab list. Drop `glass-tab-list` on the role="tablist"
+   container and `glass-tab` on each role="tab" button; the selected state
+   responds to BOTH `.active` and `aria-selected="true"` so it is drop-in with
+   either convention. The existing in-modal tab lists (Skillset, Projects,
+   ResumeHighlights) already carry the equivalent glass treatment via the same
+   tokens; use these classes for any NEW tab list.
+   ========================================================================== */
+.glass-tab-list {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  padding: 0.24rem;
+  border-radius: 999px;
+  background: var(--lg-tint);
+  border: 1px solid var(--lg-edge);
+  backdrop-filter: var(--lg-blur);
+  -webkit-backdrop-filter: var(--lg-blur);
+}
+
+.glass-tab {
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--noir-muted);
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 0.34rem 0.84rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.glass-tab:hover:not(.active):not([aria-selected="true"]) {
+  color: var(--noir-text);
+}
+
+.glass-tab.active,
+.glass-tab[aria-selected="true"] {
+  background: var(--noir-accent);
+  color: #fff;
+  box-shadow: 0 2px 10px var(--noir-accent-glow);
+}
+
+.glass-tab:focus-visible {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: 2px;
+}
+
+.glass-tab-panel {
+  color: var(--noir-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glass-tab {
+    transition: none;
   }
 }

--- a/src/components/features/about/AboutMeModal/AboutMeModal.css
+++ b/src/components/features/about/AboutMeModal/AboutMeModal.css
@@ -1,14 +1,14 @@
 /* ===== ABOUT — "THE DOSSIER" / CHAPTERED NARRATIVE ===== */
 
 .about-dossier {
-  --about-accent: var(--light-accent);
-  --about-accent-soft: var(--light-accent-soft);
-  --about-accent-glow: var(--light-accent-glow);
-  --about-text: var(--light-text);
-  --about-muted: var(--light-muted);
-  --about-faint: var(--light-faint);
-  --about-border: var(--light-border);
-  --about-panel: var(--light-panel);
+  --about-accent: var(--noir-accent);
+  --about-accent-soft: var(--noir-accent-soft);
+  --about-accent-glow: var(--noir-accent-glow);
+  --about-text: var(--noir-text);
+  --about-muted: var(--noir-muted);
+  --about-faint: var(--noir-faint);
+  --about-border: var(--noir-border);
+  --about-panel: var(--noir-panel);
 
   display: grid;
   grid-template-columns: 210px 1fr;
@@ -62,7 +62,7 @@
 
 .about-rail-item:hover:not(.active) {
   background: var(--about-panel);
-  color: rgba(43, 42, 40, 0.78);
+  color: rgba(240, 236, 232, 0.78);
 }
 
 .about-rail-item.active {
@@ -204,7 +204,7 @@
   padding-left: 1.5rem;
   font-size: 0.92rem;
   line-height: 1.58;
-  color: rgba(43, 42, 40, 0.72);
+  color: rgba(240, 236, 232, 0.72);
 }
 
 .about-points li::before {
@@ -231,10 +231,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid rgba(43, 42, 40, 0.14);
+  border: 1px solid rgba(240, 236, 232, 0.14);
   border-radius: 999px;
   background: var(--about-panel);
-  color: rgba(43, 42, 40, 0.68);
+  color: rgba(240, 236, 232, 0.68);
   font-family: inherit;
   font-size: 0.8rem;
   font-weight: 600;
@@ -250,7 +250,7 @@
 
 .about-pill:hover {
   border-color: rgba(182, 95, 56, 0.4);
-  color: rgba(43, 42, 40, 0.9);
+  color: rgba(240, 236, 232, 0.9);
   transform: translateY(-1px);
 }
 
@@ -316,8 +316,8 @@
   height: 32px;
   border-radius: 50%;
   background: var(--about-panel);
-  border: 1px solid rgba(43, 42, 40, 0.14);
-  color: rgba(43, 42, 40, 0.45);
+  border: 1px solid rgba(240, 236, 232, 0.14);
+  color: rgba(240, 236, 232, 0.45);
   font-size: 0.72rem;
   cursor: pointer;
   display: flex;
@@ -356,12 +356,12 @@
 }
 
 .about-prog-sep {
-  color: rgba(43, 42, 40, 0.18);
+  color: rgba(240, 236, 232, 0.18);
   margin: 0 0.15em;
 }
 
 .about-prog-total {
-  color: rgba(43, 42, 40, 0.25);
+  color: rgba(240, 236, 232, 0.25);
 }
 
 /* ── Featured chapter ─────────────────────────────────── */

--- a/src/components/features/contact/ContactForm/ContactForm.css
+++ b/src/components/features/contact/ContactForm/ContactForm.css
@@ -1,14 +1,14 @@
 /* ===== CONTACT — "THE INVITATION" / WARM NOIR ===== */
 
 .contact-invite {
-  --cf-accent: var(--light-accent);
-  --cf-accent-soft: var(--light-accent-soft);
-  --cf-accent-glow: var(--light-accent-glow);
-  --cf-text: var(--light-text);
-  --cf-muted: var(--light-muted);
-  --cf-faint: var(--light-faint);
-  --cf-border: var(--light-border);
-  --cf-surface: var(--light-panel);
+  --cf-accent: var(--noir-accent);
+  --cf-accent-soft: var(--noir-accent-soft);
+  --cf-accent-glow: var(--noir-accent-glow);
+  --cf-text: var(--noir-text);
+  --cf-muted: var(--noir-muted);
+  --cf-faint: var(--noir-faint);
+  --cf-border: var(--noir-border);
+  --cf-surface: var(--noir-panel);
 
   flex: 1;
   min-height: 0;
@@ -324,7 +324,7 @@
 
 .field input:hover:not(:focus),
 .field textarea:hover:not(:focus) {
-  border-color: rgba(43, 42, 40, 0.26);
+  border-color: rgba(240, 236, 232, 0.26);
 }
 
 .field input:focus + label,

--- a/src/components/features/media/DocumentaryPlayer/DocumentaryPlayer.css
+++ b/src/components/features/media/DocumentaryPlayer/DocumentaryPlayer.css
@@ -1807,3 +1807,34 @@
     min-width: 44px;
   }
 }
+
+/* ==========================================================================
+   Liquid Glass — dark-glass alignment for the in-player episode/info dropdowns.
+   Re-skins the light iOS-glass surfaces to the shared Dark Glass tokens so
+   these panels match the dark modal shell. Placed last so it wins over the
+   duplicated episode-selector and info-dropdown rules above; only colors and
+   surfaces are overridden (the existing backdrop blur, padding and layout
+   stand). The selected-episode blue-to-violet gradient and the video are kept.
+   ========================================================================== */
+.episode-selector,
+.info-dropdown {
+  background: var(--lg-tint);
+  border-bottom: 1px solid var(--lg-edge);
+}
+
+.episode-selector h3 {
+  color: var(--noir-text);
+}
+
+.episode-item {
+  background: var(--lg-tint-strong);
+  border-color: var(--lg-edge);
+}
+
+.episode-title {
+  color: var(--noir-text);
+}
+
+.episode-duration {
+  color: var(--noir-muted);
+}

--- a/src/components/features/modal/ModalFrame.module.css
+++ b/src/components/features/modal/ModalFrame.module.css
@@ -25,19 +25,39 @@
   display: flex;
   flex-direction: column;
   border-radius: 18px;
-  border: 1px solid rgba(220, 175, 130, 0.12);
-  background: rgba(13, 10, 9, 0.95);
+  border: 1px solid var(--lg-edge);
+  background: var(--lg-tint);
   box-shadow:
     0 36px 90px rgba(0, 0, 0, 0.65),
     0 10px 28px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 205, 155, 0.07),
+    inset 0 1px 0 rgba(255, 205, 155, 0.12),
     inset 0 -1px 0 rgba(0, 0, 0, 0.25);
   overflow: hidden;
   outline: none;
-  /* The frame is the element that animates; hint compositing and avoid a
-     backdrop-filter here (the surface is opaque, so a blur behind it is
-     invisible yet forces an expensive re-sample on every animated frame). */
+  /* Liquid-glass frame: a translucent dark tint, NOT a blur layer. The blur is
+     done once on the overlay (which only animates opacity), so it is never
+     re-sampled per animated frame. The frame only tweens transform — keeping a
+     backdrop-filter off it avoids an expensive per-frame re-sample. */
   will-change: transform;
+}
+
+/* 135deg white->transparent sheen — the kit's ".glass::before" reflection.
+   Clipped by the frame's overflow:hidden to follow the corner radius. */
+.frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--lg-sheen);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Keep the window chrome above the sheen so it can't be painted over. */
+.titleBar,
+.content {
+  position: relative;
+  z-index: 1;
 }
 
 .sizeSm { --modal-max-width: 520px; }
@@ -51,12 +71,14 @@
   justify-content: space-between;
   min-height: 52px;
   padding: 0 18px;
-  border-bottom: 1px solid rgba(220, 175, 130, 0.09);
+  border-bottom: 1px solid var(--lg-edge);
   position: relative;
   flex-shrink: 0;
+  /* Slightly denser than the body so the macOS title stays legible over the
+     translucent glass, but still lets the blurred backdrop read through. */
   background: linear-gradient(180deg,
-    rgba(9, 7, 5, 0.99) 0%,
-    rgba(13, 10, 9, 0.97) 100%);
+    rgba(13, 10, 9, 0.62) 0%,
+    rgba(13, 10, 9, 0.48) 100%);
 }
 
 .titleBar::before {
@@ -87,7 +109,7 @@
 .closeButton {
   width: 28px;
   height: 28px;
-  border: 1px solid rgba(220, 175, 130, 0.18);
+  border: 1px solid var(--lg-edge-bright);
   border-radius: 50%;
   cursor: pointer;
   display: flex;
@@ -206,61 +228,38 @@
 }
 
 /* ==========================================================================
-   Light variant — re-skins the shared shell to the light desktop palette.
-   Opt in via <ModalFrame variant="light">. Content CSS supplies its own
-   light colors; this only handles the overlay scrim and the window chrome.
+   Unified Dark Glass.
+   Several modals still pass variant="light" (ContactForm, AboutMe, Skillset,
+   Projects, ResumeHighlights). Under the liquid-glass redesign every modal
+   renders the SAME Dark Glass shell, so the light variant no longer diverges —
+   it simply re-asserts the shared glass tokens and lets the title bar, title
+   and close button inherit the base dark-glass rules above. The `.light` class
+   is kept alive so the prop keeps working with no .tsx churn; each modal's own
+   CSS migrates its content palette to the noir tokens.
    ========================================================================== */
-.overlay.light {
-  background: linear-gradient(135deg,
-    rgba(40, 36, 33, 0.42) 0%,
-    rgba(40, 36, 33, 0.34) 100%);
-}
-
 .frame.light {
-  border-color: var(--light-border);
-  background: var(--light-surface);
-  box-shadow:
-    0 36px 90px rgba(22, 20, 18, 0.26),
-    0 10px 28px rgba(22, 20, 18, 0.14),
-    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  border-color: var(--lg-edge);
+  background: var(--lg-tint);
 }
 
-.frame.light .titleBar {
-  border-bottom: 1px solid var(--light-border);
-  background: linear-gradient(180deg, #f8fafc 0%, #eef1f5 100%);
-}
+/* ==========================================================================
+   Fallback when backdrop-filter is unsupported: the overlay can't blur, so
+   raise the scrim and the frame/title alphas back toward opaque to preserve
+   legibility over the busy wallpaper.
+   ========================================================================== */
+@supports not (backdrop-filter: blur(1px)) {
+  .overlay {
+    background: rgba(8, 5, 3, 0.86);
+  }
 
-.frame.light .titleBar::before {
-  background: linear-gradient(90deg,
-    transparent 0%,
-    var(--light-accent-soft) 25%,
-    var(--light-accent-line) 50%,
-    var(--light-accent-soft) 75%,
-    transparent 100%);
-}
+  .frame,
+  .frame.light {
+    background: rgba(16, 12, 10, 0.96);
+  }
 
-.frame.light .windowTitle {
-  color: rgba(43, 42, 40, 0.55);
-}
-
-.frame.light .closeButton {
-  border-color: var(--light-border);
-  background: rgba(0, 0, 0, 0.04);
-}
-
-.frame.light .closeButton::after {
-  color: rgba(43, 42, 40, 0.5);
-}
-
-.frame.light .closeButton:hover {
-  background: var(--light-accent-soft);
-  border-color: var(--light-accent-line);
-}
-
-.frame.light .closeButton:hover::after {
-  color: var(--light-accent);
-}
-
-.frame.light .closeButton:focus-visible {
-  outline-color: var(--light-accent);
+  .titleBar {
+    background: linear-gradient(180deg,
+      rgba(13, 10, 9, 0.98) 0%,
+      rgba(16, 12, 10, 0.96) 100%);
+  }
 }

--- a/src/components/features/portfolio/ProjectsModal/ProjectsModal.css
+++ b/src/components/features/portfolio/ProjectsModal/ProjectsModal.css
@@ -1,17 +1,17 @@
 /* ===== PROJECTS GALLERY — LIGHT DESKTOP AESTHETIC ===== */
 
 .projects-gallery {
-  --gallery-accent: var(--light-accent);
-  --gallery-accent-soft: var(--light-accent-soft);
-  --gallery-accent-line: var(--light-accent-line);
-  --gallery-accent-glow: var(--light-accent-glow);
-  --gallery-text: var(--light-text);
-  --gallery-muted: var(--light-muted);
-  --gallery-faint: var(--light-faint);
-  --gallery-border: var(--light-border);
-  --gallery-panel: var(--light-panel);
-  --gallery-panel-strong: var(--light-panel-strong);
-  --gallery-surface: var(--light-surface);
+  --gallery-accent: var(--noir-accent);
+  --gallery-accent-soft: var(--noir-accent-soft);
+  --gallery-accent-line: var(--noir-accent-line);
+  --gallery-accent-glow: var(--noir-accent-glow);
+  --gallery-text: var(--noir-text);
+  --gallery-muted: var(--noir-muted);
+  --gallery-faint: var(--noir-faint);
+  --gallery-border: var(--noir-border);
+  --gallery-panel: var(--noir-panel);
+  --gallery-panel-strong: var(--noir-panel-strong);
+  --gallery-surface: var(--noir-surface);
 
   display: flex;
   flex-direction: column;
@@ -39,8 +39,10 @@
 .gallery-tabs {
   display: flex;
   gap: 0.28rem;
-  background: var(--gallery-surface);
-  border: 1px solid var(--gallery-border);
+  background: var(--lg-tint);
+  border: 1px solid var(--lg-edge);
+  backdrop-filter: var(--lg-blur);
+  -webkit-backdrop-filter: var(--lg-blur);
   border-radius: 999px;
   padding: 0.24rem;
 }
@@ -201,12 +203,12 @@
 }
 
 .counter-sep {
-  color: rgba(43, 42, 40, 0.25);
+  color: rgba(240, 236, 232, 0.25);
   margin: 0 0.15em;
 }
 
 .counter-total {
-  color: rgba(43, 42, 40, 0.35);
+  color: rgba(240, 236, 232, 0.35);
 }
 
 .gallery-doc-tag {

--- a/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
+++ b/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
@@ -1,17 +1,17 @@
 /* ===== RESUME HIGHLIGHTS — LIGHT DESKTOP GALLERY GRAMMAR ===== */
 
 .resume-highlights-content {
-  --resume-accent: var(--light-accent);
-  --resume-accent-soft: var(--light-accent-soft);
-  --resume-accent-line: var(--light-accent-line);
-  --resume-accent-glow: var(--light-accent-glow);
-  --resume-text: var(--light-text);
-  --resume-muted: var(--light-muted);
-  --resume-faint: var(--light-faint);
-  --resume-border: var(--light-border);
-  --resume-panel: var(--light-panel);
-  --resume-panel-strong: var(--light-panel-strong);
-  --resume-surface: var(--light-surface);
+  --resume-accent: var(--noir-accent);
+  --resume-accent-soft: var(--noir-accent-soft);
+  --resume-accent-line: var(--noir-accent-line);
+  --resume-accent-glow: var(--noir-accent-glow);
+  --resume-text: var(--noir-text);
+  --resume-muted: var(--noir-muted);
+  --resume-faint: var(--noir-faint);
+  --resume-border: var(--noir-border);
+  --resume-panel: var(--noir-panel);
+  --resume-panel-strong: var(--noir-panel-strong);
+  --resume-surface: var(--noir-surface);
 
   display: flex;
   flex-direction: column;
@@ -37,8 +37,10 @@
 .resume-highlights-tabs {
   display: flex;
   gap: 0.28rem;
-  background: var(--resume-surface);
-  border: 1px solid var(--resume-border);
+  background: var(--lg-tint);
+  border: 1px solid var(--lg-edge);
+  backdrop-filter: var(--lg-blur);
+  -webkit-backdrop-filter: var(--lg-blur);
   border-radius: 999px;
   padding: 0.24rem;
 }

--- a/src/components/features/skills/SkillsetModal/SkillsetModal.css
+++ b/src/components/features/skills/SkillsetModal/SkillsetModal.css
@@ -1,14 +1,14 @@
 /* ===== SKILLSET — WARM NOIR: PLATES + PROFICIENCY WALL ===== */
 
 .skillset {
-  --skill-accent: var(--light-accent);
-  --skill-accent-soft: var(--light-accent-soft);
-  --skill-accent-glow: var(--light-accent-glow);
-  --skill-text: var(--light-text);
-  --skill-muted: var(--light-muted);
-  --skill-faint: var(--light-faint);
-  --skill-border: var(--light-border);
-  --skill-panel: var(--light-panel);
+  --skill-accent: var(--noir-accent);
+  --skill-accent-soft: var(--noir-accent-soft);
+  --skill-accent-glow: var(--noir-accent-glow);
+  --skill-text: var(--noir-text);
+  --skill-muted: var(--noir-muted);
+  --skill-faint: var(--noir-faint);
+  --skill-border: var(--noir-border);
+  --skill-panel: var(--noir-panel);
 
   display: flex;
   flex-direction: column;
@@ -34,8 +34,10 @@
 .skill-tabs {
   display: flex;
   gap: 0.28rem;
-  background: var(--skill-panel);
-  border: 1px solid var(--skill-border);
+  background: var(--lg-tint);
+  border: 1px solid var(--lg-edge);
+  backdrop-filter: var(--lg-blur);
+  -webkit-backdrop-filter: var(--lg-blur);
   border-radius: 999px;
   padding: 0.24rem;
 }
@@ -44,7 +46,7 @@
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: rgba(43, 42, 40, 0.4);
+  color: rgba(240, 236, 232, 0.4);
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.03em;
@@ -60,7 +62,7 @@
 }
 
 .skill-tab:hover:not(.active) {
-  color: rgba(43, 42, 40, 0.7);
+  color: rgba(240, 236, 232, 0.7);
 }
 
 .skill-tab:focus-visible,
@@ -173,12 +175,12 @@
 }
 
 .counter-sep {
-  color: rgba(43, 42, 40, 0.18);
+  color: rgba(240, 236, 232, 0.18);
   margin: 0 0.15em;
 }
 
 .counter-total {
-  color: rgba(43, 42, 40, 0.25);
+  color: rgba(240, 236, 232, 0.25);
 }
 
 .plate-title {
@@ -226,8 +228,8 @@
   height: 32px;
   border-radius: 50%;
   background: var(--skill-panel);
-  border: 1px solid rgba(43, 42, 40, 0.14);
-  color: rgba(43, 42, 40, 0.45);
+  border: 1px solid rgba(240, 236, 232, 0.14);
+  color: rgba(240, 236, 232, 0.45);
   font-size: 0.72rem;
   cursor: pointer;
   display: flex;
@@ -306,7 +308,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid rgba(43, 42, 40, 0.14);
+  border: 1px solid rgba(240, 236, 232, 0.14);
   border-radius: 0.66rem;
   background: var(--skill-panel);
   padding: 0.5rem 0.7rem;
@@ -336,7 +338,7 @@
 }
 
 .wall-search input::placeholder {
-  color: rgba(43, 42, 40, 0.28);
+  color: rgba(240, 236, 232, 0.28);
 }
 
 .wall-chips {
@@ -346,10 +348,10 @@
 }
 
 .wall-chip {
-  border: 1px solid rgba(43, 42, 40, 0.13);
+  border: 1px solid rgba(240, 236, 232, 0.13);
   border-radius: 999px;
   background: var(--skill-panel);
-  color: rgba(43, 42, 40, 0.45);
+  color: rgba(240, 236, 232, 0.45);
   font-size: 0.7rem;
   font-weight: 700;
   padding: 0.3rem 0.62rem;
@@ -359,7 +361,7 @@
 
 .wall-chip:hover:not(.active) {
   border-color: rgba(182, 95, 56, 0.32);
-  color: rgba(43, 42, 40, 0.75);
+  color: rgba(240, 236, 232, 0.75);
 }
 
 .wall-chip.active {
@@ -409,7 +411,7 @@
   height: 1.3rem;
   padding: 0 0.35rem;
   border-radius: 999px;
-  border: 1px solid rgba(43, 42, 40, 0.14);
+  border: 1px solid rgba(240, 236, 232, 0.14);
   display: grid;
   place-items: center;
   font-size: 0.66rem;
@@ -461,7 +463,7 @@
   font-size: 0.74rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: rgba(43, 42, 40, 0.62);
+  color: rgba(240, 236, 232, 0.62);
   line-height: 1.2;
 }
 
@@ -481,7 +483,7 @@
 /* ── Empty state ──────────────────────────────────────── */
 
 .wall-empty {
-  border: 1px dashed rgba(43, 42, 40, 0.18);
+  border: 1px dashed rgba(240, 236, 232, 0.18);
   border-radius: 0.88rem;
   background: var(--skill-panel);
   padding: 1.6rem;

--- a/src/components/layout/LandingPage/LandingPage.menu.css
+++ b/src/components/layout/LandingPage/LandingPage.menu.css
@@ -104,7 +104,7 @@
 .menu-dropdown-project-title {
   font-weight: 700;
   font-size: 15px;
-  color: #0f172a;
+  color: var(--noir-text);
   margin-bottom: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -116,7 +116,7 @@
 
 .menu-dropdown-project-desc {
   font-size: 12px;
-  color: #64748b;
+  color: var(--noir-muted);
   margin-bottom: 0;
   line-height: 1.5;
   max-width: 280px;
@@ -137,7 +137,7 @@
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
   border: 2px solid transparent;
-  background: linear-gradient(135deg, #fff 0%, #f8fafc 100%);
+  background: var(--lg-tint-strong);
   max-width: 360px;
   width: 100%;
   box-sizing: border-box;
@@ -159,12 +159,10 @@
 }
 
 .menu-dropdown-project-item:hover {
-  background: linear-gradient(135deg,
-      rgba(255, 255, 255, 0.95) 0%,
-      rgba(248, 250, 252, 0.9) 100%);
-  border-color: rgba(59, 130, 246, 0.4);
-  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.15),
-    0 6px 16px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  background: var(--lg-tint);
+  border-color: var(--noir-accent-line);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35),
+    0 6px 16px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.08);
   transform: translateY(-2px);
 }
 
@@ -870,7 +868,7 @@
   cursor: pointer;
   border: 1px solid transparent;
   position: relative;
-  background: linear-gradient(135deg, #f8fafc 0%, #e0e7ef 100%);
+  background: var(--lg-tint-strong);
   overflow: visible;
   min-height: fit-content;
   box-sizing: border-box;
@@ -878,13 +876,11 @@
 }
 
 .menu-dropdown-service-item:hover {
-  background: linear-gradient(135deg,
-      rgba(255, 255, 255, 0.9) 0%,
-      rgba(248, 250, 252, 0.7) 100%);
-  border-color: rgba(16, 185, 129, 0.3);
+  background: var(--lg-tint);
+  border-color: rgba(16, 185, 129, 0.4);
   transform: translateY(-2px);
   box-shadow: 0 8px 20px rgba(16, 185, 129, 0.12),
-    0 4px 12px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    0 4px 12px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 /* Emerald accent bar on hover */
@@ -933,7 +929,7 @@
 
 .menu-dropdown-service-title {
   margin: 0;
-  color: #0f172a;
+  color: var(--noir-text);
   font-size: 14px;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -942,7 +938,7 @@
 
 .menu-dropdown-service-desc {
   margin: 0;
-  color: #64748b;
+  color: var(--noir-muted);
   font-size: 12px;
   line-height: 1.45;
   display: -webkit-box;
@@ -1027,20 +1023,24 @@
 /* Menu Bar Root - Enhanced */
 .menu-bar {
   max-width: 100%;
-  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+  background: linear-gradient(180deg,
+    rgba(28, 20, 16, 0.72) 0%,
+    rgba(20, 14, 11, 0.68) 50%,
+    rgba(13, 10, 9, 0.74) 100%);
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 6px 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 -1px 0 rgba(0, 0, 0, 0.05);
-  border-bottom: 1px solid #cbd5e1;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--lg-edge);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
   position: relative;
   z-index: 1000;
-  backdrop-filter: blur(8px);
-  border-top: 1px solid rgba(255, 255, 255, 0.6);
+  backdrop-filter: var(--lg-blur);
+  -webkit-backdrop-filter: var(--lg-blur);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .menu-left {
@@ -1088,7 +1088,7 @@
   user-select: none;
   outline: none;
   background: transparent;
-  color: #374151;
+  color: rgba(240, 236, 232, 0.78);
   font-size: 13px;
   font-weight: 500;
   border: 1px solid transparent;
@@ -1096,24 +1096,26 @@
 }
 
 .menu-item:hover {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  color: #1f2937;
-  border-color: rgba(59, 130, 246, 0.2);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.1);
+  background: var(--lg-tint-strong);
+  color: var(--noir-text);
+  border-color: var(--lg-edge);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
   transform: translateY(-1px);
 }
 
 .menu-item:focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
 }
 
 .menu-item-active {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-  border-color: #2563eb;
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.25),
-    0 2px 6px rgba(59, 130, 246, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  background: linear-gradient(135deg,
+    rgba(212, 132, 90, 0.92) 0%,
+    rgba(191, 111, 71, 0.92) 100%);
+  color: #fff;
+  border-color: var(--noir-accent);
+  box-shadow: 0 4px 12px rgba(212, 132, 90, 0.3),
+    0 2px 6px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.18);
   transform: translateY(-1px);
 }
 
@@ -1122,12 +1124,13 @@
   top: calc(100% + 8px);
   left: 0;
   min-width: 240px;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(16px);
-  color: #1f2937;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1), 0 8px 20px rgba(0, 0, 0, 0.06),
-    0 4px 8px rgba(0, 0, 0, 0.04);
-  border: 1px solid rgba(229, 231, 235, 0.8);
+  background: var(--lg-tint);
+  backdrop-filter: var(--lg-blur-strong);
+  -webkit-backdrop-filter: var(--lg-blur-strong);
+  color: var(--noir-text);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45), 0 8px 20px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--lg-edge);
   border-radius: 12px;
   padding: 8px;
   z-index: 1011;
@@ -1154,9 +1157,9 @@
   left: 24px;
   width: 12px;
   height: 12px;
-  background: rgba(255, 255, 255, 0.95);
-  border-left: 1px solid rgba(229, 231, 235, 0.8);
-  border-top: 1px solid rgba(229, 231, 235, 0.8);
+  background: var(--lg-tint);
+  border-left: 1px solid var(--lg-edge);
+  border-top: 1px solid var(--lg-edge);
   transform: rotate(45deg);
   z-index: -1;
 }
@@ -1173,7 +1176,7 @@
 
 .menu-dropdown-title {
   font-size: 16px;
-  color: #22223b;
+  color: var(--noir-text);
   letter-spacing: 0.1px;
   font-weight: bold;
 }
@@ -1199,8 +1202,8 @@
   width: 100%;
   min-height: 52px;
   border-radius: 12px;
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: var(--lg-tint-strong);
+  border: 1px solid var(--lg-edge);
   padding: 14px 16px;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
@@ -1208,9 +1211,9 @@
 }
 
 .menu-dropdown-pill-item:hover {
-  background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
-  border-color: rgba(14, 116, 144, 0.3);
-  box-shadow: 0 4px 12px rgba(14, 116, 144, 0.15);
+  background: var(--lg-tint);
+  border-color: var(--noir-accent-line);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   transform: translateY(-1px);
 }
 
@@ -1225,7 +1228,7 @@
   padding: 6px 10px;
   font-size: 14px;
   font-weight: 500;
-  color: #334155;
+  color: var(--noir-text);
   letter-spacing: 0.02em;
   max-width: calc(100% - 50px);
 }
@@ -1501,21 +1504,21 @@
 }
 
 .pill-tag-clickable:hover {
-  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
-  border-color: rgba(37, 99, 235, 0.3);
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.15);
+  background: var(--lg-tint);
+  border-color: var(--noir-accent-line);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   transform: translateY(-1px);
 }
 
 .pill-tag-clickable:hover .pill-tag-label {
-  background: rgba(255, 255, 255, 0.9);
-  color: #1e40af;
-  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.1);
+  background: var(--noir-accent-soft);
+  color: var(--noir-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(4px);
 }
 
 .pill-tag-clickable:hover .pill-tag-arrow {
-  color: #2563eb;
+  color: var(--noir-accent);
   transform: translateX(3px);
 }
 


### PR DESCRIPTION
## Summary

Brings the **Liquid Glass UI Kit** aesthetic from the `codepenz` repo — **Frosted Surface** (Component 01), **Dark Glass** (Component 02), and **Navigation Tabs** — into `portfolio-v4`, redesigning its modals and dropdown menus. Per the chosen direction, every modal is unified onto a single translucent **Dark Glass** surface that reads over the vibrant desktop wallpaper (exactly the bright backdrop Dark Glass is designed for).

All changes are **CSS-only** — no `.tsx`/`.ts` files were touched, so component behaviour, ARIA, and animations are unchanged.

## What changed

**Tokens & shared infra** (`globals.css`)
- New liquid-glass tokens (`--lg-tint`, `--lg-edge`, `--lg-sheen`, `--lg-blur`, …). Deliberately namespaced `--lg-*` so they can't collide with the component-scoped `--glass-*` tokens in the Resume/Documentary players.
- Reusable glass **Navigation Tabs** classes (`.glass-tab-list` / `.glass-tab` / `.glass-tab-panel`) that respond to both `.active` and `aria-selected="true"`.
- Added the two noir tokens (`--noir-accent-line`, `--noir-surface`) the migrated modals expect.

**Modal shell** (`ModalFrame.module.css`)
- `.frame` is now a translucent dark tint with a 135° reflective sheen. The blur stays on the (opacity-only) overlay so the transform-animated frame never re-samples a backdrop — no per-frame cost.
- Both variants render Dark Glass; title bar and close button glassified; added a `@supports not (backdrop-filter)` opacity fallback.

**Modal content → dark palette** (Contact, About, Skillset, Projects, ResumeHighlights)
- Flipped each modal's alias block from the `--light-*` palette to `--noir-*`.
- Fixed hardcoded light text/border stragglers (`rgba(43,42,40,…)`) so content stays legible on dark glass; dark accents (`rgba(182,95,56,…)`) kept as warm accents.

**Dropdowns & menu bar** (`LandingPage.menu.css`)
- macOS menu bar, its About/Services/Projects dropdown containers + carets, and the item cards reskinned to dark glass with light text and warm-accent hovers. Icon chips intentionally left bright (they read as app-icon tiles).

**Navigation Tabs & Documentary** 
- The in-modal tab lists (Skillset, Projects, ResumeHighlights) are now glass pills with a warm-accent selected state.
- The Documentary player's episode/info dropdowns aligned to the shared glass tokens.

## Notes / scope
- **InteractiveResume & DocumentaryPlayer** already used dark (noir) shells, so their bespoke inner content was left intact — notably the resume's `.workxp-container` is captured by `html2canvas` into a white-background PDF, so darkening its text would have broken the resume download.
- The desktop **Welcome window** and bottom **taskbar** are separate desktop chrome (not modals/dropdowns) and were left as-is; they can be a follow-up if you want the whole desktop to go dark glass.

## Verification
- `pnpm build` passes (CSS compiles, types valid, all 6 routes generated).
- Drove the app with headless Chromium and screenshotted each surface: menu bar, all three dropdowns, and the AboutMe / Skillset / Contact / Projects modals + the Documentary episode dropdown — all render as legible Dark Glass, and the glass tabs (Skillset "Services/Toolbelt", Projects "Recent/Archived") switch with the warm-accent active state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp2zBh2BbhyDL8ZYNwjvoW)_