### PR TITLE
Apply Liquid Glass Button effect to desktop icons

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -70,6 +70,7 @@
 /* reduce motion preference */
 @media (prefers-reduced-motion: reduce) {
   .icon-image,
+  .icon-glass,
   .desktop-icon:hover .icon-image,
   .desktop-icon:focus-within .icon-image {
     transition: none;
@@ -241,6 +242,75 @@
     box-shadow 220ms ease, background 220ms ease;
   position: relative;
   overflow: visible;
+}
+
+/* Liquid Glass icon surface (ported from the "Liquid Glass Button" codepen):
+   a frosted, distorted panel behind the glyph that swells and softens on
+   hover with a springy easing curve. The distortion/base/border layers live
+   inside their own overflow-hidden wrapper so the notification badge (which
+   needs to poke outside the rounded surface) is unaffected. */
+.desktop-glass-filter {
+  position: absolute;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.icon-glass {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-radius 500ms cubic-bezier(0.175, 0.885, 0.32, 2.2);
+}
+
+.icon-glass-distortion {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  filter: url(#desktop-icon-glass-distortion);
+  isolation: isolate;
+  pointer-events: none;
+}
+
+.icon-glass-base {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.16);
+  pointer-events: none;
+}
+
+.icon-glass-border {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border-radius: inherit;
+  box-shadow: inset 1px 1px 1px rgba(255, 255, 255, 0.5),
+    inset -1px -1px 1px rgba(255, 255, 255, 0.15);
+  pointer-events: none;
+}
+
+.icon-glass-content {
+  position: relative;
+  z-index: 30;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.desktop-icon:hover .icon-glass {
+  border-radius: 18px;
 }
 
 /* Notification Badge */

--- a/src/components/layout/LandingPage/components/DesktopIcons.tsx
+++ b/src/components/layout/LandingPage/components/DesktopIcons.tsx
@@ -31,6 +31,34 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
 
   return (
     <div className="desktop">
+      {/* Shared displacement filter (ported from the "Liquid Glass Button"
+          codepen) that gives the icon surfaces their liquid refraction. */}
+      <svg className="desktop-glass-filter" aria-hidden="true">
+        <filter
+          id="desktop-icon-glass-distortion"
+          x="-20%"
+          y="-20%"
+          width="140%"
+          height="140%"
+        >
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.02 0.03"
+            numOctaves="2"
+            seed="92"
+            result="noise"
+          />
+          <feGaussianBlur in="noise" stdDeviation="2" result="blurred" />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="blurred"
+            scale="25"
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+      </svg>
+
       <div className="desktop-items">
         {desktopApps.map((app) => (
           <button
@@ -49,7 +77,14 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
             }}
           >
             <div className="icon-image">
-              <FontAwesomeIcon icon={app.icon} />
+              <div className="icon-glass">
+                <div className="icon-glass-distortion" />
+                <div className="icon-glass-base" />
+                <div className="icon-glass-border" />
+                <span className="icon-glass-content">
+                  <FontAwesomeIcon icon={app.icon} />
+                </span>
+              </div>
               {app.name === "Contact" && showContactNotification && (
                 <div className="notification-badge">!</div>
               )}


### PR DESCRIPTION
## Summary
- Port the layered distortion/base/border "Liquid Glass Button" technique (and its SVG `feTurbulence`/`feDisplacementMap` filter) from the `codepenz` repo's `glass-button` pen into `DesktopIcons`
- Each desktop icon now has a frosted glass surface behind the glyph that refracts the wallpaper and swells/softens (border-radius grows) with a springy easing on hover
- The notification badge continues to sit outside the new overflow-hidden glass layer so it isn't clipped

## Test plan
- [x] `pnpm lint` — no warnings or errors
- [x] `npx tsc --noEmit` — no type errors
- [x] Ran `pnpm dev` and screenshotted the desktop icons in normal and hover state via Playwright to confirm the frosted glass panel renders and grows/softens correctly on hover


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lr3fT2wWXHmLMit7VMpJ78)_