### PR TITLE
DesktopIcons: preload on selection, notification-badge a11y, live reduced-motion

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -11,11 +11,8 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* slightly larger on desktop for the main desktop icon set (JS sets the
-   actual per-row size inline; this is just the fallback/base value) */
+/* The per-row icon size is set inline by JS; only the rounding is styled here. */
 .desktop-wheel-row .icon-image {
-  width: 84px;
-  height: 84px;
   border-radius: 16px;
 }
 

--- a/src/components/layout/LandingPage/components/DesktopIcons.tsx
+++ b/src/components/layout/LandingPage/components/DesktopIcons.tsx
@@ -73,8 +73,21 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
   const wheelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setPrefersReducedMotion(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mql.matches);
+    const onChange = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
   }, []);
+
+  // Preload the centered app's route whenever the selection changes, so a
+  // launch is instant no matter how the row was centered (drag, wheel, or
+  // keyboard). Hover/touch still preload eagerly for rows the pointer passes
+  // over without centering. preloadByPath is idempotent (dynamic-import cache)
+  // and maybePreloadByPath is stable, so this is cheap to run on every change.
+  useEffect(() => {
+    maybePreloadByPath(DESKTOP_APPS[active].path);
+  }, [active, maybePreloadByPath]);
 
   const bounds = useMemo(
     () => ({
@@ -161,8 +174,8 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
 
   // Keyboard control follows the ARIA listbox pattern: focus stays on the
   // wheel container while aria-activedescendant tracks the centered option.
-  // Arrow keys move the selection (and preload its route like pointer hover
-  // does); Enter/Space launches the selected app.
+  // Arrow keys move the selection (its route is preloaded by the active-change
+  // effect above); Enter/Space launches the selected app.
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
@@ -191,7 +204,6 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
     event.preventDefault();
     if (next === active) return;
     setActive(next);
-    maybePreloadByPath(DESKTOP_APPS[next].path);
   }
 
   // React attaches "wheel" as a passive listener by default, so preventDefault
@@ -315,6 +327,7 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
           const opacity = clamp(1 - 0.65 * t, 0.35, 1);
           const isActive = index === active;
           const iconSize = isActive ? ACTIVE_ICON_SIZE : Math.round(BASE_ICON_SIZE * scale);
+          const hasNotification = app.name === "Contact" && showContactNotification;
 
           return (
             <div
@@ -323,6 +336,9 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
               data-row-index={index}
               role="option"
               aria-selected={isActive}
+              // Surface the otherwise purely-visual "!" badge to assistive
+              // tech by folding it into the option's accessible name.
+              aria-label={hasNotification ? `${app.name}, new notification` : undefined}
               className="desktop-wheel-row"
               style={{
                 transform: `translateY(-50%) translate(${-curveX}px, ${translateY}px)`,
@@ -356,8 +372,10 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
                     <FontAwesomeIcon icon={app.icon} />
                   </span>
                 </div>
-                {app.name === "Contact" && showContactNotification && (
-                  <div className="notification-badge">!</div>
+                {hasNotification && (
+                  <div className="notification-badge" aria-hidden="true">
+                    !
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary

A second follow-up pass on the `DesktopIcons` picker (the first, #37, is merged). These address remaining interactivity, accessibility, and cleanup opportunities.

## Changes

- **Preload on selection change.** Added an effect that preloads the centered app's route whenever the selection changes, so launching is instant regardless of *how* the row was centered. Previously only hover / touch / keyboard preloaded — **drag and wheel releases never did**, so flinging to an app and tapping it paid the dynamic-import cost cold. The manual preload call in the key handler is removed since the effect now covers keyboard too (dynamic-import preloading is idempotent via the module cache, and `maybePreloadByPath` is stable).
- **Notification-badge accessibility.** The Contact `!` badge was a purely visual `<div>` with no accessible name, so screen-reader users had no signal that Contact had a pending notification. It's now folded into the option's accessible name (`aria-label="Contact, new notification"`) and the decorative glyph is marked `aria-hidden`.
- **Live `prefers-reduced-motion`.** The preference was read once at mount; it now subscribes to the media query so toggling the OS setting mid-session enables/disables the row transitions immediately.
- **CSS cleanup.** Dropped the redundant `width`/`height: 84px` from the `.desktop-wheel-row .icon-image` fallback rule — JS always sets the per-row size inline, so only the `border-radius` was ever doing anything there.

## Notes

- The sibling `AppSwitcher` (mobile pill switcher) has the same purely-visual notification badge; folding it into an accessible name there too would be a small parallel follow-up, left out here to keep this scoped to the audited desktop component.
- `DesktopRain` keeps its mount-time reduced-motion decision (it skips WebGL init entirely under reduced motion rather than creating a context that would never animate); this pass only makes the `DesktopIcons` transitions responsive to live changes.

## Verification

- `npx tsc --noEmit` passes.
- `npx next lint` on the component reports no warnings or errors.
- `npm run build` compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151DTJXRkDB6XKrwdHBxZww)_