### PR TITLE
Hide top MenuBar on mobile/tablet

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.menu.css
+++ b/src/components/layout/LandingPage/LandingPage.menu.css
@@ -1809,3 +1809,17 @@
     max-width: 100%;
   }
 }
+
+/* ==========================================================================
+   Phone & tablet — drop the MenuBar entirely.
+   Its content (About/Services/Projects) is already reachable from the
+   desktop icons and the welcome window's quick links, and a mac-style top
+   menu bar doesn't translate well to a touch layout. Kept as the last rule
+   in this file so it wins the cascade over the unconditional `.menu-bar`
+   rule above (same selector specificity, so source order decides).
+   ========================================================================== */
+@media (max-width: 768px) {
+  .menu-bar {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Hides the mac-style top `MenuBar` on phones and tablets (`max-width: 768px`), as a first step in a broader mobile-responsive UI pass.
- On mobile the bar's About/Services/Projects items were redundant with the desktop icons and the welcome window's quick links, and the bar visually collided with the corner clock/date display (see attached screenshot from a real device).
- The rule is placed as the last `.menu-bar` selector in `LandingPage.menu.css` so it wins the cascade over an existing unconditional `.menu-bar { display: flex; }` rule further down the file (same specificity, so source order decides).

## Test plan
- [x] Ran the dev server and used Playwright at 390px (phone), 768px (tablet), and 1440px (desktop) viewports to confirm the MenuBar is hidden at phone/tablet widths and unaffected on desktop.
- [x] Confirmed the rest of the layout (welcome window, desktop icon dock, taskbar) reflows correctly with the bar removed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6fDipMHZSqNfyESwkdkr6)_