### PR TITLE
AppViews accessibility: graph keyboard, headings, tab pattern, focus restore (pass 3)

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.tsx
+++ b/src/components/features/about/AboutAppView/AboutAppView.tsx
@@ -304,7 +304,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
                 }`}
                 onClick={() => handlePillClick(pill)}
                 aria-expanded={isActive}
-                aria-controls="about-strength-detail"
+                aria-controls={isActive ? "about-strength-detail" : undefined}
               >
                 <span>{pill.label}</span>
                 {pill.link && (
@@ -367,7 +367,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
 
         {/* ── Stage ────────────────────────────────────── */}
         <div className="about-stage-wrap">
-          <div className="about-stage" aria-live="polite">
+          <div className="about-stage">
             <AnimatePresence mode="wait" custom={direction}>
               <motion.section
                 key={chapter.id}

--- a/src/components/features/modal/ModalShell.tsx
+++ b/src/components/features/modal/ModalShell.tsx
@@ -19,6 +19,9 @@ const ModalShell: React.FC<ModalShellProps> = ({
   useEffect(() => {
     pushOverlay(instanceId);
     lockBodyScroll();
+    // Return focus here (the trigger) when this overlay closes, so keyboard
+    // users don't get dropped to <body>.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape" && isTopmostOverlay(instanceId)) {
@@ -33,6 +36,7 @@ const ModalShell: React.FC<ModalShellProps> = ({
       popOverlay(instanceId);
       document.removeEventListener("keydown", handleKeyDown);
       unlockBodyScroll();
+      previouslyFocused?.focus?.();
     };
   }, [onClose, instanceId]);
 

--- a/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
@@ -77,10 +77,16 @@ const ProjectsAppView: React.FC<ModalProps> = ({ onClose }) => {
               onFacetToggle={handleFacetToggle}
               tabListLabel="Project categories"
               facetListLabel="Filter by technology"
+              panelId="projects-panel"
             />
           </div>
 
-          <div className={styles.stage}>
+          <div
+            className={styles.stage}
+            role="tabpanel"
+            id="projects-panel"
+            aria-labelledby={`projects-panel-tab-${activeTab}`}
+          >
             {visibleProjects.length > 0 ? (
               <Grid minItemWidth="200px" gap="md" fill="fit" className={styles.grid}>
                 {visibleProjects.map((project) => (

--- a/src/components/features/shell/AppView.tsx
+++ b/src/components/features/shell/AppView.tsx
@@ -28,6 +28,8 @@ const AppView: React.FC<AppViewProps> = ({ onClose, title, headerActions, titleI
   useEffect(() => {
     pushOverlay(instanceId);
     lockBodyScroll();
+    // Return focus to the trigger (desktop icon / app switcher) on close.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape" && isTopmostOverlay(instanceId)) {
@@ -42,6 +44,7 @@ const AppView: React.FC<AppViewProps> = ({ onClose, title, headerActions, titleI
       popOverlay(instanceId);
       document.removeEventListener("keydown", handleKeyDown);
       unlockBodyScroll();
+      previouslyFocused?.focus?.();
     };
   }, [onClose, instanceId]);
 
@@ -86,9 +89,9 @@ const AppView: React.FC<AppViewProps> = ({ onClose, title, headerActions, titleI
           </button>
         </div>
 
-        <span id={resolvedTitleId} className={styles.titleText}>
+        <h1 id={resolvedTitleId} className={styles.titleText}>
           {title}
-        </span>
+        </h1>
 
         <div className={styles.headerActions}>
           {headerActions ?? <div className={styles.headerSpacer} aria-hidden="true" />}

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
@@ -105,6 +105,16 @@
   stroke: var(--noir-accent-line);
 }
 
+/* Keyboard focus ring on category nodes (SVG <g> is focusable via tabindex). */
+.node:focus {
+  outline: none;
+}
+
+.node:focus-visible circle {
+  stroke: var(--noir-accent);
+  stroke-width: 3px;
+}
+
 .node title {
   pointer-events: none;
 }

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as d3 from "d3";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
@@ -208,6 +208,16 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     [isSearching, collapsed]
   );
 
+  // Shared by pointer click and keyboard (Enter/Space) on category nodes.
+  const toggleCategory = useCallback((id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
   // ── Mount-once: create svg layers, simulation, and the tick/drag handlers ──
   useEffect(() => {
     const svgEl = svgRef.current;
@@ -347,13 +357,14 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
         g.append("text").attr("text-anchor", "middle");
 
         g.on("click", (_event, d) => {
+          if (d.hasChildren) toggleCategory(d.id);
+        });
+        g.on("keydown", (event, d) => {
           if (!d.hasChildren) return;
-          setCollapsed((prev) => {
-            const next = new Set(prev);
-            if (next.has(d.id)) next.delete(d.id);
-            else next.add(d.id);
-            return next;
-          });
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            toggleCategory(d.id);
+          }
         });
 
         g.call(
@@ -382,6 +393,16 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
 
     nodeSel.classed(styles.signature, (d) => Boolean(d.isSignature));
     nodeSel.classed(styles.hasHiddenChildren, (d) => effectiveCollapsed.has(d.id));
+
+    // Category nodes are keyboard-operable buttons; leaves stay non-focusable
+    // (exposed via their <title>). aria-expanded refreshes on every update.
+    nodeSel
+      .attr("tabindex", (d) => (d.hasChildren ? 0 : null))
+      .attr("role", (d) => (d.hasChildren ? "button" : null))
+      .attr("aria-label", (d) => (d.hasChildren ? d.name : null))
+      .attr("aria-expanded", (d) =>
+        d.hasChildren ? String(!effectiveCollapsed.has(d.id)) : null
+      );
 
     nodeSel
       .select<SVGCircleElement>("circle")
@@ -414,7 +435,7 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     // Gentle re-heat: existing nodes are already near equilibrium so they barely
     // move; only new/changed nodes settle. alphaDecay makes reduced-motion snap.
     simulation.alpha(0.3).restart();
-  }, [tree, effectiveCollapsed, resizeTick, active, prefersReducedMotion]);
+  }, [tree, effectiveCollapsed, resizeTick, active, prefersReducedMotion, toggleCategory]);
 
   return (
     <div ref={wrapRef} className={styles.stage}>
@@ -444,7 +465,12 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
         ))}
       </div>
 
-      <svg ref={svgRef} className={styles.svg} />
+      <svg
+        ref={svgRef}
+        className={styles.svg}
+        role="group"
+        aria-label="Toolbelt skills graph"
+      />
     </div>
   );
 };

--- a/src/components/ui/FilterBar/FilterBar.tsx
+++ b/src/components/ui/FilterBar/FilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useRef } from "react";
 import Chip from "../Chip/Chip";
 import styles from "./FilterBar.module.css";
 
@@ -19,6 +19,9 @@ interface FilterBarProps {
   onFacetToggle?: (facet: string) => void;
   tabListLabel?: string;
   facetListLabel?: string;
+  /** id of the panel these tabs control — enables aria-controls + stable tab
+   *  ids (so the panel can be aria-labelledby the active tab). */
+  panelId?: string;
 }
 
 const FilterBar: React.FC<FilterBarProps> = ({
@@ -30,23 +33,49 @@ const FilterBar: React.FC<FilterBarProps> = ({
   onFacetToggle,
   tabListLabel = "Filter categories",
   facetListLabel = "Filter by tag",
+  panelId,
 }) => {
+  const tabListRef = useRef<HTMLDivElement>(null);
+
+  // WAI-ARIA tabs keyboard pattern: arrows/Home/End move selection + focus.
+  const handleTabKeyDown = (event: React.KeyboardEvent, index: number) => {
+    let next: number | null = null;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") next = (index + 1) % tabs.length;
+    else if (event.key === "ArrowLeft" || event.key === "ArrowUp")
+      next = (index - 1 + tabs.length) % tabs.length;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = tabs.length - 1;
+    if (next === null) return;
+    event.preventDefault();
+    onTabChange(tabs[next].key);
+    tabListRef.current
+      ?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+      [next]?.focus();
+  };
+
   return (
     <div className={styles.filterBar}>
-      <div className="glass-tab-list" role="tablist" aria-label={tabListLabel}>
-        {tabs.map((tab) => (
-          <button
-            key={tab.key}
-            type="button"
-            role="tab"
-            className={`glass-tab ${activeTab === tab.key ? "active" : ""}`}
-            aria-selected={activeTab === tab.key}
-            onClick={() => onTabChange(tab.key)}
-          >
-            {tab.label}
-            {typeof tab.count === "number" ? ` (${tab.count})` : ""}
-          </button>
-        ))}
+      <div ref={tabListRef} className="glass-tab-list" role="tablist" aria-label={tabListLabel}>
+        {tabs.map((tab, index) => {
+          const selected = activeTab === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              id={panelId ? `${panelId}-tab-${tab.key}` : undefined}
+              className={`glass-tab ${selected ? "active" : ""}`}
+              aria-selected={selected}
+              aria-controls={panelId}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => onTabChange(tab.key)}
+              onKeyDown={(event) => handleTabKeyDown(event, index)}
+            >
+              {tab.label}
+              {typeof tab.count === "number" ? ` (${tab.count})` : ""}
+            </button>
+          );
+        })}
       </div>
 
       {facets && facets.length > 0 && onFacetToggle && (


### PR DESCRIPTION
## Summary

Third audit pass (follows #39, #41) — the contained accessibility wins. The one wide-blast-radius item, a Tab-cycling focus **trap** across every overlay, is intentionally split into a follow-up PR so it gets isolated cross-overlay verification; this PR ships the safe, high-value pieces.

### Changes
- **Toolbelt graph is keyboard-operable** (`ToolbeltGraph.tsx` + `.module.css`): the `<svg>` gets `role="group"` + `aria-label`; each category node is now a real button (`tabindex=0`, `role="button"`, `aria-expanded`, `aria-label`) that toggles on **Enter/Space** (shared with the click handler), with a `:focus-visible` ring. Leaf nodes stay non-focusable, exposed via their `<title>`. Previously the graph was mouse-only and unlabeled.
- **Heading hierarchy** (`AppView.tsx`): the shell title is a real `<h1>` (was a `<span>`), so each app view has a proper top heading and inner `h2`/`h3` descend cleanly. Visual is identical (same class).
- **Focus restoration** (`ModalShell.tsx`, `AppView.tsx`): capture `document.activeElement` on open and restore it on close, so closing an overlay returns keyboard focus to the trigger (desktop icon / originating tile) instead of dropping to `<body>`.
- **FilterBar tab pattern** (`FilterBar.tsx`, `ProjectsAppView.tsx`): implements the WAI-ARIA tabs keyboard pattern (roving `tabindex` + Left/Right/Home/End) and wires `aria-controls` + tab ids to the gallery stage, which is now `role="tabpanel"` `aria-labelledby` the active tab. (FilterBar is used only by Projects — confirmed contained.)
- **About live regions** (`AboutAppView.tsx`): removed the over-broad `aria-live="polite"` on the chapter stage (it re-announced the entire chapter on every nav; the scoped `role="status"` strength-detail region stays), and the strength pills only set `aria-controls` while their detail panel is open (drops the dangling reference).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Playwright against `npm run dev`:
  - [x] Graph `<svg>` `role="group"`; 9 category button nodes; focus one + Enter → `aria-expanded` false→true and it expands (9→18 circles)
  - [x] "Skillset" renders as an `<h1>`
  - [x] Focus a project tile → Enter (opens detail) → Escape → focus returns to that tile
  - [x] Focus a FilterBar tab → ArrowRight → selection moves Recent→Archived
  - [x] No JS/page errors

Follow-up (PR 4): the Tab-cycling focus **trap** in the shared overlay shell, verified across ContactForm / InteractiveResume / Projects detail+deep-dive / Documentary iframe / About / Skillset / Welcome.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RQXP7RGdphM6GegaWkBVND)_