### PR TITLE
Focus trap in the overlay shells (pass 4 — final)

### DIFF
--- a/src/components/features/modal/ModalShell.tsx
+++ b/src/components/features/modal/ModalShell.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef } from "react";
 import { motion, useReducedMotion, type Variants } from "framer-motion";
 import { ModalShellProps } from "@/lib/types";
 import { pushOverlay, popOverlay, isTopmostOverlay, lockBodyScroll, unlockBodyScroll } from "@/lib/utils/overlayStack";
+import { trapTabKey } from "@/lib/utils/focusTrap";
 
 const ModalShell: React.FC<ModalShellProps> = ({
   onClose,
@@ -24,8 +25,11 @@ const ModalShell: React.FC<ModalShellProps> = ({
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && isTopmostOverlay(instanceId)) {
+      if (!isTopmostOverlay(instanceId)) return;
+      if (event.key === "Escape") {
         onClose();
+      } else if (event.key === "Tab" && dialogRef.current) {
+        trapTabKey(event, dialogRef.current);
       }
     };
 

--- a/src/components/features/shell/AppView.tsx
+++ b/src/components/features/shell/AppView.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
 import { AppViewProps } from "@/lib/types";
 import { pushOverlay, popOverlay, isTopmostOverlay, lockBodyScroll, unlockBodyScroll } from "@/lib/utils/overlayStack";
+import { trapTabKey } from "@/lib/utils/focusTrap";
 import styles from "./AppView.module.css";
 
 /**
@@ -32,8 +33,11 @@ const AppView: React.FC<AppViewProps> = ({ onClose, title, headerActions, titleI
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && isTopmostOverlay(instanceId)) {
+      if (!isTopmostOverlay(instanceId)) return;
+      if (event.key === "Escape") {
         onClose();
+      } else if (event.key === "Tab" && containerRef.current) {
+        trapTabKey(event, containerRef.current);
       }
     };
 

--- a/src/lib/utils/focusTrap.ts
+++ b/src/lib/utils/focusTrap.ts
@@ -1,0 +1,54 @@
+// Focus-trap helpers shared by the overlay shells (ModalShell + AppView).
+// Only the topmost overlay should call trapTabKey (see overlayStack), so a
+// modal opened over an AppView traps within the modal while the AppView
+// beneath stays untrapped.
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "iframe",
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(",");
+
+/** Visible, focusable descendants of `container`, in DOM order. */
+export function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    // getClientRects() is empty for display:none (and works for position:fixed,
+    // unlike offsetParent). Also skip anything explicitly inert.
+    (el) => el.getClientRects().length > 0 && !el.closest("[inert]")
+  );
+}
+
+/**
+ * Keep Tab / Shift+Tab focus within `container`, wrapping at the ends. Call
+ * from a keydown handler when the Tab key is pressed and this overlay is
+ * topmost. Note: focus that enters a nested <iframe> (e.g. the Documentary
+ * player) is managed by the iframe's own document until it tabs back out —
+ * a browser limitation the parent can't intercept.
+ */
+export function trapTabKey(event: KeyboardEvent, container: HTMLElement): void {
+  const focusables = getFocusable(container);
+  if (focusables.length === 0) {
+    event.preventDefault();
+    container.focus();
+    return;
+  }
+
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey) {
+    if (active === first || active === container || !container.contains(active)) {
+      event.preventDefault();
+      last.focus();
+    }
+  } else if (active === last || !container.contains(active)) {
+    event.preventDefault();
+    first.focus();
+  }
+}


### PR DESCRIPTION
## Summary

Final pass of the AppViews UI/UX audit (after #39, #41, #42). Adds the one deferred, wider-blast-radius accessibility item: a **Tab / Shift+Tab focus trap** in the shared overlay shells, so keyboard focus can't escape the active overlay into the content behind it (the bug where Tabbing out of a Project detail modal wandered into the gallery underneath).

### Changes
- **New `src/lib/utils/focusTrap.ts`**: `getFocusable(container)` (visible, non-inert focusables — uses `getClientRects()` so it's correct for `position:fixed`, unlike `offsetParent`) + `trapTabKey(event, container)` (wraps focus at the first/last focusable and pulls stray focus back in).
- **`ModalShell.tsx` + `AppView.tsx`**: on Tab, call `trapTabKey` — but only when `isTopmostOverlay(instanceId)`. So a modal opened over an AppView traps within the modal while the AppView beneath does not, and nesting (gallery → detail → deep-dive) just works because each overlay's handler self-checks topmost. No extra stack bookkeeping or `inert` needed — the topmost-only trap is sufficient to keep focus contained.
- **Known limitation** (documented in the util): focus that enters a nested `<iframe>` (the Documentary PBS player) is managed by the iframe's own document until it tabs back out — a browser constraint the parent can't intercept. Escape still closes.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Playwright against `npm run dev` (30 Tab presses per level, asserting `activeElement` never leaves the topmost container):
  - [x] Projects gallery (AppView): Tab stays within the region
  - [x] Project detail modal over the gallery: Tab stays within the dialog
  - [x] Resume deep-dive over the detail (2 stacked dialogs): Tab stays within the **topmost** dialog
  - [x] Escape still closes deepest-first (2 dialogs → 1)
  - [x] No JS/page errors

---

This completes the four-part audit of the three AppViews:
- **#39** — token sweep (fixes the two-orange accent bug), dead-CSS removal, visible-bug fixes, low-risk a11y/perf
- **#41** — Skillset graph: state preservation across tab switches + incremental d3 updates
- **#42** — accessibility: graph keyboard ops, `<h1>` headings, FilterBar tab pattern, About live regions, focus restoration
- **this** — focus trap in the overlay shells


---
_Generated by [Claude Code](https://claude.ai/code/session_01RQXP7RGdphM6GegaWkBVND)_