### PR TITLE
Add delayed Flying Birds ambient background

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -85,6 +85,18 @@
   align-items: center;
   padding: 0;
   margin: 0;
+  position: relative;
+}
+
+/* Painted before .mac-screen (see FlyingBirds.tsx), so it sits over the
+   wallpaper and behind the framed screen with no z-index needed. */
+.flying-birds-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
 }
 
 .mac-screen {

--- a/src/components/layout/LandingPage/LandingPage.tsx
+++ b/src/components/layout/LandingPage/LandingPage.tsx
@@ -10,6 +10,7 @@ import {
   Taskbar,
   Modals,
   TimeDisplay,
+  FlyingBirds,
 } from "./components";
 import {
   useModalState,
@@ -32,6 +33,8 @@ const LandingPage = () => {
 
   return (
     <div className="macintosh-container">
+      <FlyingBirds />
+
       <div className="mac-screen">
         <MenuBar
           openDropdown={dropdownState.openDropdown}

--- a/src/components/layout/LandingPage/components/FlyingBirds.tsx
+++ b/src/components/layout/LandingPage/components/FlyingBirds.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+// Ported from the "Flying Birds" codepen in the codepenz repo. Rendered as
+// the first child of .macintosh-container (see LandingPage.tsx) so it paints
+// over the wallpaper but behind .mac-screen with no z-index needed — birds
+// are visible in the wallpaper margin and hidden wherever the desktop's own
+// opaque surfaces (e.g. the rain canvas) sit in front of them.
+interface Bird {
+  x: number;
+  y: number;
+  size: number;
+  speed: number;
+  flap: number;
+  flapSpeed: number;
+  driftSeed: number;
+  turnSeed: number;
+  opacity: number;
+}
+
+const BIRD_COUNT = 28;
+const START_DELAY_MS = 6000;
+
+function createBirds(width: number): Bird[] {
+  return Array.from({ length: BIRD_COUNT }, () => ({
+    x: Math.random() * width,
+    y: 80 + Math.random() * 220,
+    size: 1.2 + Math.random() * 3.2,
+    // Source pen had this at 15 + Math.random() * .45 — birds would rocket
+    // across at ~40x the speed they get reset to on wraparound below.
+    // Matching the wraparound speed here instead so the very first pass
+    // looks the same as every pass after it.
+    speed: 0.15 + Math.random() * 0.45,
+    flap: Math.random() * Math.PI * 2,
+    flapSpeed: 0.08 + Math.random() * 0.15,
+    driftSeed: Math.random() * 5000,
+    turnSeed: Math.random() * 5000,
+    opacity: 0.25 + Math.random() * 0.6,
+  }));
+}
+
+export default function FlyingBirds() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvasEl = canvasRef.current;
+    const parentEl = canvasEl?.parentElement;
+    if (!canvasEl || !parentEl) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const context = canvasEl.getContext("2d");
+    if (!context) return;
+
+    const canvas = canvasEl;
+    const container = parentEl;
+    const ctx = context;
+
+    let width = container.clientWidth;
+    let height = container.clientHeight;
+    const birds = createBirds(width);
+
+    function resize() {
+      width = container.clientWidth;
+      height = container.clientHeight;
+      canvas.width = width * devicePixelRatio;
+      canvas.height = height * devicePixelRatio;
+      ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+    }
+    resize();
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(container);
+
+    function drawBird(bird: Bird, time: number) {
+      const wing = Math.sin(bird.flap) * bird.size * 0.9;
+      ctx.save();
+      ctx.translate(bird.x, bird.y);
+      const heading = Math.sin(time * 0.00012 + bird.turnSeed) * 0.25;
+      ctx.rotate(heading);
+      ctx.strokeStyle = `rgba(25,25,25,${bird.opacity})`;
+      ctx.lineWidth = 1.2;
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      ctx.moveTo(-bird.size, wing);
+      ctx.lineTo(0, 0);
+      ctx.lineTo(bird.size, wing);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    let frameId: number;
+    function animate(time: number) {
+      ctx.clearRect(0, 0, width, height);
+      birds.forEach((bird) => {
+        bird.flap += bird.flapSpeed;
+        bird.x += bird.speed;
+        bird.y += Math.sin(time * 0.0006 + bird.driftSeed) * 0.18;
+        if (bird.x > width + 20) {
+          bird.x = -20;
+          bird.y = 80 + Math.random() * 250;
+          bird.speed = 0.15 + Math.random() * 0.45;
+        }
+        drawBird(bird, time);
+      });
+      frameId = requestAnimationFrame(animate);
+    }
+
+    const startTimeout = window.setTimeout(() => {
+      frameId = requestAnimationFrame(animate);
+    }, START_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(startTimeout);
+      cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="flying-birds-canvas"
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/layout/LandingPage/components/index.ts
+++ b/src/components/layout/LandingPage/components/index.ts
@@ -1,6 +1,7 @@
 export { default as MenuBar } from './MenuBar';
 export { default as DesktopIcons } from './DesktopIcons';
 export { default as DesktopRain } from './DesktopRain';
+export { default as FlyingBirds } from './FlyingBirds';
 export { default as WelcomeWindow } from './WelcomeWindow';
 export { default as Taskbar } from './Taskbar';
 export { default as Modals } from './Modals';


### PR DESCRIPTION
## Summary
- Port the "Flying Birds" codepen (plain canvas 2D, no new dependency) from the `codepenz` repo into a new `FlyingBirds` component.
- Render it as the first child of `.macintosh-container`, so it paints over the wallpaper and behind `.mac-screen` purely by DOM order — no z-index needed. Birds are visible in the wallpaper margin around the framed screen and hidden wherever the desktop's own opaque surfaces (e.g. the rain canvas added previously) sit in front of them.
- The animation's start is delayed **6 seconds** after mount, per request.
- Corrected the source pen's initial bird speed (`15 + rand*.45`, ~40x the speed birds get reset to on wraparound) to match the wraparound reset speed (`.15 + rand*.45`), so the first pass reads the same as every pass after it, instead of rocketing across the screen.
- Skips starting the animation entirely under `prefers-reduced-motion`, consistent with the existing `DesktopRain` effect.

Note: this branch's previous PR (#24, the rain-on-glass effect) was already merged into `main`, and `main` has since moved forward with an unrelated desktop-icons redesign (#27). This PR's branch was restarted from the latest `main` and only carries this new Flying Birds change.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npx next lint` — no warnings/errors
- [x] `npx next build` — production build succeeds
- [x] Verified in a real browser (Playwright + Chromium): birds are absent for the first ~6s, then animate; visible only in the wallpaper margin as expected
- [x] Verified `prefers-reduced-motion: reduce` skips starting the animation
- [x] Verified against the current curved-picker desktop redesign — no regressions, icon interactions still work


---
_Generated by [Claude Code](https://claude.ai/code/session_01FeKT3pKBiwjrjoAC9HU7xJ)_