### PR TITLE
Fix MenuBar interactions and remove dead menu styles/markup

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.menu.css
+++ b/src/components/layout/LandingPage/LandingPage.menu.css
@@ -1,1026 +1,8 @@
-/* --- Projects Dropdown --- */
-.menu-dropdown-projects {
-  margin-top: 8px;
-  width: fit-content;
-  max-width: 90vw;
-  max-height: 480px;
-  overflow-y: auto;
-  border-radius: 12px;
-  padding: 16px;
-  backdrop-filter: blur(12px);
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  list-style: none;
-}
-
-/* Enhanced scrollbar for dropdowns */
-.menu-dropdown-projects::-webkit-scrollbar {
-  width: 6px;
-  border-radius: 3px;
-}
-
-.menu-dropdown-projects::-webkit-scrollbar-thumb {
-  background: linear-gradient(135deg, #cbd5e1 0%, #94a3b8 100%);
-  border-radius: 3px;
-  transition: background 0.3s ease;
-}
-
-.menu-dropdown-projects::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(135deg, #94a3b8 0%, #64748b 100%);
-}
-
-.menu-dropdown-projects::-webkit-scrollbar-track {
-  background: rgba(248, 250, 252, 0.5);
-  border-radius: 3px;
-}
-
-.menu-dropdown-project-img {
-  width: 62px;
-  height: 62px;
-  border-radius: 10px;
-  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-  border: 2px solid rgba(255, 255, 255, 0.8);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  position: relative;
-  flex-shrink: 0;
-}
-
-.menu-dropdown-project-img-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-  padding: 6px;
-  background:
-    radial-gradient(circle at 30% 22%, rgba(255, 255, 255, 0.86), transparent 64%),
-    linear-gradient(145deg, rgba(248, 250, 252, 0.95), rgba(226, 232, 240, 0.84));
-}
-
-.menu-dropdown-project-img-media {
-  width: 50px !important;
-  height: 50px !important;
-  display: block;
-  object-fit: contain;
-  object-position: center center;
-  border-radius: 6px;
-}
-
-.menu-dropdown-project-icon {
-  line-height: 1;
-}
-
-.menu-dropdown-project-icon .svg-inline--fa {
-  display: block;
-  vertical-align: 0;
-}
-
-.menu-dropdown-project-img::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg,
-      rgba(59, 130, 246, 0.1) 0%,
-      rgba(29, 78, 216, 0.1) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.menu-dropdown-project-info {
-  flex: 1;
-  min-width: 0;
-  padding-left: 4px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 8px;
-}
-
-.menu-dropdown-project-title {
-  font-weight: 700;
-  font-size: 15px;
-  color: var(--noir-text);
-  margin-bottom: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.2;
-  letter-spacing: -0.01em;
-  transition: color 0.3s ease;
-}
-
-.menu-dropdown-project-desc {
-  font-size: 12px;
-  color: var(--noir-muted);
-  margin-bottom: 0;
-  line-height: 1.5;
-  max-width: 280px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-weight: 400;
-  transition: color 0.3s ease;
-}
-
-.menu-dropdown-project-item {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 12px 14px;
-  border-radius: 12px;
-  position: relative;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: pointer;
-  border: 2px solid transparent;
-  background: var(--lg-tint-strong);
-  max-width: 360px;
-  width: 100%;
-  box-sizing: border-box;
-  overflow: hidden;
-}
-
-.menu-dropdown-project-item::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(59, 130, 246, 0.08),
-      transparent);
-  transition: left 0.6s ease;
-}
-
-.menu-dropdown-project-item:hover {
-  background: var(--lg-tint);
-  border-color: var(--noir-accent-line);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35),
-    0 6px 16px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.08);
-  transform: translateY(-2px);
-}
-
-.menu-dropdown-project-item:hover::before {
-  left: 100%;
-}
-
-.menu-dropdown-project-item:active {
-  transform: translateY(-1px);
-}
-
-/* --- TECH STACK DROPDOWN - PILL STYLE DESIGN --- */
-.menu-dropdown-tech-categories {
-  margin: 12px 0 0 0;
-  width: 100%;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: fit-content;
-  max-width: 440px;
-  background: transparent;
-  box-sizing: border-box;
-  overflow-x: hidden;
-}
-
-.menu-dropdown-tech-categories::before {
-  display: none;
-}
-
-.menu-dropdown-tech-categories>* {
-  position: relative;
-  z-index: 1;
-}
-
-/* Category Item Container - Pill Style */
-.tech-category-item {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: fit-content;
-  border-radius: 10px;
-  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  padding: 10px 12px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
-  min-height: 40px;
-  /* overflow: hidden; */
-}
-
-.tech-category-item:hover {
-  background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
-  border-color: rgba(14, 116, 144, 0.3);
-  box-shadow: 0 4px 12px rgba(14, 116, 144, 0.15);
-}
-
-/* Main Category Display - Simplified */
-.tech-category-main {
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  width: 80%;
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.tech-category-name {
-  flex: 1 1 auto;
-  max-width: 70%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: break-word;
-  line-height: 1.3;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  padding-right: 6px;
-  border-radius: 5px;
-  padding: 3px 7px;
-  font-size: 12.5px;
-  font-weight: 500;
-  color: #334155;
-  letter-spacing: 0.01em;
-}
-
-.tech-category-item:hover .tech-category-name {
-  background: rgba(255, 255, 255, 0.8);
-  color: #0f172a;
-  box-shadow: 0 2px 8px rgba(14, 116, 144, 0.1);
-  backdrop-filter: blur(4px);
-}
-
-.tech-category-count {
-  margin-left: 10px;
-  background: linear-gradient(135deg, #e2e8f0 0%, #cbd5e1 100%);
-  color: #64748b;
-  border-radius: 10px;
-  padding: 2px 7px;
-  font-size: 9.5px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  min-width: 20px;
-  max-width: 20%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: center;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-}
-
-.tech-category-item:hover .tech-category-count {
-  background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
-  color: white;
-  border-color: rgba(14, 116, 144, 0.3);
-  transform: scale(1.05);
-}
-
-/* Tools Submenu - Updated for Pill Style */
-.tech-tools-submenu {
-  position: absolute;
-  top: 0;
-  left: calc(100% + 10px);
-  min-width: 220px;
-  max-width: 320px;
-  max-height: 56vh;
-  overflow-y: auto;
-  background: rgba(255, 255, 255, 0.97);
-  backdrop-filter: blur(14px);
-  border: 1px solid rgba(229, 231, 235, 0.7);
-  border-radius: 10px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08), 0 6px 16px rgba(0, 0, 0, 0.04);
-  padding: 12px;
-  z-index: 1050;
-  animation: slideInFromLeft 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  margin-top: -6px;
-}
-
-@keyframes slideInFromLeft {
-  from {
-    opacity: 0;
-    transform: translateX(-12px) scale(0.95);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0) scale(1);
-  }
-}
-
-.tech-tools-submenu::before {
-  content: "";
-  position: absolute;
-  right: 100%;
-  top: 24px;
-  border: 10px solid transparent;
-  border-right-color: rgba(255, 255, 255, 0.98);
-  filter: drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.06));
-  z-index: 2;
-}
-
-.tech-tools-submenu::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: radial-gradient(circle at 30% 30%,
-      rgba(59, 130, 246, 0.015) 0%,
-      transparent 60%),
-    radial-gradient(circle at 70% 70%,
-      rgba(16, 185, 129, 0.015) 0%,
-      transparent 60%);
-  pointer-events: none;
-  z-index: 0;
-}
-
-/* Tools Grid - Compact Layout */
-.tech-tools-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
-  gap: 6px;
-  position: relative;
-  z-index: 1;
-}
-
-/* Individual Tool Item - Compact Card Design */
-.tech-tool-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 7px 5px;
-  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-  border: 1px solid rgba(229, 231, 235, 0.3);
-  border-radius: 7px;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  cursor: default;
-  position: relative;
-  overflow: hidden;
-  backdrop-filter: blur(3px);
-}
-
-.tech-tool-item::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 40%;
-  height: 70%;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(16, 185, 129, 0.06),
-      transparent);
-  transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.tech-tool-item::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg,
-      rgba(16, 185, 129, 0.02) 0%,
-      rgba(5, 150, 105, 0.02) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.tech-tool-item:hover {
-  background: linear-gradient(135deg,
-      rgba(209, 250, 229, 0.8) 0%,
-      rgba(167, 243, 208, 0.6) 100%);
-  border-color: rgba(110, 231, 183, 0.6);
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.12),
-    0 2px 6px rgba(16, 185, 129, 0.08);
-}
-
-.tech-tool-item:hover::before {
-  left: 100%;
-}
-
-.tech-tool-item:hover::after {
-  opacity: 1;
-}
-
-/* Tool Icon - Compact Styling */
-.tech-tool-icon {
-  font-size: 15px;
-  color: #374151;
-  margin-bottom: 2px;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.08));
-}
-
-.tech-tool-item:hover .tech-tool-icon {
-  color: #047857;
-  transform: scale(1.1);
-  filter: drop-shadow(0 2px 4px rgba(4, 120, 87, 0.2));
-}
-
-/* Tool Name - Compact Typography */
-.tech-tool-name {
-  font-size: 9.5px;
-  font-weight: 500;
-  color: #6b7280;
-  text-align: center;
-  line-height: 1.1;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  letter-spacing: 0.01em;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.tech-tool-item:hover .tech-tool-name {
-  color: #065f46;
-  font-weight: 600;
-  text-shadow: 0 1px 2px rgba(6, 95, 70, 0.1);
-}
-
-/* Legacy styles for compatibility - can be removed if not needed */
-.tech-category {
-  margin-bottom: 20px;
-}
-
-.tech-category:last-child {
-  margin-bottom: 0;
-}
-
-.tech-category-label {
-  font-size: 12px;
-  font-weight: 600;
-  color: #475569;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 8px;
-  padding-left: 4px;
-  border-left: 3px solid #3b82f6;
-}
-
-.tech-category-icons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-}
-
-.menu-dropdown-tech-icon {
-  font-size: 1.4rem;
-  color: #374151;
-  background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
-  border-radius: 8px;
-  padding: 8px 10px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid #e5e7eb;
-  position: relative;
-  overflow: hidden;
-  min-width: 36px;
-  height: 36px;
-}
-
-.menu-dropdown-tech-icon::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(255, 255, 255, 0.4),
-      transparent);
-  transition: left 0.5s ease;
-}
-
-.menu-dropdown-tech-icon[title]:hover {
-  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
-  color: #2563eb;
-  border-color: #93c5fd;
-  transform: translateY(-2px) scale(1.05);
-  box-shadow: 0 6px 16px rgba(59, 130, 246, 0.2);
-  z-index: 10;
-}
-
-.menu-dropdown-tech-icon[title]:hover::before {
-  left: 100%;
-}
-
-.tech-more-indicator {
-  font-size: 11px;
-  font-weight: 600;
-  color: #6b7280;
-  background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
-  border-radius: 6px;
-  padding: 4px 8px;
-  border: 1px solid #d1d5db;
-  cursor: help;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-}
-
-.tech-more-indicator:hover {
-  background: linear-gradient(135deg, #e5e7eb 0%, #d1d5db 100%);
-  color: #374151;
-  transform: translateY(-1px);
-}
-
-/* View All Button - Enhanced Design */
-.tech-view-all {
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid rgba(229, 231, 235, 0.6);
-  text-align: center;
-  position: relative;
-}
-
-.tech-view-all::before {
-  content: "";
-  position: absolute;
-  top: -1px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 40px;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, #3b82f6, transparent);
-  opacity: 0.6;
-}
-
-.tech-view-all-btn {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-  border: none;
-  border-radius: 12px;
-  padding: 12px 24px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.25),
-    0 3px 10px rgba(59, 130, 246, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2);
-  position: relative;
-  overflow: hidden;
-  backdrop-filter: blur(8px);
-  letter-spacing: 0.01em;
-}
-
-.tech-view-all-btn::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(255, 255, 255, 0.15),
-      transparent);
-  transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.tech-view-all-btn::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg,
-      rgba(37, 99, 235, 0.1) 0%,
-      rgba(29, 78, 216, 0.1) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.tech-view-all-btn:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: translateY(-3px) scale(1.02);
-  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.35),
-    0 6px 15px rgba(59, 130, 246, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3);
-}
-
-.tech-view-all-btn:hover::before {
-  left: 100%;
-}
-
-.tech-view-all-btn:hover::after {
-  opacity: 1;
-}
-
-.tech-view-all-btn:active {
-  transform: translateY(-1px) scale(1.01);
-  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.3),
-    0 3px 10px rgba(59, 130, 246, 0.2);
-}
-
-/* Enhanced Responsive Design */
-/* Enhanced Mobile and Tablet Responsive Design */
-@media (max-width: 1024px) {
-  .menu-bar {
-    padding: 8px 16px;
-    backdrop-filter: blur(12px);
-  }
-
-  .menu-item {
-    padding: 8px 12px;
-    font-size: 13px;
-  }
-
-  .menu-dropdown-projects,
-  .menu-dropdown-services,
-  .menu-dropdown-contact-info {
-    max-width: 85vw;
-    margin: 8px 0 0 0;
-  }
-}
-
-@media (max-width: 768px) {
-  .menu-bar {
-    padding: 6px 12px;
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), 0 2px 8px rgba(0, 0, 0, 0.04);
-  }
-
-  .menu-item {
-    padding: 6px 10px;
-    font-size: 12px;
-    border-radius: 6px;
-  }
-
-  .menu-dropdown,
-  .menu-dropdown-projects,
-  .menu-dropdown-services,
-  .menu-dropdown-contact-info {
-    max-width: 90vw;
-    border-radius: 8px;
-    padding: 12px;
-  }
-
-  .menu-dropdown-project-item {
-    padding: 12px 10px;
-  }
-
-  .menu-dropdown-service-item {
-    padding: 14px 12px;
-    gap: 12px;
-    min-height: 70px;
-  }
-
-  .menu-dropdown-service-title {
-    font-size: 14px;
-  }
-
-  .menu-dropdown-service-desc {
-    font-size: 12px;
-  }
-}
-
-@media (max-width: 1200px) {
-  .tech-tools-submenu {
-    position: fixed;
-    left: auto;
-    right: 24px;
-    top: 50%;
-    transform: translateY(-50%);
-    max-width: 280px;
-    margin: 0;
-    animation: slideInFromRight 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-  }
-
-  @keyframes slideInFromRight {
-    from {
-      opacity: 0;
-      transform: translateY(-50%) translateX(20px) scale(0.92);
-    }
-
-    to {
-      opacity: 1;
-      transform: translateY(-50%) translateX(0) scale(1);
-    }
-  }
-
-  .tech-tools-submenu::before {
-    display: none;
-  }
-}
-
-@media (max-width: 768px) {
-  .menu-dropdown-tech-categories {
-    min-width: 340px;
-    max-width: 380px;
-    padding: 16px;
-  }
-
-  .tech-category-main {
-    padding: 12px 16px;
-  }
-
-  .tech-category-name {
-    font-size: 14px;
-  }
-
-  .tech-category-count {
-    font-size: 10px;
-    padding: 3px 8px;
-  }
-
-  .tech-tools-submenu {
-    position: fixed;
-    left: 12px;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    max-width: none;
-    max-height: 70vh;
-    overflow-y: auto;
-    animation: slideInFromBottom 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-  }
-
-  @keyframes slideInFromBottom {
-    from {
-      opacity: 0;
-      transform: translateY(-50%) translateY(30px) scale(0.9);
-    }
-
-    to {
-      opacity: 1;
-      transform: translateY(-50%) translateY(0) scale(1);
-    }
-  }
-
-  .tech-tools-grid {
-    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
-    gap: 6px;
-  }
-
-  .tech-tool-item {
-    padding: 8px 6px;
-  }
-
-  .tech-tool-icon {
-    font-size: 16px;
-    margin-bottom: 3px;
-  }
-
-  .tech-tool-name {
-    font-size: 9px;
-  }
-
-  .tech-view-all-btn {
-    padding: 10px 20px;
-    font-size: 12px;
-  }
-}
-
-@media (max-width: 480px) {
-  .menu-dropdown-tech-categories {
-    min-width: 300px;
-    max-width: 340px;
-    padding: 14px;
-  }
-
-  .tech-tools-grid {
-    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-    gap: 4px;
-  }
-
-  .tech-tool-item {
-    padding: 6px 4px;
-  }
-
-  .tech-tool-icon {
-    font-size: 14px;
-  }
-
-  .tech-tool-name {
-    font-size: 8px;
-  }
-}
-
-/* Enhanced Scrollbar for Mobile Submenu */
-.tech-tools-submenu::-webkit-scrollbar {
-  width: 6px;
-}
-
-.tech-tools-submenu::-webkit-scrollbar-track {
-  background: rgba(243, 244, 246, 0.5);
-  border-radius: 3px;
-}
-
-.tech-tools-submenu::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg,
-      rgba(156, 163, 175, 0.6) 0%,
-      rgba(107, 114, 128, 0.6) 100%);
-  border-radius: 3px;
-  transition: all 0.3s ease;
-}
-
-.tech-tools-submenu::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(180deg,
-      rgba(107, 114, 128, 0.8) 0%,
-      rgba(75, 85, 99, 0.8) 100%);
-}
-
-/* --- Services Dropdown - Enhanced --- */
-.menu-dropdown-services {
-  margin: 16px 0;
-  padding: 16px 14px;
-  max-width: 380px;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  max-height: 440px;
-  min-width: 320px;
-  overflow-y: auto;
-  border-radius: 12px;
-  backdrop-filter: blur(10px);
-  position: relative;
-}
-
-.menu-dropdown-service-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-  border-radius: 10px;
-  padding: 20px 16px;
-  margin: 0;
-  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-    background 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: pointer;
-  border: 1px solid transparent;
-  position: relative;
-  background: var(--lg-tint-strong);
-  overflow: visible;
-  min-height: fit-content;
-  box-sizing: border-box;
-  z-index: 1;
-}
-
-.menu-dropdown-service-item:hover {
-  background: var(--lg-tint);
-  border-color: rgba(16, 185, 129, 0.4);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(16, 185, 129, 0.12),
-    0 4px 12px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-/* Emerald accent bar on hover */
-.menu-dropdown-service-item:hover::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 20%;
-  bottom: 20%;
-  width: 3px;
-  background: linear-gradient(180deg, #10b981 0%, #059669 100%);
-  border-radius: 2px;
-  animation: slideIn 0.2s ease;
-}
-
-.menu-dropdown-service-item:last-child {
-  border-bottom: 1px solid transparent;
-}
-
-.menu-dropdown-service-icon {
-  width: 46px;
-  height: 46px;
-  object-fit: contain;
-  border-radius: 10px;
-  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
-  border: 1px solid rgba(233, 236, 239, 0.8);
-  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  padding: 8px;
-}
-
-.menu-dropdown-service-item:hover .menu-dropdown-service-icon {
-  transform: translateY(-2px) scale(1.05);
-  box-shadow: 0 6px 16px rgba(16, 185, 129, 0.15), 0 3px 8px rgba(0, 0, 0, 0.08);
-  background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
-  border-color: rgba(16, 185, 129, 0.2);
-}
-
-.menu-dropdown-service-info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-  flex: 1;
-}
-
-.menu-dropdown-service-title {
-  margin: 0;
-  color: var(--noir-text);
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  line-height: 1.3;
-}
-
-.menu-dropdown-service-desc {
-  margin: 0;
-  color: var(--noir-muted);
-  font-size: 12px;
-  line-height: 1.45;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-/* --- Contact Dropdown - Enhanced --- */
-.menu-dropdown-contact-info {
-  margin-top: 8px;
-  min-width: 300px;
-  max-width: 340px;
-  padding: 20px;
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border-radius: 12px;
-  border: 1px solid rgba(229, 231, 235, 0.8);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.04);
-  text-align: center;
-  position: relative;
-}
-
-.contact-info-text {
-  margin-bottom: 16px;
-}
-
-.contact-info-text p {
-  margin: 0;
-  color: #475569;
-  font-size: 14px;
-  line-height: 1.5;
-  font-weight: 500;
-}
-
-.contact-trigger-btn {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-  border: none;
-  padding: 12px 20px;
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  font-family: inherit;
-  width: 100%;
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.25),
-    0 2px 6px rgba(59, 130, 246, 0.15);
-  position: relative;
-  overflow: hidden;
-}
-
-.contact-trigger-btn::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(255, 255, 255, 0.2),
-      transparent);
-  transition: left 0.6s ease;
-}
-
-.contact-trigger-btn:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.35),
-    0 4px 12px rgba(59, 130, 246, 0.25);
-}
-
-.contact-trigger-btn:hover::before {
-  left: 100%;
-}
-
-.contact-trigger-btn:active {
-  transform: translateY(-1px);
-}
-
-/* Menu Bar Root - Enhanced */
+/* ==========================================================================
+   MenuBar (mac-style top bar) + its dropdowns: About, Services, Projects.
+   ========================================================================== */
+
+/* Menu Bar Root */
 .menu-bar {
   max-width: 100%;
   background: linear-gradient(180deg,
@@ -1046,7 +28,7 @@
 .menu-left {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 6px;
 }
 
 .my-logo {
@@ -1065,13 +47,7 @@
 .menu-item-wrapper {
   position: relative;
   display: inline-block;
-  margin-right: 4px;
   z-index: 1;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.menu-item-wrapper:last-child {
-  margin-right: 0;
 }
 
 .menu-item-wrapper-active {
@@ -1082,15 +58,21 @@
   cursor: pointer;
   padding: 8px 16px;
   border-radius: 8px;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   z-index: 2;
   user-select: none;
-  outline: none;
+  appearance: none;
   background: transparent;
   color: rgba(240, 236, 232, 0.78);
+  font-family: inherit;
   font-size: 13px;
   font-weight: 500;
+  line-height: 1;
   border: 1px solid transparent;
   letter-spacing: 0.01em;
 }
@@ -1136,6 +118,10 @@
   z-index: 1011;
   animation: dropdownFadeIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   overflow: visible;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  box-sizing: border-box;
 }
 
 @keyframes dropdownFadeIn {
@@ -1164,25 +150,9 @@
   z-index: -1;
 }
 
-.menu-dropdown-mac-active {
-  transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  pointer-events: auto;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
-  font-size: 14px;
-  box-sizing: border-box;
-  opacity: 1;
-}
-
-.menu-dropdown-title {
-  font-size: 16px;
-  color: var(--noir-text);
-  letter-spacing: 0.1px;
-  font-weight: bold;
-}
-
+/* --- About Dropdown (personality pills) --- */
 .menu-dropdown-pills {
-  margin: 16px 0 0 0;
+  margin: 0;
   width: 100%;
   padding: 0;
   list-style: none;
@@ -1205,7 +175,10 @@
   background: var(--lg-tint-strong);
   border: 1px solid var(--lg-edge);
   padding: 14px 16px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   box-sizing: border-box;
 }
@@ -1217,13 +190,22 @@
   transform: translateY(-1px);
 }
 
+.pill-tag-mac {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
 .pill-tag-label {
   flex: 1 1 auto;
   white-space: normal;
   word-wrap: break-word;
   overflow-wrap: break-word;
   line-height: 1.4;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 14px;
@@ -1231,13 +213,6 @@
   color: var(--noir-text);
   letter-spacing: 0.02em;
   max-width: calc(100% - 50px);
-}
-
-.pill-tag-mac {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
 }
 
 .pill-tag-icon {
@@ -1254,26 +229,8 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04),
     inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 -1px 0 rgba(0, 0, 0, 0.02);
-  position: relative;
-}
-
-.pill-tag-icon::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg,
-      rgba(59, 130, 246, 0.1) 0%,
-      rgba(16, 185, 129, 0.05) 50%,
-      rgba(139, 92, 246, 0.08) 100%);
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  border-radius: inherit;
 }
 
 .pill-tag-icon img {
@@ -1281,368 +238,358 @@
   height: 100%;
   object-fit: cover;
   border-radius: 6px;
-  position: relative;
-  z-index: 1;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   filter: saturate(0.9) brightness(1.02);
 }
 
-.pill-tag-mac:hover .pill-tag-icon,
-.pill-tag-mac:focus .pill-tag-icon {
-  background: linear-gradient(135deg,
-      rgba(255, 255, 255, 0.95) 0%,
-      rgba(240, 249, 255, 0.9) 50%,
-      rgba(229, 241, 255, 0.85) 100%);
-  border-color: rgba(59, 130, 246, 0.3);
-  transform: scale(1.08) translateY(-1px);
-  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.15),
-    0 3px 12px rgba(16, 185, 129, 0.08), 0 1px 6px rgba(0, 0, 0, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9),
-    inset 0 -1px 0 rgba(59, 130, 246, 0.1);
-  backdrop-filter: blur(12px);
-}
-
-.pill-tag-mac:hover .pill-tag-icon::before,
-.pill-tag-mac:focus .pill-tag-icon::before {
-  opacity: 1;
-}
-
-.pill-tag-mac:hover .pill-tag-icon img,
-.pill-tag-mac:focus .pill-tag-icon img {
-  transform: scale(1.02);
-  filter: saturate(1.1) brightness(1.05) contrast(1.05);
-}
-
-.pill-tag-mac:active .pill-tag-icon {
-  transform: scale(1.02) translateY(0px);
-  transition: all 0.15s cubic-bezier(0.4, 0, 0.6, 1);
-}
-
-.pill-tag-mac:hover .pill-tag-label,
-.pill-tag-mac:focus .pill-tag-label {
-  background: rgba(255, 255, 255, 0.8);
-  color: #0f172a;
-  box-shadow: 0 2px 8px rgba(14, 116, 144, 0.1);
-  /* backdrop-filter: blur(4px); */
-}
-
-.pill-tag-arrow {
-  margin-left: 12px;
-  color: #64748b;
-  font-weight: 600;
-  font-size: 14px;
-  user-select: none;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.menu-dropdown-pill-item:hover .pill-tag-arrow {
-  color: #0e7490;
-  transform: translateX(2px);
-}
-
-.pill-tooltip-mac {
-  display: none;
-  position: absolute;
-  left: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  margin-left: 16px;
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  color: #1e293b;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 12px;
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12), 0 4px 10px rgba(0, 0, 0, 0.08),
-    0 0 0 1px rgba(255, 255, 255, 0.05);
-  padding: 12px 16px;
-  font-size: 13px;
-  line-height: 1.5;
-  min-width: 200px;
-  max-width: 280px;
-  z-index: 2000;
-  white-space: pre-line;
-  pointer-events: none;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Arial,
-    sans-serif;
-  font-weight: 400;
-  backdrop-filter: blur(8px);
-}
-
-.pill-tooltip-mac::before {
-  content: "";
-  position: absolute;
-  right: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  border: 6px solid transparent;
-  border-right-color: rgba(255, 255, 255, 0.9);
-  filter: drop-shadow(-1px 0 1px rgba(148, 163, 184, 0.1));
-}
-
-.pill-tag-mac .pill-tooltip-mac[data-show] {
-  display: block !important;
-  animation: fadeInMacTooltip 0.18s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-@keyframes fadeInMacTooltip {
-  from {
-    opacity: 0;
-    transform: translateY(-50%) scale(0.98);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(-50%) scale(1);
-  }
-}
-
-/* Side dropdown for pill details */
-.pill-side-dropdown {
-  position: absolute;
-  left: 100%;
-  top: 0;
-  margin-left: 0;
-  padding: 20px;
-  padding-left: 36px;
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  background-clip: padding-box;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 12px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12), 0 6px 16px rgba(0, 0, 0, 0.08),
-    0 0 0 1px rgba(255, 255, 255, 0.05);
-  z-index: 2000;
-  min-width: 300px;
-  max-width: 400px;
-  animation: fadeInSideDropdown 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-/* Invisible bridge to prevent hover gap between pill and side dropdown */
-.pill-side-dropdown::after {
-  content: "";
-  position: absolute;
-  left: -20px;
-  top: 0;
-  width: 20px;
-  height: 100%;
-  background: transparent;
-}
-
-.pill-side-dropdown::before {
-  content: "";
-  position: absolute;
-  left: 8px;
-  top: 20px;
-  width: 0;
-  height: 0;
-  border: 8px solid transparent;
-  border-right-color: rgba(255, 255, 255, 0.9);
-  filter: drop-shadow(-1px 0 1px rgba(148, 163, 184, 0.1));
-}
-
-.pill-side-content {
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-}
-
-.pill-side-icon {
-  flex-shrink: 0;
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
-  background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
-  border: 1px solid rgba(14, 116, 144, 0.2);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-
-.pill-side-icon img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: inherit;
-}
-
-.pill-side-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.pill-side-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: #1e293b;
-  margin-bottom: 8px;
-  line-height: 1.3;
-}
-
-.pill-side-description {
-  font-size: 14px;
-  color: #475569;
-  line-height: 1.5;
-  margin: 0;
-}
-
-@keyframes fadeInSideDropdown {
-  from {
-    opacity: 0;
-    transform: translateX(-8px) scale(0.98);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0) scale(1);
-  }
-}
-
-/* Clickable pill styles for interactive elements like "& more..." */
+/* Clickable pills (e.g. "& more...") */
 .pill-tag-clickable {
   cursor: pointer;
   user-select: none;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.pill-tag-clickable:hover {
-  background: var(--lg-tint);
-  border-color: var(--noir-accent-line);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  transform: translateY(-1px);
 }
 
 .pill-tag-clickable:hover .pill-tag-label {
   background: var(--noir-accent-soft);
   color: var(--noir-text);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(4px);
 }
 
-.pill-tag-clickable:hover .pill-tag-arrow {
-  color: var(--noir-accent);
-  transform: translateX(3px);
-}
-
-.pill-tag-clickable:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 6px rgba(37, 99, 235, 0.2);
-}
-
-.pill-tag-clickable:focus {
+.pill-tag-clickable:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
-/* Add subtle indicator for clickable pills */
-.pill-tag-clickable .pill-tag-label::after {
+/* --- Services Dropdown --- */
+.menu-dropdown-services {
+  margin: 0;
+  padding: 4px;
+  max-width: 380px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 440px;
+  min-width: 320px;
+  overflow-y: auto;
+  border-radius: 12px;
+  position: relative;
+}
+
+.menu-dropdown-service-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  border-radius: 10px;
+  padding: 16px;
+  margin: 0;
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+  border: 1px solid transparent;
+  position: relative;
+  background: var(--lg-tint-strong);
+  box-sizing: border-box;
+}
+
+.menu-dropdown-service-item:hover {
+  background: var(--lg-tint);
+  border-color: rgba(16, 185, 129, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(16, 185, 129, 0.12),
+    0 4px 12px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+/* Emerald accent bar on hover */
+.menu-dropdown-service-item::before {
   content: "";
+  position: absolute;
+  left: 0;
+  top: 20%;
+  bottom: 20%;
+  width: 3px;
+  background: linear-gradient(180deg, #10b981 0%, #059669 100%);
+  border-radius: 2px;
   opacity: 0;
-  margin-left: 6px;
-  font-size: 12px;
   transition: opacity 0.2s ease;
 }
 
-.pill-tag-clickable:hover .pill-tag-label::after {
-  opacity: 0.7;
+.menu-dropdown-service-item:hover::before {
+  opacity: 1;
+}
+
+.menu-dropdown-service-icon {
+  width: 46px;
+  height: 46px;
+  object-fit: contain;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  border: 1px solid rgba(233, 236, 239, 0.8);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  padding: 8px;
+  flex-shrink: 0;
+}
+
+.menu-dropdown-service-item:hover .menu-dropdown-service-icon {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 6px 16px rgba(16, 185, 129, 0.15), 0 3px 8px rgba(0, 0, 0, 0.08);
+  background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
+  border-color: rgba(16, 185, 129, 0.2);
+}
+
+.menu-dropdown-service-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+}
+
+.menu-dropdown-service-title {
+  margin: 0;
+  color: var(--noir-text);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.menu-dropdown-service-desc {
+  margin: 0;
+  color: var(--noir-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* --- Projects Dropdown --- */
+.menu-dropdown-projects {
+  margin: 0;
+  width: fit-content;
+  max-width: 90vw;
+  max-height: 480px;
+  overflow-y: auto;
+  border-radius: 12px;
+  padding: 4px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  list-style: none;
+}
+
+.menu-dropdown-project-img {
+  width: 62px;
+  height: 62px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.menu-dropdown-project-img-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  padding: 6px;
+  background:
+    radial-gradient(circle at 30% 22%, rgba(255, 255, 255, 0.86), transparent 64%),
+    linear-gradient(145deg, rgba(248, 250, 252, 0.95), rgba(226, 232, 240, 0.84));
+}
+
+.menu-dropdown-project-img-media {
+  width: 50px !important;
+  height: 50px !important;
+  display: block;
+  object-fit: contain;
+  object-position: center center;
+  border-radius: 6px;
+}
+
+.menu-dropdown-project-icon {
+  line-height: 1;
+  font-size: 28px;
+}
+
+.menu-dropdown-project-icon .svg-inline--fa {
+  display: block;
+  vertical-align: 0;
+}
+
+.menu-dropdown-project-info {
+  flex: 1;
+  min-width: 0;
+  padding-left: 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+}
+
+.menu-dropdown-project-title {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--noir-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.menu-dropdown-project-desc {
+  font-size: 12px;
+  color: var(--noir-muted);
+  line-height: 1.5;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 400;
+}
+
+.menu-dropdown-project-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  position: relative;
+  transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+  border: 2px solid transparent;
+  background: var(--lg-tint-strong);
+  max-width: 360px;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.menu-dropdown-project-item:hover {
+  background: var(--lg-tint);
+  border-color: var(--noir-accent-line);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35),
+    0 6px 16px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  transform: translateY(-2px);
+}
+
+.menu-dropdown-project-item:active {
+  transform: translateY(-1px);
+}
+
+.menu-right {
+  display: flex;
+  align-items: center;
+}
+
+/* --- Custom scrollbars for scrollable dropdowns --- */
+.menu-dropdown-projects,
+.menu-dropdown-services {
+  scrollbar-width: thin;
+  scrollbar-color: #94a3b8 rgba(243, 244, 246, 0.5);
+}
+
+.menu-dropdown-projects::-webkit-scrollbar,
+.menu-dropdown-services::-webkit-scrollbar {
+  width: 6px;
+}
+
+.menu-dropdown-projects::-webkit-scrollbar-track,
+.menu-dropdown-services::-webkit-scrollbar-track {
+  background: rgba(248, 250, 252, 0.5);
+  border-radius: 3px;
+}
+
+.menu-dropdown-projects::-webkit-scrollbar-thumb,
+.menu-dropdown-services::-webkit-scrollbar-thumb {
+  background: linear-gradient(135deg, #cbd5e1 0%, #94a3b8 100%);
+  border-radius: 3px;
+}
+
+.menu-dropdown-projects::-webkit-scrollbar-thumb:hover,
+.menu-dropdown-services::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(135deg, #94a3b8 0%, #64748b 100%);
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+@media (max-width: 1024px) {
+  .menu-bar {
+    padding: 8px 16px;
+  }
+
+  .menu-item {
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
+  .menu-dropdown-projects,
+  .menu-dropdown-services {
+    max-width: 85vw;
+  }
 }
 
 @media (max-width: 900px) {
-  .menu-item-wrapper {
-    min-width: 70px;
-    margin-right: 8px;
-  }
-
   .menu-dropdown {
-    min-width: 160px;
-    padding: 14px;
+    min-width: 200px;
   }
 }
 
-/* --- Accessibility, Motion, and Touch Improvements (Additive) --- */
-
-/* 1) Respect reduced motion: disable non-essential animations/transforms */
-@media (prefers-reduced-motion: reduce) {
-
-  .tech-tools-submenu,
-  .pill-tag-mac .pill-tooltip-mac[data-show] {
-    animation: none !important;
-  }
-
-  .menu-dropdown-project-img,
-  .menu-dropdown-project-link,
-  .menu-dropdown-project-item,
-  .menu-dropdown-service-item,
-  .tech-tool-item,
-  .tech-view-all-btn,
-  .pill-tag-clickable,
-  .menu-item {
-    transition-duration: 0.01ms !important;
-    transition-delay: 0s !important;
-    transform: none !important;
-  }
-}
-
-/* 2) Keyboard accessibility: clear focus rings without layout shift */
-:where(.menu-item,
-  .menu-dropdown-project-link,
-  .menu-dropdown-project-item,
-  .menu-dropdown-service-item,
-  .contact-trigger-btn,
-  .tech-tool-item,
-  .tech-view-all-btn,
-  .menu-dropdown-pill-item,
-  .pill-tag-clickable) {
-  outline: none;
-}
-
-:where(.menu-item,
-  .menu-dropdown-project-link,
-  .menu-dropdown-project-item,
-  .menu-dropdown-service-item,
-  .contact-trigger-btn,
-  .tech-tool-item,
-  .tech-view-all-btn,
-  .menu-dropdown-pill-item,
-  .pill-tag-clickable):focus-visible {
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25), 0 0 0 1.5px #2563eb inset;
-  border-radius: 8px;
-}
-
-/* 3) Touch-friendly targets on coarse pointers */
-@media (pointer: coarse) {
-
-  :where(.menu-dropdown-project-item,
-    .menu-dropdown-service-item,
-    .menu-dropdown-pill-item) {
-    min-height: 44px;
-  }
-
-  :where(.menu-dropdown-project-item,
-    .menu-dropdown-service-item,
-    .menu-dropdown-pill-item) {
-    padding-top: 12px;
-    padding-bottom: 12px;
-  }
-
-  /* Avoid hover-only motion on touch devices */
-  .menu-dropdown-project-item:hover,
-  .menu-dropdown-service-item:hover,
-  .tech-tool-item:hover,
-  .pill-tag-clickable:hover {
-    transform: none;
-  }
-}
-
-/* 4) Lighter visual effects on small screens for performance */
 @media (max-width: 768px) {
+  .menu-item {
+    padding: 6px 10px;
+    font-size: 12px;
+    border-radius: 6px;
+  }
+
+  .menu-dropdown,
+  .menu-dropdown-projects,
+  .menu-dropdown-services {
+    max-width: 90vw;
+    border-radius: 8px;
+    padding: 12px;
+  }
+
   .menu-dropdown {
     backdrop-filter: blur(6px) saturate(110%);
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.08);
   }
 
   .menu-dropdown-project-item,
-  .menu-dropdown-service-item,
-  .tech-tool-item {
+  .menu-dropdown-service-item {
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  }
+
+  .menu-dropdown-project-item {
+    padding: 12px 10px;
+  }
+
+  .menu-dropdown-service-item {
+    padding: 14px 12px;
+    gap: 12px;
+  }
+
+  .menu-dropdown-service-title {
+    font-size: 14px;
+  }
+
+  .menu-dropdown-service-desc {
+    font-size: 12px;
   }
 
   .menu-dropdown-pills {
@@ -1658,57 +605,6 @@
   .pill-tag-label {
     font-size: 13px;
     padding: 5px 8px;
-  }
-
-  /* Side dropdown adjustments for mobile */
-  .pill-side-dropdown {
-    left: 50%;
-    top: 100%;
-    transform: translateX(-50%);
-    margin-left: 0;
-    margin-top: 8px;
-    min-width: 280px;
-    max-width: 320px;
-  }
-
-  .pill-side-dropdown::before {
-    left: 50%;
-    top: -8px;
-    transform: translateX(-50%) rotate(90deg);
-    border-right-color: transparent;
-    border-bottom-color: rgba(255, 255, 255, 0.9);
-  }
-}
-
-/* 5) High contrast/forced-colors friendly fallbacks */
-@media (prefers-contrast: more),
-(forced-colors: active) {
-
-  .menu-dropdown,
-  .menu-dropdown-projects,
-  .menu-dropdown-project-item,
-  .menu-dropdown-service-item,
-  .tech-tools-submenu,
-  .menu-dropdown-pill-item,
-  .contact-trigger-btn,
-  .tech-view-all-btn {
-    background: Canvas !important;
-    color: CanvasText !important;
-    border-color: ButtonBorder !important;
-    box-shadow: none !important;
-    backdrop-filter: none !important;
-  }
-
-  :where(.menu-item,
-    .menu-dropdown-project-item,
-    .menu-dropdown-service-item,
-    .tech-tool-item,
-    .menu-dropdown-pill-item,
-    .contact-trigger-btn,
-    .tech-view-all-btn):focus-visible {
-    outline: 2px solid Highlight !important;
-    outline-offset: 2px;
-    box-shadow: none !important;
   }
 }
 
@@ -1739,7 +635,6 @@
   .menu-dropdown-service-item {
     padding: 12px 10px;
     gap: 10px;
-    min-height: 60px;
   }
 
   .menu-dropdown-service-title {
@@ -1749,14 +644,6 @@
   .menu-dropdown-service-desc {
     font-size: 11px;
   }
-}
-
-/* 6) Scrollbar polish (Firefox + WebKit) */
-.menu-dropdown-projects,
-.tech-tools-submenu {
-  scrollbar-width: thin;
-  /* Firefox */
-  scrollbar-color: #94a3b8 rgba(243, 244, 246, 0.5);
 }
 
 /* ==========================================================================
@@ -1773,9 +660,6 @@
   }
 
   .menu-item {
-    /* Keep horizontal footprint compact so all items fit a narrow bar,
-       but give a full-height (>=44px) tap target — .menu-item is a span,
-       so use inline-flex to make min-height take effect. */
     display: inline-flex;
     align-items: center;
     min-height: 44px;
@@ -1811,17 +695,87 @@
 }
 
 /* ==========================================================================
+   Accessibility & motion
+   ========================================================================== */
+
+/* Respect reduced motion: disable non-essential animations/transforms */
+@media (prefers-reduced-motion: reduce) {
+  .menu-dropdown {
+    animation: none !important;
+  }
+
+  .menu-dropdown-project-img,
+  .menu-dropdown-project-item,
+  .menu-dropdown-service-item,
+  .menu-dropdown-pill-item,
+  .pill-tag-clickable,
+  .menu-item {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+    transform: none !important;
+  }
+}
+
+/* Keyboard focus rings without layout shift */
+:where(.menu-item,
+  .menu-dropdown-project-item,
+  .menu-dropdown-service-item,
+  .menu-dropdown-pill-item,
+  .pill-tag-clickable):focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25), 0 0 0 1.5px #2563eb inset;
+  border-radius: 8px;
+}
+
+/* Touch-friendly targets on coarse pointers */
+@media (pointer: coarse) {
+  :where(.menu-dropdown-project-item,
+    .menu-dropdown-service-item,
+    .menu-dropdown-pill-item) {
+    min-height: 44px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+
+  /* Avoid hover-only motion on touch devices */
+  .menu-dropdown-project-item:hover,
+  .menu-dropdown-service-item:hover,
+  .pill-tag-clickable:hover {
+    transform: none;
+  }
+}
+
+/* High contrast / forced-colors friendly fallbacks */
+@media (prefers-contrast: more),
+(forced-colors: active) {
+  .menu-dropdown,
+  .menu-dropdown-project-item,
+  .menu-dropdown-service-item,
+  .menu-dropdown-pill-item {
+    background: Canvas !important;
+    color: CanvasText !important;
+    border-color: ButtonBorder !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+  }
+
+  :where(.menu-item,
+    .menu-dropdown-project-item,
+    .menu-dropdown-service-item,
+    .menu-dropdown-pill-item):focus-visible {
+    outline: 2px solid Highlight !important;
+    outline-offset: 2px;
+    box-shadow: none !important;
+  }
+}
+
+/* ==========================================================================
    Phone & tablet — drop the MenuBar entirely.
    Its content (About/Services/Projects) is already reachable from the
    desktop icons and the welcome window's quick links, and a mac-style top
-   menu bar doesn't translate well to a touch layout. The width check alone
-   only catches phones — real tablets in portrait (iPad Mini/Air at
-   768-820px, iPad Pro at 834-1024px) sit above 768px and were rendering
-   the MenuBar *and* the touch-oriented desktop icon wheel at once, so
-   `(pointer: coarse)` is included to catch touch devices regardless of
-   width. Kept as the last rule in this file so it wins the cascade over
-   the unconditional `.menu-bar` rule above (same selector specificity, so
-   source order decides).
+   menu bar doesn't translate well to a touch layout. `(pointer: coarse)`
+   catches real tablets in portrait that sit above the 768px width check.
+   Kept last so it wins the cascade over the unconditional `.menu-bar` rule.
    ========================================================================== */
 @media (max-width: 768px), (pointer: coarse) {
   .menu-bar {

--- a/src/components/layout/LandingPage/LandingPage.tsx
+++ b/src/components/layout/LandingPage/LandingPage.tsx
@@ -47,8 +47,6 @@ const LandingPage = () => {
         <MenuBar
           openDropdown={dropdownState.openDropdown}
           setOpenDropdown={dropdownActions.setOpenDropdown}
-          hoveredTechCategory={dropdownState.hoveredTechCategory}
-          setHoveredTechCategory={dropdownActions.setHoveredTechCategory}
           setShowAboutMe={modalActions.setShowAboutMe}
           setShowProjects={modalActions.setShowProjects}
           setShowSkillset={modalActions.setShowSkillset}

--- a/src/components/layout/LandingPage/components/MenuBar.tsx
+++ b/src/components/layout/LandingPage/components/MenuBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { aboutMePills } from "@/data/aboutMePills";
 import { ASSET_PATHS } from "@/lib/constants/paths";
@@ -11,18 +11,14 @@ import {
   PROJECT_ICON_FALLBACK,
   isImageIcon,
 } from "@/lib/constants/projectIcons";
-// import tools from "@/data/toolbelt";
 import Image from "next/image";
 
 interface MenuBarProps {
   openDropdown: string | null;
   setOpenDropdown: (dropdown: string | null) => void;
-  hoveredTechCategory: string | null;
-  setHoveredTechCategory: (category: string | null) => void;
   setShowAboutMe: (show: boolean) => void;
   setShowProjects: (show: boolean) => void;
   setShowSkillset: (show: boolean) => void;
-  // setShowContactForm: (show: boolean) => void;
   preload: {
     about: () => void;
     contact: () => void;
@@ -32,93 +28,46 @@ interface MenuBarProps {
   TimeDisplay: React.ComponentType;
 }
 
+const MENU_ITEMS = [
+  { label: "About", key: "about" },
+  { label: "Services", key: "services" },
+  { label: "Projects", key: "projects" },
+] as const;
+
+const getServicePreview = (description: string) => {
+  const normalizedDescription = description.replace(/\s+/g, " ").trim();
+  const firstSentence =
+    normalizedDescription.match(/[^.!?]+[.!?]/)?.[0] ?? normalizedDescription;
+  if (firstSentence.length <= 110) return firstSentence;
+  return `${firstSentence.slice(0, 107).trimEnd()}...`;
+};
+
 const MenuBar: React.FC<MenuBarProps> = ({
   openDropdown,
   setOpenDropdown,
-  // hoveredTechCategory,
-  // setHoveredTechCategory,
   setShowAboutMe,
   setShowProjects,
   setShowSkillset,
-  // setShowContactForm,
   preload,
   TimeDisplay,
 }) => {
   const menuBarRef = useRef<HTMLDivElement>(null);
 
-  const getServicePreview = (description: string) => {
-    const normalizedDescription = description.replace(/\s+/g, " ").trim();
-    const firstSentence =
-      normalizedDescription.match(/[^.!?]+[.!?]/)?.[0] ?? normalizedDescription;
-    if (firstSentence.length <= 110) return firstSentence;
-    return `${firstSentence.slice(0, 107).trimEnd()}...`;
+  const activeProjects = useMemo(
+    () => projectsData.filter((p) => !p.archived),
+    []
+  );
+
+  const toggleDropdown = (key: string) =>
+    setOpenDropdown(openDropdown === key ? null : key);
+
+  const preloadFor = (key: string) => {
+    if (key === "about") preload.about();
+    else if (key === "projects") preload.projects();
+    else if (key === "services") preload.skillset();
   };
 
-  // Define category order and display names for tech stack
-  // const techStackCategories = [
-  //   { key: "Frontend", name: "Frontend Development" },
-  //   { key: "Backend", name: "Backend Development" },
-  //   { key: "DevOps", name: "DevOps & Version Control" },
-  //   { key: "Cloud", name: "Cloud & Infrastructure" },
-  //   { key: "Design", name: "Design Tools" },
-  //   { key: "Package Management", name: "Package Management" },
-  //   { key: "Collaboration", name: "Collaboration" },
-  //   { key: "Project Management", name: "Project Management" },
-  //   { key: "Documentation", name: "Documentation & Testing" },
-  // ];
-
-  // Memoized grouping of tools by category
-  // const groupedTools = React.useMemo(() => {
-  //   return tools.reduce((acc, tool) => {
-  //     if (!acc[tool.category]) acc[tool.category] = [];
-  //     acc[tool.category].push(tool);
-  //     return acc;
-  //   }, {} as Record<string, typeof tools>);
-  // }, []);
-
-  // Helper function to render category item
-  // const renderCategoryItem = (category: { key: string; name: string }) => {
-  //   const categoryTools = groupedTools[category.key] || [];
-
-  //   if (categoryTools.length === 0) return null;
-
-  //   return (
-  //     <div
-  //       key={category.key}
-  //       className="tech-category-item"
-  //       onMouseEnter={() => setHoveredTechCategory(category.key)}
-  //       onMouseLeave={() => setHoveredTechCategory(null)}
-  //     >
-  //       <div className="tech-category-main">
-  //         <span className="tech-category-name">{category.name}</span>
-  //         <span className="tech-category-count">({categoryTools.length})</span>
-  //       </div>
-
-  //       {hoveredTechCategory === category.key && (
-  //         <div className="tech-tools-submenu">
-  //           <div className="tech-tools-grid">
-  //             {categoryTools.map((tool, index) => (
-  //               <div
-  //                 key={`${category.key}-${index}`}
-  //                 className="tech-tool-item"
-  //                 title={tool.tooltip}
-  //               >
-  //                 <FontAwesomeIcon
-  //                   icon={tool.icon}
-  //                   className="tech-tool-icon"
-  //                 />
-  //                 <span className="tech-tool-name">{tool.tooltip}</span>
-  //               </div>
-  //             ))}
-  //           </div>
-  //         </div>
-  //       )}
-  //     </div>
-  //   );
-  // };
-
-  // Close dropdown on outside click
-
+  // Close dropdown on outside click (listener only attached while open)
   useEffect(() => {
     if (!openDropdown) return;
     const handleClick = (e: MouseEvent) => {
@@ -133,6 +82,16 @@ const MenuBar: React.FC<MenuBarProps> = ({
     return () => document.removeEventListener("mousedown", handleClick);
   }, [openDropdown, setOpenDropdown]);
 
+  // Close dropdown on Escape from anywhere within the bar
+  useEffect(() => {
+    if (!openDropdown) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpenDropdown(null);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [openDropdown, setOpenDropdown]);
+
   return (
     <div className="menu-bar" ref={menuBarRef}>
       <div className="menu-left">
@@ -143,63 +102,48 @@ const MenuBar: React.FC<MenuBarProps> = ({
           width={24}
           height={24}
         />
-        {[
-          { label: "About", key: "about" },
-          { label: "Services", key: "services" },
-          // { label: "Tech Stack", key: "tech" },
-          { label: "Projects", key: "projects" },
-          // { label: "Contact", key: "contact" },
-        ].map((item, idx, arr) => (
-          <div
-            key={item.key}
-            className={`menu-item-wrapper${openDropdown === item.key ? " menu-item-wrapper-active" : ""
+        {MENU_ITEMS.map((item) => {
+          const isOpen = openDropdown === item.key;
+          return (
+            <div
+              key={item.key}
+              className={`menu-item-wrapper${
+                isOpen ? " menu-item-wrapper-active" : ""
               }`}
-            data-menu-index={idx}
-            style={{
-              zIndex: openDropdown === item.key ? 1010 : 1,
-              marginRight: idx < arr.length - 1 ? 16 : 0,
-            }}
-          >
-            <span
-              className={`menu-item${openDropdown === item.key ? " menu-item-active" : ""
-                }`}
-              tabIndex={0}
-              onMouseEnter={() => {
-                if (item.key === "about") preload.about();
-                if (item.key === "projects") preload.projects();
-                if (item.key === "contact") preload.contact();
-                if (item.key === "tech" || item.key === "services")
-                  preload.skillset();
-              }}
-              onClick={() =>
-                setOpenDropdown(openDropdown === item.key ? null : item.key)
-              }
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ")
-                  setOpenDropdown(openDropdown === item.key ? null : item.key);
-                if (e.key === "Escape") setOpenDropdown(null);
-              }}
-              aria-haspopup="true"
-              aria-expanded={openDropdown === item.key}
             >
-              {item.label}
-            </span>
-            {openDropdown === item.key && (
-              <div
-                className={`menu-dropdown menu-dropdown-mac${openDropdown === item.key ? " menu-dropdown-mac-active" : ""
-                  }`}
-                onClick={(e) => e.stopPropagation()}
+              <button
+                type="button"
+                className={`menu-item${isOpen ? " menu-item-active" : ""}`}
+                onMouseEnter={() => preloadFor(item.key)}
+                onFocus={() => preloadFor(item.key)}
+                onClick={() => toggleDropdown(item.key)}
+                aria-haspopup="menu"
+                aria-expanded={isOpen}
               >
-                {item.key === "about" && (
-                  <div>
+                {item.label}
+              </button>
+              {isOpen && (
+                <div
+                  className="menu-dropdown menu-dropdown-mac"
+                  role="menu"
+                  aria-label={item.label}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {item.key === "about" && (
                     <ul className="menu-dropdown-pills">
                       {aboutMePills.map((pill) => {
-                        const handlePillAction = () => {
+                        const isAction =
+                          pill.label === "& more..." || Boolean(pill.link);
+                        const handleAction = () => {
                           if (pill.label === "& more...") {
                             setShowAboutMe(true);
                             setOpenDropdown(null);
                           } else if (pill.link) {
-                            window.open(pill.link, "_blank");
+                            window.open(
+                              pill.link,
+                              "_blank",
+                              "noopener,noreferrer"
+                            );
                           }
                         };
                         return (
@@ -208,55 +152,71 @@ const MenuBar: React.FC<MenuBarProps> = ({
                             className="menu-dropdown-pill-item"
                           >
                             <span
-                              className={`pill-tag-mac ${pill.label === "& more..."
-                                  ? "pill-tag-clickable"
-                                  : ""
-                                }`}
-                              tabIndex={0}
-                              onMouseEnter={handlePillAction}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                  handlePillAction();
-                                }
-                              }}
+                              className={`pill-tag-mac${
+                                isAction ? " pill-tag-clickable" : ""
+                              }`}
+                              title={pill.tooltip}
+                              {...(isAction
+                                ? {
+                                    role: "menuitem",
+                                    tabIndex: 0,
+                                    onClick: handleAction,
+                                    onKeyDown: (
+                                      e: React.KeyboardEvent
+                                    ) => {
+                                      if (e.key === "Enter" || e.key === " ") {
+                                        e.preventDefault();
+                                        handleAction();
+                                      }
+                                    },
+                                  }
+                                : {})}
                             >
                               {pill.icon && (
                                 <div className="pill-tag-icon">
                                   <Image
                                     src={pill.icon}
-                                    alt={pill.label}
+                                    alt=""
                                     width={20}
                                     height={20}
                                   />
                                 </div>
                               )}
-                              <span className="pill-tag-label">{pill.label}</span>
+                              <span className="pill-tag-label">
+                                {pill.label}
+                              </span>
                             </span>
                           </li>
                         );
                       })}
                     </ul>
-                  </div>
-                )}
+                  )}
 
-                {item.key === "services" && (
-                  <div>
+                  {item.key === "services" && (
                     <ul className="menu-dropdown-services">
                       {services.map((service) => {
-                        const servicePreview = getServicePreview(service.description);
+                        const openSkillset = () => {
+                          setShowSkillset(true);
+                          setOpenDropdown(null);
+                        };
                         return (
                           <li
                             key={service.id}
                             className="menu-dropdown-service-item"
-                            onClick={() => {
-                              setShowSkillset(true);
-                              setOpenDropdown(null);
+                            role="menuitem"
+                            tabIndex={0}
+                            onClick={openSkillset}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                openSkillset();
+                              }
                             }}
                           >
                             {service.icon && (
                               <Image
                                 src={service.icon}
-                                alt={service.title}
+                                alt=""
                                 className="menu-dropdown-service-icon"
                                 width={38}
                                 height={38}
@@ -270,75 +230,72 @@ const MenuBar: React.FC<MenuBarProps> = ({
                                 className="menu-dropdown-service-desc"
                                 title={service.description}
                               >
-                                {servicePreview}
+                                {getServicePreview(service.description)}
                               </div>
                             </div>
                           </li>
                         );
                       })}
                     </ul>
-                  </div>
-                )}
-                {item.key === "projects" && (
-                  <div>
+                  )}
+
+                  {item.key === "projects" && (
                     <ul className="menu-dropdown-projects">
-                      {projectsData
-                        .filter((p) => !p.archived)
-                        .map((proj) => (
+                      {activeProjects.map((proj) => {
+                        const openProjects = () => {
+                          setShowProjects(true);
+                          setOpenDropdown(null);
+                        };
+                        let projectVisual: React.ReactNode = null;
+                        if (isImageIcon(proj.icon)) {
+                          projectVisual = (
+                            <span className="menu-dropdown-project-img menu-dropdown-project-img-icon">
+                              <Image
+                                src={proj.icon as string}
+                                alt=""
+                                className="menu-dropdown-project-img-media"
+                                width={50}
+                                height={50}
+                              />
+                            </span>
+                          );
+                        } else if (proj.icon) {
+                          projectVisual = (
+                            <span className="menu-dropdown-project-img menu-dropdown-project-icon">
+                              <FontAwesomeIcon
+                                icon={
+                                  PROJECT_ICON_MAP[proj.icon as string] ||
+                                  PROJECT_ICON_FALLBACK
+                                }
+                              />
+                            </span>
+                          );
+                        } else if (proj.image) {
+                          projectVisual = (
+                            <Image
+                              src={proj.image}
+                              alt=""
+                              className="menu-dropdown-project-img"
+                              width={78}
+                              height={78}
+                            />
+                          );
+                        }
+                        return (
                           <li
                             key={proj.id}
                             className="menu-dropdown-project-item"
-                            onClick={() => {
-                              setShowProjects(true);
-                              setOpenDropdown(null);
+                            role="menuitem"
+                            tabIndex={0}
+                            onClick={openProjects}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                openProjects();
+                              }
                             }}
                           >
-                            {(() => {
-                              let projectVisual = null;
-                              if (isImageIcon(proj.icon)) {
-                                projectVisual = (
-                                  <span className="menu-dropdown-project-img menu-dropdown-project-img-icon">
-                                    <Image
-                                      src={proj.icon as string}
-                                      alt={`${proj.name} icon`}
-                                      className="menu-dropdown-project-img-media"
-                                      width={50}
-                                      height={50}
-                                    />
-                                  </span>
-                                );
-                              } else if (proj.icon) {
-                                projectVisual = (
-                                  <span
-                                    className="menu-dropdown-project-img menu-dropdown-project-icon"
-                                    style={{
-                                      fontSize: 28,
-                                      display: "flex",
-                                      alignItems: "center",
-                                      justifyContent: "center",
-                                    }}
-                                  >
-                                    <FontAwesomeIcon
-                                      icon={
-                                        PROJECT_ICON_MAP[proj.icon as string] ||
-                                        PROJECT_ICON_FALLBACK
-                                      }
-                                    />
-                                  </span>
-                                );
-                              } else if (proj.image) {
-                                projectVisual = (
-                                  <Image
-                                    src={proj.image}
-                                    alt={proj.name}
-                                    className="menu-dropdown-project-img"
-                                    width={78}
-                                    height={78}
-                                  />
-                                );
-                              }
-                              return projectVisual;
-                            })()}
+                            {projectVisual}
                             <div className="menu-dropdown-project-info">
                               <div className="menu-dropdown-project-title">
                                 {proj.name}
@@ -346,61 +303,17 @@ const MenuBar: React.FC<MenuBarProps> = ({
                               <div className="menu-dropdown-project-desc">
                                 {proj.description}
                               </div>
-                              {/* <a
-                                href={proj.link}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="menu-dropdown-project-link"
-                              >
-                                Visit
-                              </a> */}
                             </div>
                           </li>
-                        ))}
+                        );
+                      })}
                     </ul>
-                  </div>
-                )}
-                {/* {item.key === "tech" && (
-                  <div>
-                    <div className="menu-dropdown-tech-categories">
-                      {techStackCategories.map((category) =>
-                        renderCategoryItem(category)
-                      )}
-                      <div className="tech-view-all">
-                        <button
-                          className="tech-view-all-btn"
-                          onClick={() => {
-                            setShowSkillset(true);
-                            setOpenDropdown(null);
-                          }}
-                          title="View complete tech stack"
-                        >
-                          View All Tools & Skills
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )} */}
-                {/* {item.key === "contact" && (
-                  <div className="menu-dropdown-contact-info">
-                    <div className="contact-info-text">
-                      <p>Ready to connect? Let&apos;s start a conversation!</p>
-                    </div>
-                    <button
-                      className="contact-trigger-btn"
-                      onClick={() => {
-                        setShowContactForm(true);
-                        setOpenDropdown(null);
-                      }}
-                    >
-                      Open Contact Form
-                    </button>
-                  </div>
-                )} */}
-              </div>
-            )}
-          </div>
-        ))}
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
       <div className="menu-right">
         <TimeDisplay />


### PR DESCRIPTION
## Summary

A UI/UX audit of the `MenuBar` and its three dropdowns (About, Services, Projects). This fixes several broken/unexpected interactions, makes the menu keyboard-accessible, and removes a large amount of dead code left behind by the removed Tech Stack and Contact menus.

## Broken interactions fixed

- **About pills fired on hover.** `onMouseEnter` was wired to the pill action, so simply moving the cursor across the About dropdown opened external links in new tabs (`window.open`) and/or opened the About modal. Actions now fire on **click / Enter / Space**.
- **"& more…" did nothing on click.** The only actionable pill had no `onClick` (only a hover + keydown handler), so a normal mouse click was a no-op. It's now a proper `role="menuitem"` control that opens the About view and closes the dropdown.
- **Trait pills were misleadingly interactive.** The six personality pills have no action, yet were focusable and hover-styled. They're now non-focusable and expose their description via `title` (that `tooltip` text was previously unrendered/dead).
- **Service & Project rows were mouse-only.** Added `role="menuitem"`, `tabIndex`, and Enter/Space handlers so they're keyboard operable.
- **Menu triggers are now real `<button>`s** (were focusable `<span>`s). Space no longer scrolls the page, and Escape now closes an open dropdown from anywhere within the bar.
- Added `role="menu"` / `role="menuitem"` and `aria-haspopup="menu"` semantics; external links open with `noopener,noreferrer`.

## Redundant / dead code removed

- Deleted the large commented-out Tech Stack and Contact markup in `MenuBar.tsx`, plus the unused `groupedTools`/`techStackCategories`/`renderCategoryItem` scaffolding and the unused `hoveredTechCategory` props.
- Removed ~640 lines of CSS that backed those removed menus and never-rendered elements: `tech-*`, `menu-dropdown-tech-*`, `menu-dropdown-contact-info`, `contact-*`, `pill-tooltip-mac`, `pill-side-*`, legacy `tech-category*`, `pill-tag-arrow`, `menu-dropdown-title`, and orphaned keyframes/media-query references.
- Dropped always-true class ternaries (`menu-dropdown-mac-active` etc.) and inline `zIndex`/`marginRight` styles that duplicated existing CSS rules.

## Performance / polish

- Fixed a hover rule that animated an **undefined `slideIn` keyframe** (no-op → replaced with an opacity transition).
- Replaced `transition: all` declarations with property-scoped transitions to avoid compositing unrelated properties.
- Memoized the active-projects filter so it doesn't re-run every render.

## Verification

- `tsc --noEmit` and `next lint` both pass.
- Drove the live app with Playwright and confirmed: menu buttons toggle with correct `aria-expanded`; hovering trait pills opens **0** tabs/modals; clicking "& more…" opens the About view; Enter on a Service row opens Skillset; outside-click and Escape both close dropdowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01844ugHKw5UJgLogC1DREHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01844ugHKw5UJgLogC1DREHN)_