### PR TITLE
Skillset de-modal + force-directed Toolbelt graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@use-gesture/react": "^10.3.1",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
+        "d3": "^7.9.0",
         "framer-motion": "^12.23.6",
         "gsap": "^3.13.0",
         "html2canvas": "^1.4.1",
@@ -27,6 +28,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/d3": "^7.4.3",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1437,10 +1439,301 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2635,6 +2928,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2684,6 +2986,407 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2805,6 +3508,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/detect-libc": {
@@ -3981,6 +4693,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4031,6 +4755,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/iobuffer": {
@@ -5629,6 +6362,12 @@
         "node": ">= 0.8.15"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5652,6 +6391,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -5707,6 +6452,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@use-gesture/react": "^10.3.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "d3": "^7.9.0",
     "framer-motion": "^12.23.6",
     "gsap": "^3.13.0",
     "html2canvas": "^1.4.1",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/d3": "^7.4.3",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.3.1(next@15.4.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
       framer-motion:
         specifier: ^12.23.6
         version: 12.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -60,6 +63,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
+      '@types/d3':
+        specifier: ^7.4.3
+        version: 7.4.3
       '@types/node':
         specifier: ^20
         version: 20.19.37
@@ -536,8 +542,104 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -918,6 +1020,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -933,6 +1039,133 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -976,6 +1209,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1309,6 +1545,10 @@ packages:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
     engines: {node: '>=8.0.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1328,6 +1568,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iobuffer@5.4.0:
     resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
@@ -1807,8 +2051,14 @@ packages:
     resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
     engines: {node: '>= 0.8.15'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -1821,6 +2071,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -2397,7 +2650,126 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -2755,6 +3127,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@7.2.0: {}
+
   concat-map@0.0.1: {}
 
   core-js@3.49.0:
@@ -2771,6 +3145,158 @@ snapshots:
       utrie: 1.0.2
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
 
   damerau-levenshtein@1.0.8: {}
 
@@ -2813,6 +3339,10 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   detect-libc@2.1.2: {}
 
@@ -3294,6 +3824,10 @@ snapshots:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3310,6 +3844,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   iobuffer@5.4.0: {}
 
@@ -3790,9 +4326,13 @@ snapshots:
   rgbcolor@1.0.1:
     optional: true
 
+  robust-predicates@3.0.3: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -3812,6 +4352,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.26.0: {}
 

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.css
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.css
@@ -1,4 +1,4 @@
-/* ===== SKILLSET — WARM NOIR: PLATES + PROFICIENCY WALL ===== */
+/* ===== SKILLSET — WARM NOIR: PLATES + TOOLBELT GRAPH ===== */
 
 .skillset {
   --skill-accent: var(--noir-accent);
@@ -68,8 +68,6 @@
 .skill-tab:focus-visible,
 .plate-arrow:focus-visible,
 .plate-dot:focus-visible,
-.wall-chip:focus-visible,
-.wall-search input:focus-visible,
 .skill-studio-byline:focus-visible {
   outline: 2px solid rgba(182, 95, 56, 0.55);
   outline-offset: 2px;
@@ -285,222 +283,13 @@
   background: rgba(43, 42, 40, 0.38);
 }
 
-/* ── Toolbelt: proficiency wall ───────────────────────── */
+/* ── Toolbelt: force-directed graph ───────────────────── */
 
 .skill-tools {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
-}
-
-.wall-toolbar {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--skill-border);
-  background: var(--skill-panel);
-  flex-shrink: 0;
-}
-
-.wall-search {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  border: 1px solid rgba(240, 236, 232, 0.14);
-  border-radius: 0.66rem;
-  background: var(--skill-panel);
-  padding: 0.5rem 0.7rem;
-  transition: border-color 0.2s ease, background 0.2s ease;
-}
-
-.wall-search:focus-within {
-  border-color: rgba(182, 95, 56, 0.42);
-  background: rgba(182, 95, 56, 0.05);
-}
-
-.wall-search-icon {
-  color: var(--skill-faint);
-  font-size: 0.8rem;
-  flex-shrink: 0;
-}
-
-.wall-search input {
-  flex: 1;
-  min-width: 0;
-  border: 0;
-  background: transparent;
-  color: var(--skill-text);
-  font-family: inherit;
-  font-size: 0.84rem;
-  outline: none;
-}
-
-.wall-search input::placeholder {
-  color: rgba(240, 236, 232, 0.28);
-}
-
-.wall-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.36rem;
-}
-
-.wall-chip {
-  border: 1px solid rgba(240, 236, 232, 0.13);
-  border-radius: 999px;
-  background: var(--skill-panel);
-  color: rgba(240, 236, 232, 0.45);
-  font-size: 0.7rem;
-  font-weight: 700;
-  padding: 0.3rem 0.62rem;
-  cursor: pointer;
-  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
-}
-
-.wall-chip:hover:not(.active) {
-  border-color: rgba(182, 95, 56, 0.32);
-  color: rgba(240, 236, 232, 0.75);
-}
-
-.wall-chip.active {
-  border-color: rgba(182, 95, 56, 0.55);
-  color: #fff;
-  background: var(--skill-accent);
-  box-shadow: 0 2px 8px var(--skill-accent-glow);
-}
-
-.wall-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-}
-
-.wall-group-head {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  margin-bottom: 0.6rem;
-}
-
-.wall-group-head h3 {
-  margin: 0;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--skill-muted);
-}
-
-.wall-group-head::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: rgba(43, 42, 40, 0.1);
-}
-
-.wall-group-count {
-  min-width: 1.3rem;
-  height: 1.3rem;
-  padding: 0 0.35rem;
-  border-radius: 999px;
-  border: 1px solid rgba(240, 236, 232, 0.14);
-  display: grid;
-  place-items: center;
-  font-size: 0.66rem;
-  font-weight: 700;
-  color: var(--skill-faint);
-  background: var(--skill-panel);
-}
-
-.wall-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(116px, 1fr));
-  gap: 0.5rem;
-}
-
-.wall-tile {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  padding: 0.85rem 0.6rem;
-  border-radius: 0.7rem;
-  border: 1px solid var(--skill-border);
-  background: var(--skill-panel);
-  text-align: center;
-  cursor: default;
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.wall-tile:hover {
-  transform: translateY(-2px);
-  border-color: rgba(182, 95, 56, 0.3);
-  background: rgba(182, 95, 56, 0.06);
-  box-shadow: 0 6px 18px rgba(22, 20, 18, 0.12);
-}
-
-.wall-tile-icon {
-  font-size: 1.35rem;
-  color: rgba(182, 95, 56, 0.62);
-  transition: color 0.2s ease;
-}
-
-.wall-tile:hover .wall-tile-icon {
-  color: var(--skill-accent);
-}
-
-.wall-tile-label {
-  font-size: 0.74rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: rgba(240, 236, 232, 0.62);
-  line-height: 1.2;
-}
-
-.wall-tile.signature {
-  border-color: rgba(182, 95, 56, 0.28);
-  background: rgba(182, 95, 56, 0.07);
-}
-
-.wall-tile.signature .wall-tile-icon {
-  color: var(--skill-accent);
-}
-
-.wall-tile.signature .wall-tile-label {
-  color: var(--skill-text);
-}
-
-/* ── Empty state ──────────────────────────────────────── */
-
-.wall-empty {
-  border: 1px dashed rgba(240, 236, 232, 0.18);
-  border-radius: 0.88rem;
-  background: var(--skill-panel);
-  padding: 1.6rem;
-  text-align: center;
-}
-
-.wall-empty h3 {
-  margin: 0;
-  font-size: 0.92rem;
-  color: var(--skill-text);
-}
-
-.wall-empty p {
-  margin: 0.4rem 0 0;
-  color: var(--skill-muted);
-  font-size: 0.82rem;
-  line-height: 1.46;
 }
 
 /* ── Responsive ───────────────────────────────────────── */
@@ -530,24 +319,12 @@
   .plate-description {
     font-size: 0.84rem;
   }
-
-  .wall-grid {
-    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
-  }
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .wall-search input {
-    font-size: 16px; /* prevent iOS zoom-on-focus */
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .service-plate,
   .plate-dot,
-  .plate-arrow,
-  .wall-tile,
-  .wall-tile-icon {
+  .plate-arrow {
     transition: none;
   }
 }

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
@@ -1,17 +1,14 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { motion, AnimatePresence, type Variants } from "framer-motion";
-import {
-  faChevronLeft,
-  faChevronRight,
-  faMagnifyingGlass,
-} from "@fortawesome/free-solid-svg-icons";
+import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
 import services from "@/data/services";
 import tools from "@/data/toolbelt";
 import { ModalProps } from "@/lib/types";
-import { ModalFrame } from "@/components/features/modal";
-import "./SkillsetModal.css";
+import { AppView } from "@/components/features/shell";
+import ToolbeltGraph from "./ToolbeltGraph";
+import "./SkillsetAppView.css";
 
 type SkillsetTab = "services" | "tools";
 
@@ -37,8 +34,8 @@ const serviceOutcomes: Record<string, string> = {
   sb7: "Less manual overhead through targeted automation and scripting.",
 };
 
-// Tools shown larger as the "signature stack" rail.
-const signatureStack = ["React", "TypeScript", "Next.js", "Node.js", "AWS"];
+// Tools highlighted with the signature stroke/glow in the toolbelt graph.
+const signatureStack = ["React", "JavaScript", "Next.js", "Node.js", "AWS"];
 
 const plateVariants: Variants = {
   enter: (dir: number) => ({ opacity: 0, x: dir > 0 ? 40 : -40 }),
@@ -54,16 +51,12 @@ const plateVariants: Variants = {
   }),
 };
 
-const SkillsetModal: React.FC<ModalProps> = ({ onClose }) => {
+const SkillsetAppView: React.FC<ModalProps> = ({ onClose }) => {
   const [activeTab, setActiveTab] = useState<SkillsetTab>("services");
 
   // Services carousel state
   const [serviceIndex, setServiceIndex] = useState(0);
   const [direction, setDirection] = useState<1 | -1>(1);
-
-  // Toolbelt state
-  const [toolQuery, setToolQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState("All");
 
   const service = services[serviceIndex];
 
@@ -79,65 +72,8 @@ const SkillsetModal: React.FC<ModalProps> = ({ onClose }) => {
     setServiceIndex(index);
   };
 
-  const categories = useMemo(() => {
-    const discovered = Array.from(new Set(tools.map((tool) => tool.category)));
-
-    const prioritized = orderedCategories.filter((category) =>
-      discovered.includes(category)
-    );
-
-    const remaining = discovered
-      .filter((category) => !prioritized.includes(category))
-      .sort((a, b) => a.localeCompare(b));
-
-    return [...prioritized, ...remaining];
-  }, []);
-
-  const filteredTools = useMemo(() => {
-    const normalizedQuery = toolQuery.trim().toLowerCase();
-
-    return tools.filter((tool) => {
-      const categoryMatches =
-        selectedCategory === "All" || tool.category === selectedCategory;
-
-      const queryMatches =
-        normalizedQuery.length === 0 ||
-        tool.tooltip.toLowerCase().includes(normalizedQuery) ||
-        tool.category.toLowerCase().includes(normalizedQuery);
-
-      return categoryMatches && queryMatches;
-    });
-  }, [selectedCategory, toolQuery]);
-
-  const toolsByCategory = useMemo(() => {
-    return filteredTools.reduce((acc, tool) => {
-      if (!acc[tool.category]) acc[tool.category] = [];
-      acc[tool.category].push(tool);
-      return acc;
-    }, {} as Record<string, typeof tools>);
-  }, [filteredTools]);
-
-  const visibleCategories = useMemo(() => {
-    return Object.keys(toolsByCategory).sort((a, b) => {
-      const aIndex = categories.indexOf(a);
-      const bIndex = categories.indexOf(b);
-
-      if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
-      if (aIndex === -1) return 1;
-      if (bIndex === -1) return -1;
-      return aIndex - bIndex;
-    });
-  }, [categories, toolsByCategory]);
-
   return (
-    <ModalFrame
-      onClose={onClose}
-      title="Skillset"
-      size="lg"
-      variant="light"
-      titleId="skillset-title"
-      closeAriaLabel="Close skillset modal"
-    >
+    <AppView onClose={onClose} title="Skillset" titleId="skillset-title">
       <div className="skillset">
         {/* ── Tabs ─────────────────────────────────────── */}
         <div className="skill-topbar">
@@ -285,7 +221,7 @@ const SkillsetModal: React.FC<ModalProps> = ({ onClose }) => {
             </motion.section>
           )}
 
-          {/* ── Toolbelt: proficiency wall ─────────────── */}
+          {/* ── Toolbelt: collapsible force-directed graph ─ */}
           {activeTab === "tools" && (
             <motion.section
               key="tools"
@@ -298,103 +234,17 @@ const SkillsetModal: React.FC<ModalProps> = ({ onClose }) => {
               id="tools-panel"
               aria-labelledby="tools-tab"
             >
-              <div className="wall-toolbar">
-                <label className="wall-search" htmlFor="tools-query">
-                  <FontAwesomeIcon
-                    icon={faMagnifyingGlass}
-                    className="wall-search-icon"
-                    aria-hidden="true"
-                  />
-                  <input
-                    id="tools-query"
-                    type="search"
-                    value={toolQuery}
-                    onChange={(event) => setToolQuery(event.target.value)}
-                    placeholder="Search tools or categories"
-                    aria-label="Search tools or categories"
-                  />
-                </label>
-
-                <div className="wall-chips" role="group" aria-label="Tool categories">
-                  <button
-                    type="button"
-                    className={`wall-chip ${selectedCategory === "All" ? "active" : ""}`}
-                    onClick={() => setSelectedCategory("All")}
-                  >
-                    All
-                  </button>
-                  {categories.map((category) => (
-                    <button
-                      key={category}
-                      type="button"
-                      className={`wall-chip ${selectedCategory === category ? "active" : ""}`}
-                      onClick={() => setSelectedCategory(category)}
-                    >
-                      {category}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="wall-scroll">
-                {visibleCategories.length === 0 ? (
-                  <div className="wall-empty">
-                    <h3>No matching tools</h3>
-                    <p>Try a different search term or switch category filters.</p>
-                  </div>
-                ) : (
-                  visibleCategories.map((category) => (
-                    <section key={category} className="wall-group">
-                      <header className="wall-group-head">
-                        <h3>{category}</h3>
-                        <span className="wall-group-count">
-                          {toolsByCategory[category].length}
-                        </span>
-                      </header>
-
-                      <motion.div
-                        className="wall-grid"
-                        role="list"
-                        aria-label={`${category} tools`}
-                        initial="hidden"
-                        animate="show"
-                        variants={{
-                          hidden: {},
-                          show: { transition: { staggerChildren: 0.025 } },
-                        }}
-                      >
-                        {toolsByCategory[category].map((tool, index) => {
-                          const isSignature = signatureStack.includes(tool.tooltip);
-                          return (
-                            <motion.div
-                              key={`${category}-${tool.tooltip}-${index}`}
-                              className={`wall-tile ${isSignature ? "signature" : ""}`}
-                              role="listitem"
-                              title={tool.tooltip}
-                              variants={{
-                                hidden: { opacity: 0, y: 10 },
-                                show: { opacity: 1, y: 0 },
-                              }}
-                            >
-                              <FontAwesomeIcon
-                                className="wall-tile-icon"
-                                icon={tool.icon}
-                              />
-                              <span className="wall-tile-label">{tool.tooltip}</span>
-                            </motion.div>
-                          );
-                        })}
-                      </motion.div>
-                    </section>
-                  ))
-                )}
-              </div>
+              <ToolbeltGraph
+                tools={tools}
+                orderedCategories={orderedCategories}
+                signatureStack={signatureStack}
+              />
             </motion.section>
           )}
         </AnimatePresence>
       </div>
-    </ModalFrame>
+    </AppView>
   );
 };
 
-export default SkillsetModal;
+export default SkillsetAppView;

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
@@ -1,0 +1,148 @@
+.stage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+  padding: 16px 20px 20px;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: min(360px, 100%);
+  padding: 8px 14px;
+  border: 1px solid var(--noir-border);
+  border-radius: 999px;
+  background: var(--noir-panel);
+  transition: border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.search:focus-within {
+  border-color: var(--noir-accent-line);
+  background: var(--noir-panel-strong);
+}
+
+.searchIcon {
+  font-size: 12px;
+  color: var(--noir-muted);
+  flex-shrink: 0;
+}
+
+.search input {
+  flex: 1;
+  border: none;
+  background: none;
+  outline: none;
+  font-family: var(--font-body, inherit);
+  font-size: 13px;
+  color: var(--noir-text);
+}
+
+.search input::placeholder {
+  color: var(--noir-faint);
+}
+
+.hint {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--noir-faint);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--noir-muted);
+  white-space: nowrap;
+}
+
+.legendSwatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.svg {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+.link {
+  stroke: var(--noir-border);
+  stroke-width: 1.5px;
+  fill: none;
+}
+
+.node text {
+  font-family: var(--font-body, inherit);
+  font-size: 10px;
+  fill: var(--noir-muted);
+  pointer-events: none;
+  user-select: none;
+}
+
+.node circle {
+  stroke: var(--noir-border);
+  stroke-width: 1px;
+  transition: stroke 0.18s ease, stroke-width 0.18s ease;
+}
+
+.node:hover circle {
+  stroke: var(--noir-accent-line);
+}
+
+.node title {
+  pointer-events: none;
+}
+
+.nodeIcon {
+  pointer-events: none;
+  color: var(--noir-text);
+}
+
+.node.signature circle {
+  stroke: var(--noir-accent);
+  stroke-width: 2.5px;
+  filter: drop-shadow(0 0 5px var(--noir-accent-glow));
+}
+
+.node.signature text {
+  fill: var(--noir-text);
+  font-weight: 600;
+}
+
+.node.hasHiddenChildren circle {
+  stroke-dasharray: 3 2;
+  stroke: var(--noir-accent-line);
+}
+
+@media (max-width: 768px) {
+  .stage {
+    padding: 12px 12px 16px;
+    min-height: 360px;
+  }
+
+  .hint {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .node circle {
+    transition: none;
+  }
+}

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as d3 from "d3";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { buildToolbeltTree, type ToolbeltToolDatum, type ToolbeltTreeNode } from "@/lib/utils/toolbeltTree";
+import styles from "./ToolbeltGraph.module.css";
+
+interface ToolbeltGraphProps {
+  tools: ToolbeltToolDatum[];
+  orderedCategories: string[];
+  signatureStack: string[];
+}
+
+interface SimNode extends d3.SimulationNodeDatum {
+  id: string;
+  name: string;
+  depth: number;
+  rootIndex: number;
+  hasChildren: boolean;
+  isSignature?: boolean;
+  icon?: IconDefinition;
+  fx?: number | null;
+  fy?: number | null;
+}
+
+interface SimLink {
+  source: string | SimNode;
+  target: string | SimNode;
+}
+
+// Only 2 depth levels exist here (category root -> tool leaf), unlike the
+// codepenz "force-directed-node-tree" pen's up-to-3-level coffee flavor wheel.
+const RADIUS_BY_DEPTH = [26, 13];
+const ROOT_HUE_START = 21; // --noir-accent's own hue (#d4845a)
+const ROOT_SATURATION = 0.48;
+const ROOT_LIGHTNESS = 0.6;
+const RESIZE_DEBOUNCE_MS = 150;
+
+function nodeId(path: string[]): string {
+  return path.join(" / ");
+}
+
+function iconPathData(icon: IconDefinition): string {
+  const d = icon.icon[4];
+  return Array.isArray(d) ? d[0] : d;
+}
+
+function truncateLabel(name: string, depth: number): string {
+  const max = depth === 0 ? 20 : 11;
+  return name.length > max ? `${name.slice(0, max)}…` : name;
+}
+
+function flatten(tree: ToolbeltTreeNode[], collapsed: Set<string>) {
+  const nodes: SimNode[] = [];
+  const links: SimLink[] = [];
+
+  function visit(item: ToolbeltTreeNode, path: string[], depth: number, rootIndex: number) {
+    const id = nodeId(path);
+    nodes.push({
+      id,
+      name: item.name,
+      depth,
+      rootIndex,
+      hasChildren: Boolean(item.children?.length),
+      isSignature: item.isSignature,
+      icon: item.icon,
+    });
+    if (path.length > 1) {
+      links.push({ source: nodeId(path.slice(0, -1)), target: id });
+    }
+    if (item.children && !collapsed.has(id)) {
+      item.children.forEach((child) => visit(child, [...path, child.name], depth + 1, rootIndex));
+    }
+  }
+
+  tree.forEach((root, i) => visit(root, [root.name], 0, i));
+  return { nodes, links };
+}
+
+// Roots pinned in two staggered rows instead of the pen's single line of 4 —
+// 9 categories crowd badly on one line. Generalizes to any N.
+function computeRootPositions(count: number, width: number, height: number) {
+  const topCount = Math.ceil(count / 2);
+  const positions: { x: number; y: number }[] = [];
+  for (let i = 0; i < count; i++) {
+    const inTopRow = i < topCount;
+    const row = inTopRow ? topCount : count - topCount;
+    const indexInRow = inTopRow ? i : i - topCount;
+    positions.push({
+      x: ((indexInRow + 1) / (row + 1)) * width,
+      y: height * (inTopRow ? 0.32 : 0.72),
+    });
+  }
+  return positions;
+}
+
+function rootColor(index: number, count: number): string {
+  const hue = (ROOT_HUE_START + index * (360 / count)) % 360;
+  return d3.hsl(hue, ROOT_SATURATION, ROOT_LIGHTNESS).formatHex();
+}
+
+/**
+ * Collapsible force-directed graph replacing the Toolbelt tab's old
+ * search+filter+grid, adapted from codepenz's "force-directed-node-tree"
+ * pen. Categories are root nodes (pinned, collapsed by default); tools are
+ * free-simulated leaf children revealed on click.
+ */
+const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({ tools, orderedCategories, signatureStack }) => {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const positionsRef = useRef(new Map<string, { x: number; y: number }>());
+
+  const [toolQuery, setToolQuery] = useState("");
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    () => new Set(buildToolbeltTree(tools, orderedCategories, signatureStack).map((root) => root.name))
+  );
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [resizeTick, setResizeTick] = useState(0);
+
+  useEffect(() => {
+    setPrefersReducedMotion(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+  }, []);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const observer = new ResizeObserver(() => {
+      if (timeout) clearTimeout(timeout);
+      timeout = setTimeout(() => setResizeTick((t) => t + 1), RESIZE_DEBOUNCE_MS);
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (timeout) clearTimeout(timeout);
+    };
+  }, []);
+
+  const filteredTools = useMemo(() => {
+    const q = toolQuery.trim().toLowerCase();
+    if (!q) return tools;
+    return tools.filter(
+      (t) => t.tooltip.toLowerCase().includes(q) || t.category.toLowerCase().includes(q)
+    );
+  }, [tools, toolQuery]);
+
+  const tree = useMemo(
+    () => buildToolbeltTree(filteredTools, orderedCategories, signatureStack),
+    [filteredTools, orderedCategories, signatureStack]
+  );
+
+  const isSearching = toolQuery.trim().length > 0;
+  // Categories with zero matches are already absent from `tree` (buildToolbeltTree
+  // only creates roots for categories present in its input), so expanding
+  // everything currently in the tree is exactly "expand everything that matched."
+  const effectiveCollapsed = useMemo(
+    () => (isSearching ? new Set<string>() : collapsed),
+    [isSearching, collapsed]
+  );
+
+  useEffect(() => {
+    const svgEl = svgRef.current;
+    const wrapEl = wrapRef.current;
+    if (!svgEl || !wrapEl) return;
+
+    const width = wrapEl.clientWidth;
+    const height = wrapEl.clientHeight;
+    const svg = d3.select(svgEl).attr("viewBox", `0 0 ${width} ${height}`);
+
+    const linkLayer = svg.append("g").attr("class", styles.links);
+    const nodeLayer = svg.append("g").attr("class", styles.nodesLayer);
+
+    const simulation = d3
+      .forceSimulation<SimNode>()
+      .alphaDecay(prefersReducedMotion ? 0.3 : 0.0228)
+      .force(
+        "link",
+        d3.forceLink<SimNode, SimLink>().id((d) => d.id).distance(90).strength(0.7)
+      )
+      .force("charge", d3.forceManyBody().strength(-90))
+      .force(
+        "collide",
+        d3.forceCollide<SimNode>((d) => RADIUS_BY_DEPTH[Math.min(d.depth, RADIUS_BY_DEPTH.length - 1)] + 6)
+      )
+      .force("x", d3.forceX(width / 2).strength(0.03))
+      .force("y", d3.forceY(height / 2).strength(0.03));
+
+    const rootPositions = computeRootPositions(tree.length, width, height);
+
+    const { nodes, links } = flatten(tree, effectiveCollapsed);
+
+    nodes.forEach((n) => {
+      const saved = positionsRef.current.get(n.id);
+      if (saved) {
+        n.x = saved.x;
+        n.y = saved.y;
+      }
+      if (n.depth === 0) {
+        n.fx = rootPositions[n.rootIndex]?.x ?? width / 2;
+        n.fy = rootPositions[n.rootIndex]?.y ?? height / 2;
+      }
+    });
+
+    simulation.nodes(nodes);
+    (simulation.force("link") as d3.ForceLink<SimNode, SimLink>).links(links);
+    simulation.alpha(0.7).restart();
+
+    const link = linkLayer
+      .selectAll<SVGLineElement, SimLink>("line")
+      .data(
+        links,
+        (d) =>
+          `${typeof d.source === "string" ? d.source : d.source.id}->${
+            typeof d.target === "string" ? d.target : d.target.id
+          }`
+      )
+      .join("line")
+      .attr("class", styles.link);
+
+    const node = nodeLayer
+      .selectAll<SVGGElement, SimNode>("g")
+      .data(nodes, (d) => d.id)
+      .join((enter) => {
+        const g = enter.append("g").attr("class", styles.node).style("cursor", "pointer");
+        g.append("circle");
+        g.append("svg").attr("class", styles.nodeIcon).append("path");
+        g.append("title");
+        g.append("text").attr("text-anchor", "middle");
+        return g;
+      });
+
+    node.classed(
+      styles.signature,
+      (d) => Boolean(d.isSignature)
+    );
+    node.classed(styles.hasHiddenChildren, (d) => effectiveCollapsed.has(d.id));
+
+    node
+      .select("circle")
+      .attr("r", (d) => RADIUS_BY_DEPTH[Math.min(d.depth, RADIUS_BY_DEPTH.length - 1)])
+      .attr("fill", (d) => {
+        const base = d3.hsl(rootColor(d.rootIndex, tree.length));
+        base.l = Math.min(0.85, base.l + d.depth * 0.14);
+        return base.formatHex();
+      });
+
+    const iconSvg = node.select<SVGSVGElement>("svg");
+    iconSvg
+      .attr("x", -8)
+      .attr("y", -8)
+      .attr("width", 16)
+      .attr("height", 16)
+      .attr("viewBox", (d) => (d.icon ? `0 0 ${d.icon.icon[0]} ${d.icon.icon[1]}` : "0 0 1 1"))
+      .style("display", (d) => (d.icon ? null : "none"));
+
+    iconSvg
+      .select("path")
+      .attr("d", (d) => (d.icon ? iconPathData(d.icon) : ""))
+      .attr("fill", "currentColor");
+
+    node.select("title").text((d) => d.name);
+
+    node
+      .select("text")
+      .text((d) => truncateLabel(d.name, d.depth))
+      .attr("dy", (d) => RADIUS_BY_DEPTH[Math.min(d.depth, RADIUS_BY_DEPTH.length - 1)] + 10);
+
+    node.on("click", (_event, d) => {
+      if (!d.hasChildren) return;
+      setCollapsed((prev) => {
+        const next = new Set(prev);
+        if (next.has(d.id)) next.delete(d.id);
+        else next.add(d.id);
+        return next;
+      });
+    });
+
+    node.call(
+      d3
+        .drag<SVGGElement, SimNode>()
+        .on("start", (event, d) => {
+          if (!prefersReducedMotion && !event.active) simulation.alphaTarget(0.3).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on("drag", (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on("end", (event, d) => {
+          if (!prefersReducedMotion && !event.active) simulation.alphaTarget(0);
+          if (d.depth !== 0) {
+            d.fx = null;
+            d.fy = null;
+          }
+        })
+    );
+
+    simulation.on("tick", () => {
+      link
+        .attr("x1", (d) => (d.source as SimNode).x ?? 0)
+        .attr("y1", (d) => (d.source as SimNode).y ?? 0)
+        .attr("x2", (d) => (d.target as SimNode).x ?? 0)
+        .attr("y2", (d) => (d.target as SimNode).y ?? 0);
+
+      node.attr("transform", (d) => `translate(${d.x ?? 0},${d.y ?? 0})`);
+
+      nodes.forEach((n) => {
+        if (n.x !== undefined && n.y !== undefined) {
+          positionsRef.current.set(n.id, { x: n.x, y: n.y });
+        }
+      });
+    });
+
+    return () => {
+      simulation.stop();
+      svg.selectAll("*").remove();
+    };
+  }, [tree, effectiveCollapsed, prefersReducedMotion, resizeTick]);
+
+  return (
+    <div ref={wrapRef} className={styles.stage}>
+      <label className={styles.search}>
+        <FontAwesomeIcon icon={faMagnifyingGlass} className={styles.searchIcon} aria-hidden="true" />
+        <input
+          type="search"
+          value={toolQuery}
+          onChange={(event) => setToolQuery(event.target.value)}
+          placeholder="Search tools or categories"
+          aria-label="Search tools or categories"
+        />
+      </label>
+
+      <p className={styles.hint}>Click a category to expand or collapse it. Drag any node to reposition it.</p>
+
+      <div className={styles.legend}>
+        {tree.map((root, i) => (
+          <span key={root.name} className={styles.legendItem}>
+            <span
+              className={styles.legendSwatch}
+              style={{ background: rootColor(i, tree.length) }}
+              aria-hidden="true"
+            />
+            {root.name}
+          </span>
+        ))}
+      </div>
+
+      <svg ref={svgRef} className={styles.svg} />
+    </div>
+  );
+};
+
+export default ToolbeltGraph;

--- a/src/components/features/skills/index.ts
+++ b/src/components/features/skills/index.ts
@@ -1,5 +1,5 @@
 // Skills feature components barrel exports
-export { default as SkillsetModal } from './SkillsetModal/SkillsetModal';
+export { default as SkillsetAppView } from './SkillsetAppView/SkillsetAppView';
 
 // Re-export types if needed
-export type * from './SkillsetModal/SkillsetModal';
+export type * from './SkillsetAppView/SkillsetAppView';

--- a/src/components/layout/LandingPage/LandingPage.tsx
+++ b/src/components/layout/LandingPage/LandingPage.tsx
@@ -37,7 +37,11 @@ const LandingPage = () => {
     <div className="macintosh-container">
       <FlyingBirds />
 
-      <div className={`mac-screen${modalState.showAboutMe ? " mac-screen--app-view-open" : ""}`}>
+      <div
+        className={`mac-screen${
+          modalState.showAboutMe || modalState.showSkillset ? " mac-screen--app-view-open" : ""
+        }`}
+      >
         <MenuBar
           openDropdown={dropdownState.openDropdown}
           setOpenDropdown={dropdownActions.setOpenDropdown}
@@ -75,6 +79,8 @@ const LandingPage = () => {
         <AppViews
           showAboutMe={modalState.showAboutMe}
           setShowAboutMe={modalActions.setShowAboutMe}
+          showSkillset={modalState.showSkillset}
+          setShowSkillset={modalActions.setShowSkillset}
           onOpenDocumentary={() => modalActions.setShowDocumentary(true)}
         />
       </div>
@@ -84,8 +90,6 @@ const LandingPage = () => {
         setShowContactForm={modalActions.setShowContactForm}
         showResume={modalState.showResume}
         setShowResume={modalActions.setShowResume}
-        showSkillset={modalState.showSkillset}
-        setShowSkillset={modalActions.setShowSkillset}
         showProjects={modalState.showProjects}
         setShowProjects={modalActions.setShowProjects}
         showDocumentary={modalState.showDocumentary}

--- a/src/components/layout/LandingPage/components/AppViews.tsx
+++ b/src/components/layout/LandingPage/components/AppViews.tsx
@@ -15,9 +15,18 @@ const AboutAppView = dynamic(
   }
 );
 
+const SkillsetAppView = dynamic(
+  () => import("@/components/features/skills/SkillsetAppView/SkillsetAppView"),
+  {
+    loading: () => <LoadingView />,
+  }
+);
+
 interface AppViewsProps {
   showAboutMe: boolean;
   setShowAboutMe: (show: boolean) => void;
+  showSkillset: boolean;
+  setShowSkillset: (show: boolean) => void;
   onOpenDocumentary: () => void;
 }
 
@@ -25,17 +34,30 @@ interface AppViewsProps {
 // counterpart to Modals.tsx. Rendered *inside* .mac-screen (not as a sibling
 // of it like Modals.tsx) so AppView takeovers stay within the monitor bezel
 // instead of covering the real browser viewport.
-const AppViews: React.FC<AppViewsProps> = ({ showAboutMe, setShowAboutMe, onOpenDocumentary }) => {
+const AppViews: React.FC<AppViewsProps> = ({
+  showAboutMe,
+  setShowAboutMe,
+  showSkillset,
+  setShowSkillset,
+  onOpenDocumentary,
+}) => {
   return (
-    <AnimatePresence>
-      {showAboutMe && (
-        <AboutAppView
-          key="about"
-          onClose={() => setShowAboutMe(false)}
-          onOpenDocumentary={onOpenDocumentary}
-        />
-      )}
-    </AnimatePresence>
+    <>
+      <AnimatePresence>
+        {showAboutMe && (
+          <AboutAppView
+            key="about"
+            onClose={() => setShowAboutMe(false)}
+            onOpenDocumentary={onOpenDocumentary}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {showSkillset && (
+          <SkillsetAppView key="skillset" onClose={() => setShowSkillset(false)} />
+        )}
+      </AnimatePresence>
+    </>
   );
 };
 

--- a/src/components/layout/LandingPage/components/Modals.tsx
+++ b/src/components/layout/LandingPage/components/Modals.tsx
@@ -22,13 +22,6 @@ const InteractiveResume = dynamic(
   }
 );
 
-const SkillsetModal = dynamic(
-  () => import("@/components/features/skills/SkillsetModal/SkillsetModal"),
-  {
-    loading: () => <LoadingModal />,
-  }
-);
-
 const ProjectsGalleryModal = dynamic(
   () =>
     import(
@@ -52,8 +45,6 @@ interface ModalsProps {
   setShowContactForm: (show: boolean) => void;
   showResume: boolean;
   setShowResume: (show: boolean) => void;
-  showSkillset: boolean;
-  setShowSkillset: (show: boolean) => void;
   showProjects: boolean;
   setShowProjects: (show: boolean) => void;
   showDocumentary: boolean;
@@ -65,8 +56,6 @@ const Modals: React.FC<ModalsProps> = ({
   setShowContactForm,
   showResume,
   setShowResume,
-  showSkillset,
-  setShowSkillset,
   showProjects,
   setShowProjects,
   showDocumentary,
@@ -82,11 +71,6 @@ const Modals: React.FC<ModalsProps> = ({
       <AnimatePresence>
         {showResume && (
           <InteractiveResume key="resume" onClose={() => setShowResume(false)} />
-        )}
-      </AnimatePresence>
-      <AnimatePresence>
-        {showSkillset && (
-          <SkillsetModal key="skillset" onClose={() => setShowSkillset(false)} />
         )}
       </AnimatePresence>
       <AnimatePresence>

--- a/src/data/toolbelt.ts
+++ b/src/data/toolbelt.ts
@@ -43,7 +43,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 const tools = [
-    // Design Tools (5 tools)
+    // Design Tools (4 tools)
     { icon: faFigma, tooltip: "Figma", category: "Design" },
     { icon: faWebflow, tooltip: "Webflow", category: "Design" },
     { icon: faWordpress, tooltip: "WordPress", category: "Design" },
@@ -74,7 +74,7 @@ const tools = [
     { icon: faDocker, tooltip: "Docker", category: "DevOps" },
     { icon: faLinux, tooltip: "Linux", category: "DevOps" },
 
-    // Cloud & Infrastructure (5 tools)
+    // Cloud & Infrastructure (4 tools)
     { icon: faAws, tooltip: "AWS", category: "Cloud" },
     { icon: faGoogle, tooltip: "Google Cloud", category: "Cloud" },
     { icon: faMicrosoft, tooltip: "Azure", category: "Cloud" },

--- a/src/lib/utils/preload.ts
+++ b/src/lib/utils/preload.ts
@@ -15,7 +15,7 @@ const idle: RequestIdleCallback = (cb) => {
 export const preloadModules = {
     contact: () => import("@/components/features/contact/ContactForm/ContactForm"),
     about: () => import("@/components/features/about/AboutAppView/AboutAppView"),
-    skillset: () => import("@/components/features/skills/SkillsetModal/SkillsetModal"),
+    skillset: () => import("@/components/features/skills/SkillsetAppView/SkillsetAppView"),
     projects: () =>
         import("@/components/features/portfolio/ProjectsGalleryModal/ProjectsGalleryModal"),
     documentary: () =>

--- a/src/lib/utils/toolbeltTree.ts
+++ b/src/lib/utils/toolbeltTree.ts
@@ -1,0 +1,47 @@
+import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+
+export interface ToolbeltToolDatum {
+  icon: IconDefinition;
+  tooltip: string;
+  category: string;
+}
+
+export interface ToolbeltTreeNode {
+  name: string;
+  children?: ToolbeltTreeNode[];
+  /** Leaf-only — highlights a tool as part of the signature stack. */
+  isSignature?: boolean;
+  /** Leaf-only — the tool's real icon, rendered as a native SVG path in ToolbeltGraph. */
+  icon?: IconDefinition;
+}
+
+/**
+ * Reshapes the flat { icon, tooltip, category } toolbelt data into a
+ * 2-level tree (category root -> tool leaf) for the force-directed graph.
+ * Categories are ordered by `orderedCategories` first, then any
+ * undiscovered categories alphabetically — same ordering rule the old
+ * grid used.
+ */
+export function buildToolbeltTree(
+  tools: ToolbeltToolDatum[],
+  orderedCategories: string[],
+  signatureStack: string[]
+): ToolbeltTreeNode[] {
+  const discovered = Array.from(new Set(tools.map((t) => t.category)));
+  const prioritized = orderedCategories.filter((c) => discovered.includes(c));
+  const remaining = discovered
+    .filter((c) => !prioritized.includes(c))
+    .sort((a, b) => a.localeCompare(b));
+  const categories = [...prioritized, ...remaining];
+
+  return categories.map((category) => ({
+    name: category,
+    children: tools
+      .filter((t) => t.category === category)
+      .map((t) => ({
+        name: t.tooltip,
+        isSignature: signatureStack.includes(t.tooltip),
+        icon: t.icon,
+      })),
+  }));
+}


### PR DESCRIPTION
## Summary

Second de-modal pass, following About Me's conversion (#33). Skillset now opens as a full-screen `AppView` takeover instead of a floating `ModalFrame` card, and the Toolbelt tab's search+filter+grid is replaced with a collapsible force-directed node graph adapted from the codepenz `force-directed-node-tree` pen.

- **Skillset → `SkillsetAppView`**: moved/renamed from `SkillsetModal`, swapped `ModalFrame` for the shared `AppView` shell (same pattern as `AboutAppView`). Services tab (capability plate carousel) is unchanged.
- **Toolbelt graph** (`ToolbeltGraph.tsx` + `toolbeltTree.ts`): category roots (pinned) → tool leaves (free-simulated), built with `d3-force`. All 9 categories start collapsed for a legible overview; clicking a category expands/collapses it, dragging repositions any node. Leaf nodes render their real FontAwesome icon as a native nested SVG `<path>` (no `foreignObject`).
- **Search**: a lightweight filter above the graph — typing hides non-matching categories and auto-expands the rest; no pan/zoom/camera state. Clearing it restores prior manual expand/collapse state.
- Root colors are an HSL rotation anchored to `--noir-accent`; signature-stack tools (React, JavaScript, Next.js, Node.js, AWS) get a highlighted stroke/glow.
- Respects `prefers-reduced-motion` (faster alpha decay, no re-heat on drag) and re-centers the layout on container resize.
- Fixed a stale `"TypeScript"` entry in the signature stack (no such tool exists in the data) to `"JavaScript"`, and two stale tool-count comments in `src/data/toolbelt.ts`.
- New dependency: `d3` (+ `@types/d3`).

Projects remains deferred to its own pass; Contact modal is intentionally untouched.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Manual verification via Playwright against `npm run dev`:
  - [x] Skillset opens full-screen via desktop icon, same chrome as About
  - [x] Services tab carousel unaffected
  - [x] Toolbelt opens with 9 collapsed category roots in two staggered rows
  - [x] Clicking a category expands/collapses it (verified circle counts before/after)
  - [x] Dragging a leaf node repositions it without disturbing pinned category roots
  - [x] Searching "React" filters to the matching category + leaf, with signature styling visible
  - [x] Clearing search reverts to prior expand/collapse state
  - [x] `prefers-reduced-motion: reduce` — renders without errors, no reheat jiggle
  - [x] Resizing the viewport while Toolbelt is open re-centers the layout
  - [x] Escape closes Skillset via the shared overlay stack
  - [x] No console/page errors across all of the above


---
_Generated by [Claude Code](https://claude.ai/code/session_01RQXP7RGdphM6GegaWkBVND)_