### PR TITLE
Reorder active projects, add The Reckoning and STLMNT, fix Pinpoint icon crop

### DIFF
--- a/src/components/features/portfolio/ProjectsModal/ProjectsModal.tsx
+++ b/src/components/features/portfolio/ProjectsModal/ProjectsModal.tsx
@@ -10,6 +10,8 @@ import {
   faMusic,
   faCookieBite,
   faFilm,
+  faScroll,
+  faGavel,
   faExternalLinkAlt,
   faChevronLeft,
   faChevronRight,
@@ -28,6 +30,8 @@ const iconMap: Record<string, typeof faBriefcase> = {
   "fas fa-music icon": faMusic,
   "fas fa-cookie-bite icon": faCookieBite,
   "fas fa-film icon": faFilm,
+  "fas fa-scroll icon": faScroll,
+  "fas fa-gavel icon": faGavel,
 };
 
 const isImageIcon = (icon?: string) => {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -62,9 +62,14 @@ const projectData: Project[] = [
     name: "STLMNT",
     yearRange: "2025-2026",
     description:
-      "Settlement and dispute-resolution platform in active development.",
+      "Free React Native app that surfaces verified, open US class action settlements, checks user eligibility, and helps fill the official claim form, never auto-submitting on a user's behalf.",
     link: "https://github.com/demaceo/stlmnt",
-    stackPreview: ["React Native", "TypeScript"],
+    stackPreview: ["React Native", "Expo", "Firebase", "TypeScript"],
+    highlights: [
+      "Ingestion workers scrape FTC, JND, Atticus, Simpluris, and Kroll feeds into a curation queue.",
+      "Default-deny Firestore rules with an admin-gated AI drafting pipeline for settlement curation.",
+      "Field-level encryption via Cloud KMS envelope encryption for sensitive profile data.",
+    ],
     icon: "fas fa-gavel icon",
   },
   {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -2,6 +2,44 @@ import { Project } from "@/lib/types";
 
 const projectData: Project[] = [
   {
+    id: 4,
+    slug: "yap-united",
+    name: "Yap United",
+    yearRange: "2025-2026",
+    description:
+      "Real-time translation app combining Gemini Live speech translation, multilingual TTS, and location-based social conversation zones.",
+    link: "https://github.com/demaceo",
+    deepDiveKey: "yap-united",
+    stackPreview: [
+      "React Native",
+      "Gemini Live API",
+      "ElevenLabs",
+      "Firebase",
+    ],
+    highlights: [
+      "Hands-free live mode with reconnect and backoff resilience.",
+      "Bidirectional STT translation and multilingual TTS for 15 languages.",
+      "Geo-zoned chat with moderation controls and per-user voice profiles.",
+    ],
+    icon: "/icons/projects/yap.png",
+  },
+  {
+    id: 16,
+    slug: "the-reckoning",
+    name: "The Reckoning",
+    yearRange: "2025-2026",
+    description:
+      "An eleven-part roundtable debate site pitting fourteen recurring personas against each other on the promise and peril of AI, with every claim traceable to a source and a build-time pipeline that can turn any part into a voiced podcast episode.",
+    link: "https://github.com/demaceo/DeusEx",
+    stackPreview: ["React", "TypeScript", "Vite", "Recharts"],
+    highlights: [
+      "Content-as-data architecture: typed schemas, data files, and one shared component kit render every part.",
+      "Referential integrity checks catch any dangling claim or source reference at dev time.",
+      "Claude-scripted, ElevenLabs-voiced podcast generation pipeline for any roundtable part.",
+    ],
+    icon: "fas fa-scroll icon",
+  },
+  {
     id: 0,
     slug: "pinpoint",
     name: "Pinpoint",
@@ -17,7 +55,17 @@ const projectData: Project[] = [
       "Gemini SSE chat and ElevenLabs voice responses for AI official simulations.",
     ],
     icon: "/icons/projects/pinpoint.png",
-    image: "/icons/projects/pinpoint.png",
+  },
+  {
+    id: 17,
+    slug: "stlmnt",
+    name: "STLMNT",
+    yearRange: "2025-2026",
+    description:
+      "Settlement and dispute-resolution platform in active development.",
+    link: "https://github.com/demaceo/stlmnt",
+    stackPreview: ["React Native", "TypeScript"],
+    icon: "fas fa-gavel icon",
   },
   {
     id: 1,
@@ -69,28 +117,6 @@ const projectData: Project[] = [
       "Animated AI rearrangement previews with score comparisons before apply.",
     ],
     icon: "/icons/projects/fengshui.png",
-  },
-  {
-    id: 4,
-    slug: "yap-united",
-    name: "Yap United",
-    yearRange: "2025-2026",
-    description:
-      "Real-time translation app combining Gemini Live speech translation, multilingual TTS, and location-based social conversation zones.",
-    link: "https://github.com/demaceo",
-    deepDiveKey: "yap-united",
-    stackPreview: [
-      "React Native",
-      "Gemini Live API",
-      "ElevenLabs",
-      "Firebase",
-    ],
-    highlights: [
-      "Hands-free live mode with reconnect and backoff resilience.",
-      "Bidirectional STT translation and multilingual TTS for 15 languages.",
-      "Geo-zoned chat with moderation controls and per-user voice profiles.",
-    ],
-    icon: "/icons/projects/yap.png",
   },
   {
     id: 8,


### PR DESCRIPTION
## Summary

- Fixed the Pinpoint project icon overflowing/getting cropped: it was setting both `icon` and `image` to the same file, which routed it through the `object-fit: cover` hero-image path instead of the `object-fit: contain` icon path. Removed the duplicate `image` field so it renders via the correct contain-fit path.
- Added "The Reckoning" (the DeusEx repo) as a new active project.
- Added a placeholder "STLMNT" project entry (settlement/dispute-resolution platform, in active development — details to be filled in later).
- Reordered active projects to: Yap United, The Reckoning, Pinpoint, STLMNT, then the remaining projects (Payback, RentHarbor, Feng Shui).

## Test plan

- [x] `npx tsc -b` passes with no errors
- [x] `pnpm lint` passes with no warnings/errors
- [x] Ran the dev server and manually verified in a browser: Pinpoint's icon now renders fully contained (no crop), the new "The Reckoning" and "STLMNT" cards render correctly with FontAwesome icons, and the active projects list appears in the requested order (Yap United → The Reckoning → Pinpoint → STLMNT → Payback → RentHarbor → Feng Shui).


---
_Generated by [Claude Code](https://claude.ai/code/session_01S5sEeZybPDPY2SSfxHh3kD)_