### PR TITLE
AppViews UI/UX cleanup (pass 1): accent-token sweep, dead CSS, visible fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,12 @@
   --noir-accent-line: rgba(212, 132, 90, 0.3);
   --noir-surface: rgba(18, 13, 10, 0.55);
 
+  /* Documentary accent — the one non-warm hue, used by the "Documentary" tag
+     on media projects. Tokenized so the green isn't a bare literal. */
+  --noir-doc: #0f9d6b;
+  --noir-doc-soft: rgba(15, 157, 107, 0.08);
+  --noir-doc-line: rgba(15, 157, 107, 0.32);
+
   /* ===== Liquid Glass tokens (Dark Glass) =====
      Ported from the codepenz "Liquid Glass UI Kit" (Component 02 · Dark Glass).
      Structural only — the warm --noir-accent palette supplies the color so the

--- a/src/components/features/about/AboutAppView/AboutAppView.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.css
@@ -96,7 +96,7 @@
 .about-rail-item:focus-visible,
 .about-prog-arrow:focus-visible,
 .about-pill:focus-visible {
-  outline: 2px solid rgba(182, 95, 56, 0.55);
+  outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
 }
 
@@ -249,9 +249,9 @@
 }
 
 .about-highlight-card:hover {
-  border-color: rgba(182, 95, 56, 0.24);
+  border-color: var(--noir-accent-line);
   transform: translateY(-2px);
-  background: rgba(182, 95, 56, 0.05);
+  background: var(--noir-accent-soft);
 }
 
 .about-highlight-card h3 {
@@ -327,18 +327,18 @@
 }
 
 .about-pill.clickable {
-  border-color: rgba(182, 95, 56, 0.24);
+  border-color: var(--noir-accent-line);
 }
 
 .about-pill:hover {
-  border-color: rgba(182, 95, 56, 0.4);
+  border-color: var(--noir-accent-line);
   color: rgba(240, 236, 232, 0.9);
   transform: translateY(-1px);
 }
 
 .about-pill.active {
   color: #fff;
-  border-color: rgba(182, 95, 56, 0.8);
+  border-color: var(--noir-accent);
   background: var(--about-accent);
   box-shadow: 0 3px 12px var(--about-accent-glow);
 }
@@ -350,12 +350,12 @@
 
 .about-strength-detail {
   margin-top: 0.5rem;
-  border: 1px solid rgba(182, 95, 56, 0.2);
+  border: 1px solid var(--noir-accent-line);
   border-radius: 0.78rem;
   padding: 0.75rem 0.85rem;
   background:
-    radial-gradient(circle at 0% 0%, rgba(182, 95, 56, 0.08), transparent 60%),
-    rgba(255, 255, 255, 0.03);
+    radial-gradient(circle at 0% 0%, rgba(212, 132, 90, 0.08), transparent 60%),
+    var(--noir-panel);
   box-shadow: 0 8px 24px rgba(22, 20, 18, 0.12);
 }
 
@@ -411,8 +411,8 @@
 }
 
 .about-prog-arrow:hover:not(:disabled) {
-  background: rgba(182, 95, 56, 0.14);
-  border-color: rgba(182, 95, 56, 0.38);
+  background: var(--noir-accent-soft);
+  border-color: var(--noir-accent-line);
   color: var(--about-accent);
   transform: scale(1.05);
 }
@@ -434,7 +434,7 @@
 }
 
 .about-prog-current {
-  color: rgba(182, 95, 56, 0.75);
+  color: var(--noir-accent);
 }
 
 .about-prog-sep {
@@ -464,7 +464,7 @@
 }
 
 .about-featured-card:hover {
-  border-color: rgba(182, 95, 56, 0.24);
+  border-color: var(--noir-accent-line);
   transform: translateY(-2px);
 }
 
@@ -602,10 +602,6 @@
   background: var(--about-accent);
   color: #fff;
   transform: translateY(-1px);
-}
-
-.about-featured-cta--link {
-  /* inherits the same styles, rendered as <a> */
 }
 
 /* ── Responsive ───────────────────────────────────────── */

--- a/src/components/features/about/AboutAppView/AboutAppView.tsx
+++ b/src/components/features/about/AboutAppView/AboutAppView.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import React, { useCallback, useMemo, useState, type CSSProperties } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronLeft, faChevronRight, faArrowUpRightFromSquare, faPlay, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
@@ -102,7 +102,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
   const [chapterIndex, setChapterIndex] = useState(0);
   const [direction, setDirection] = useState<1 | -1>(1);
   const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
-  const heroListRef = useRef<HTMLUListElement>(null);
+  const reduceMotion = useReducedMotion();
 
   const chapter = chapters[chapterIndex];
 
@@ -113,11 +113,17 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
     }, {});
   }, []);
 
-  useEffect(() => {
-    const target = heroListRef.current?.querySelector<HTMLLIElement>(
+  // Center the "start" word within the hero list itself (not the page) each
+  // time the list mounts — including when the Profile chapter is revisited.
+  // A callback ref (not a mount-only effect) is used because AnimatePresence
+  // unmounts and remounts the chapter, so the old `[]`-deps effect never re-ran.
+  const centerHeroList = useCallback((node: HTMLUListElement | null) => {
+    if (!node) return;
+    const target = node.querySelector<HTMLLIElement>(
       `[data-index="${ABOUT_HERO_START_INDEX}"]`
     );
-    target?.scrollIntoView({ block: "center" });
+    if (!target) return;
+    node.scrollTop = target.offsetTop - (node.clientHeight - target.clientHeight) / 2;
   }, []);
 
   const goToChapter = (index: number) => {
@@ -229,7 +235,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
         <>
           <div className="about-hero">
             <div className="about-hero-phrase">I build</div>
-            <ul className="about-hero-scroll" ref={heroListRef}>
+            <ul className="about-hero-scroll" ref={centerHeroList}>
               <li className="about-hero-pad" aria-hidden="true" />
               {ABOUT_HERO_WORDS.map((word, i) => (
                 <li
@@ -324,7 +330,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
+              transition={reduceMotion ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }}
             >
               <p className="about-strength-detail-title">{activeTooltip}</p>
               <p className="about-strength-detail-copy">
@@ -370,7 +376,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
                 initial="enter"
                 animate="center"
                 exit="exit"
-                transition={{ duration: 0.26, ease: [0.25, 0.46, 0.45, 0.94] }}
+                transition={reduceMotion ? { duration: 0 } : { duration: 0.26, ease: [0.25, 0.46, 0.45, 0.94] }}
                 className="about-chapter"
                 aria-labelledby="about-title"
               >

--- a/src/components/features/portfolio/ProjectDetailModal/ProjectDetailModal.module.css
+++ b/src/components/features/portfolio/ProjectDetailModal/ProjectDetailModal.module.css
@@ -68,9 +68,9 @@
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.05em;
-  color: #0f9d6b;
-  border: 1px solid rgba(15, 157, 107, 0.32);
-  background: rgba(15, 157, 107, 0.08);
+  color: var(--noir-doc);
+  border: 1px solid var(--noir-doc-line);
+  background: var(--noir-doc-soft);
   border-radius: 999px;
   padding: 0.18rem 0.48rem;
   width: fit-content;

--- a/src/components/features/portfolio/ProjectDetailModal/ProjectDetailModal.tsx
+++ b/src/components/features/portfolio/ProjectDetailModal/ProjectDetailModal.tsx
@@ -30,7 +30,11 @@ const ProjectDetailModal: React.FC<ProjectDetailModalProps> = ({
       closeAriaLabel="Back to projects"
     >
       <div className={styles.detail}>
-        <motion.div layoutId={`project-media-${project.id}`} className={styles.media}>
+        <motion.div
+          layoutId={`project-media-${project.id}`}
+          className={styles.media}
+          aria-hidden="true"
+        >
           <ProjectMedia
             project={project}
             iconImageClassName={styles.iconImg}

--- a/src/components/features/portfolio/ProjectsAppView/ProjectTile.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectTile.tsx
@@ -14,8 +14,12 @@ interface ProjectTileProps {
 
 const ProjectTile: React.FC<ProjectTileProps> = ({ project, onOpen }) => {
   return (
-    <Card as="button" className={styles.tile} onClick={() => onOpen(project.id)}>
-      <motion.div layoutId={`project-media-${project.id}`} className={styles.media}>
+    <Card as="button" variant="flat" className={styles.tile} onClick={() => onOpen(project.id)}>
+      <motion.div
+        layoutId={`project-media-${project.id}`}
+        className={styles.media}
+        aria-hidden="true"
+      >
         <ProjectMedia
           project={project}
           iconImageClassName={styles.iconImg}

--- a/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
@@ -82,7 +82,7 @@ const ProjectsAppView: React.FC<ModalProps> = ({ onClose }) => {
 
           <div className={styles.stage}>
             {visibleProjects.length > 0 ? (
-              <Grid minItemWidth="200px" gap="md" className={styles.grid}>
+              <Grid minItemWidth="200px" gap="md" fill="fit" className={styles.grid}>
                 {visibleProjects.map((project) => (
                   <ProjectTile
                     key={project.id}

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.css
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.css
@@ -69,7 +69,7 @@
 .plate-arrow:focus-visible,
 .plate-dot:focus-visible,
 .skill-studio-byline:focus-visible {
-  outline: 2px solid rgba(182, 95, 56, 0.55);
+  outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
 }
 
@@ -91,7 +91,7 @@
 
 .skill-studio-byline:hover {
   color: var(--skill-accent);
-  border-color: rgba(182, 95, 56, 0.28);
+  border-color: var(--noir-accent-line);
   background: var(--skill-accent-soft);
 }
 
@@ -139,8 +139,8 @@
   border-radius: 50%;
   background: radial-gradient(
     circle at 50% 45%,
-    rgba(182, 95, 56, 0.18) 0%,
-    rgba(182, 95, 56, 0.05) 55%,
+    rgba(212, 132, 90, 0.18) 0%,
+    rgba(212, 132, 90, 0.05) 55%,
     transparent 72%
   );
   margin-bottom: 0.2rem;
@@ -151,14 +151,14 @@
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  border: 1px solid rgba(182, 95, 56, 0.2);
+  border: 1px solid var(--noir-accent-line);
 }
 
 .plate-icon {
   width: 72px;
   height: auto;
   object-fit: contain;
-  filter: drop-shadow(0 8px 24px rgba(182, 95, 56, 0.28));
+  filter: drop-shadow(0 8px 24px rgba(212, 132, 90, 0.28));
 }
 
 .plate-counter {
@@ -169,7 +169,7 @@
 }
 
 .counter-current {
-  color: rgba(182, 95, 56, 0.75);
+  color: var(--noir-accent);
 }
 
 .counter-sep {
@@ -239,8 +239,8 @@
 }
 
 .plate-arrow:hover {
-  background: rgba(182, 95, 56, 0.14);
-  border-color: rgba(182, 95, 56, 0.38);
+  background: var(--noir-accent-soft);
+  border-color: var(--noir-accent-line);
   color: var(--skill-accent);
   transform: scale(1.05);
 }
@@ -260,7 +260,7 @@
   height: 6px;
   width: 6px;
   border-radius: 999px;
-  background: rgba(43, 42, 40, 0.18);
+  background: var(--noir-faint);
   border: 0;
   padding: 0;
   cursor: pointer;
@@ -280,7 +280,7 @@
 }
 
 .plate-dot:hover:not(.active) {
-  background: rgba(43, 42, 40, 0.38);
+  background: var(--noir-muted);
 }
 
 /* ── Toolbelt: force-directed graph ───────────────────── */

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { motion, AnimatePresence, type Variants } from "framer-motion";
+import { motion, AnimatePresence, useReducedMotion, type Variants } from "framer-motion";
 import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
 import services from "@/data/services";
@@ -37,28 +37,34 @@ const serviceOutcomes: Record<string, string> = {
 // Tools highlighted with the signature stroke/glow in the toolbelt graph.
 const signatureStack = ["React", "JavaScript", "Next.js", "Node.js", "AWS"];
 
-const plateVariants: Variants = {
-  enter: (dir: number) => ({ opacity: 0, x: dir > 0 ? 40 : -40 }),
-  center: {
-    opacity: 1,
-    x: 0,
-    transition: { duration: 0.32, ease: [0.16, 1, 0.3, 1] },
-  },
-  exit: (dir: number) => ({
-    opacity: 0,
-    x: dir > 0 ? -28 : 28,
-    transition: { duration: 0.16, ease: "easeIn" },
-  }),
-};
-
 const SkillsetAppView: React.FC<ModalProps> = ({ onClose }) => {
   const [activeTab, setActiveTab] = useState<SkillsetTab>("services");
 
   // Services carousel state
   const [serviceIndex, setServiceIndex] = useState(0);
   const [direction, setDirection] = useState<1 | -1>(1);
+  const reduceMotion = useReducedMotion();
 
   const service = services[serviceIndex];
+
+  // Plate slide timings collapse to instant under prefers-reduced-motion; the
+  // enter/exit offsets stay so AnimatePresence still swaps plates correctly.
+  const plateVariants: Variants = useMemo(
+    () => ({
+      enter: (dir: number) => ({ opacity: 0, x: dir > 0 ? 40 : -40 }),
+      center: {
+        opacity: 1,
+        x: 0,
+        transition: reduceMotion ? { duration: 0 } : { duration: 0.32, ease: [0.16, 1, 0.3, 1] },
+      },
+      exit: (dir: number) => ({
+        opacity: 0,
+        x: dir > 0 ? -28 : 28,
+        transition: reduceMotion ? { duration: 0 } : { duration: 0.16, ease: "easeIn" },
+      }),
+    }),
+    [reduceMotion]
+  );
 
   const navigateService = (dir: 1 | -1) => {
     if (services.length <= 1) return;
@@ -127,7 +133,7 @@ const SkillsetAppView: React.FC<ModalProps> = ({ onClose }) => {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
+              transition={reduceMotion ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }}
               className="skill-services"
               role="tabpanel"
               id="services-panel"
@@ -158,7 +164,6 @@ const SkillsetAppView: React.FC<ModalProps> = ({ onClose }) => {
                         width={72}
                         height={72}
                         className="plate-icon"
-                        priority
                       />
                     </div>
 
@@ -228,7 +233,7 @@ const SkillsetAppView: React.FC<ModalProps> = ({ onClose }) => {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
+              transition={reduceMotion ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }}
               className="skill-tools"
               role="tabpanel"
               id="tools-panel"

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
@@ -170,8 +170,10 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({ tools, orderedCategories,
     const height = wrapEl.clientHeight;
     const svg = d3.select(svgEl).attr("viewBox", `0 0 ${width} ${height}`);
 
-    const linkLayer = svg.append("g").attr("class", styles.links);
-    const nodeLayer = svg.append("g").attr("class", styles.nodesLayer);
+    // Organizational group layers; the per-child .link/.node classes carry the
+    // actual styling, so these wrappers need no class of their own.
+    const linkLayer = svg.append("g");
+    const nodeLayer = svg.append("g");
 
     const simulation = d3
       .forceSimulation<SimNode>()

--- a/src/components/features/skills/index.ts
+++ b/src/components/features/skills/index.ts
@@ -1,5 +1,0 @@
-// Skills feature components barrel exports
-export { default as SkillsetAppView } from './SkillsetAppView/SkillsetAppView';
-
-// Re-export types if needed
-export type * from './SkillsetAppView/SkillsetAppView';

--- a/src/components/ui/FilterBar/FilterBar.tsx
+++ b/src/components/ui/FilterBar/FilterBar.tsx
@@ -50,7 +50,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
       </div>
 
       {facets && facets.length > 0 && onFacetToggle && (
-        <div className="glass-chip-list" aria-label={facetListLabel}>
+        <div className="glass-chip-list" role="group" aria-label={facetListLabel}>
           {facets.map((facet) => (
             <Chip
               key={facet}

--- a/src/components/ui/Grid/Grid.module.css
+++ b/src/components/ui/Grid/Grid.module.css
@@ -4,6 +4,12 @@
   width: 100%;
 }
 
+/* auto-fit collapses empty tracks so a few items expand to fill the row,
+   instead of auto-fill's phantom trailing columns on wide viewports. */
+.fit {
+  grid-template-columns: repeat(auto-fit, minmax(clamp(140px, 30vw, var(--grid-min-item, 220px)), 1fr));
+}
+
 .gapSm { gap: 0.5rem; }
 .gapMd { gap: 1rem; }
 .gapLg { gap: 1.5rem; }

--- a/src/components/ui/Grid/Grid.tsx
+++ b/src/components/ui/Grid/Grid.tsx
@@ -6,6 +6,13 @@ import styles from "./Grid.module.css";
 interface GridProps {
   minItemWidth?: string;
   gap?: "sm" | "md" | "lg";
+  /**
+   * "fill" (default) reserves empty tracks so column widths stay stable
+   * (auto-fill). "fit" collapses empty tracks so a few items expand to fill
+   * the row (auto-fit) — use it when the item count is small relative to the
+   * container width, e.g. a full-screen gallery.
+   */
+  fill?: "fill" | "fit";
   className?: string;
   children: React.ReactNode;
 }
@@ -13,6 +20,7 @@ interface GridProps {
 const Grid: React.FC<GridProps> = ({
   minItemWidth = "220px",
   gap = "md",
+  fill = "fill",
   className = "",
   children,
 }) => {
@@ -20,7 +28,9 @@ const Grid: React.FC<GridProps> = ({
 
   return (
     <div
-      className={[styles.grid, gapClass, className].filter(Boolean).join(" ")}
+      className={[styles.grid, fill === "fit" ? styles.fit : "", gapClass, className]
+        .filter(Boolean)
+        .join(" ")}
       style={{ "--grid-min-item": minItemWidth } as React.CSSProperties}
     >
       {children}


### PR DESCRIPTION
## Summary

First of a sequenced audit/cleanup of the three full-screen AppViews (About, Skillset, Projects). This pass is the low-risk cleanup + visible-bug tier; the graph-interactivity rewrite and deeper accessibility work follow in separate PRs.

The headline fix is **design-token drift that rendered as a visible two-orange bug**: About and Skillset hardcoded `rgba(182,95,56,…)` (the legacy `--light-accent`) for hover/border/focus/glow states while binding their local accent to `--noir-accent` (`#d4845a`), so two different oranges showed on the same screen. Everything now routes through the noir accent tokens.

### Changes
- **Accent-token sweep** across `AboutAppView.css` (12×) and `SkillsetAppView.css` (9×) → `--noir-accent` / `-soft` / `-line` / `-glow`. Kills the two-orange bug and the two-tone active-pill edge.
- **Visible bugs**
  - Skillset carousel dots were near-invisible (dark-on-dark `rgba(43,42,40)`); now `--noir-faint` idle / `--noir-muted` hover / accent active.
  - About hero re-centers on its start word every time the Profile chapter is revisited — the old `[]`-deps effect never re-ran because `AnimatePresence` unmounts the chapter. Now a callback ref, scoped to scroll the hero list only (not the page).
- **Dead / redundant CSS removed**: empty `.about-featured-cta--link {}`, the unused `skills/index.ts` barrel, and the undefined `styles.links`/`styles.nodesLayer` references in `ToolbeltGraph`.
- **Tokens**: added `--noir-doc` for the documentary-tag green (was a bare `#0f9d6b`).
- **Accessibility**: decorative project media is `aria-hidden` so tile/detail names stop duplicating in the a11y tree (e.g. "Yap United icon Yap United 2025-2026"); `role="group"` on the facet chip list; About + Skillset framer-motion now gated on `useReducedMotion()` (was CSS-only).
- **Performance/layout**: Projects tiles use `Card variant="flat"` (drop per-tile `backdrop-filter` over the solid AppView background); dropped the per-plate `priority` (it fired for every plate paged to); `Grid` gains an opt-in `fill="fit"` (auto-fit) so the full-screen gallery fills the row instead of leaving phantom trailing columns.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Playwright against `npm run dev`:
  - [x] About/Skillset/Projects each render a single consistent accent (verified active pill, "01/05" counters, carousel dots)
  - [x] Skillset inactive dots now visible (`rgba(240,236,232,0.3)`, was near-black)
  - [x] Leave + return to the About Profile chapter → hero re-centered on the start word (scrollTop > 0)
  - [x] Projects gallery fills the width with no trailing empty columns (`grid-template-columns` resolves to evenly-sized tracks)
  - [x] No console/page errors

Follow-ups (separate PRs): Skillset graph state-preservation + incremental d3 updates; keyboard/focus accessibility (graph keyboard ops, modal focus trap/restore, `<h1>` promotion, full FilterBar tab pattern).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RQXP7RGdphM6GegaWkBVND)_