### PR TITLE
AppSwitcher: surface Contact notification to assistive tech

### DIFF
--- a/src/components/layout/LandingPage/components/AppSwitcher.tsx
+++ b/src/components/layout/LandingPage/components/AppSwitcher.tsx
@@ -96,6 +96,7 @@ const AppSwitcher: React.FC<AppSwitcherProps> = ({
         <legend className="app-switcher-legend">Launch an app</legend>
         {DESKTOP_APPS.map((app, index) => {
           const isActive = index === activeIndex;
+          const hasNotification = app.name === "Contact" && showContactNotification;
           return (
             <label
               key={app.name}
@@ -112,7 +113,9 @@ const AppSwitcher: React.FC<AppSwitcherProps> = ({
                 onChange={() => setVisualIndex(index)}
                 onClick={() => handleTap(index)}
               />
-              <span className="app-switcher-sr-only">{app.name}</span>
+              <span className="app-switcher-sr-only">
+                {hasNotification ? `${app.name}, new notification` : app.name}
+              </span>
               <span className="icon-image app-switcher-icon-image">
                 <span className="icon-glass">
                   <span
@@ -125,8 +128,10 @@ const AppSwitcher: React.FC<AppSwitcherProps> = ({
                     <FontAwesomeIcon icon={app.icon} />
                   </span>
                 </span>
-                {app.name === "Contact" && showContactNotification && (
-                  <span className="notification-badge">!</span>
+                {hasNotification && (
+                  <span className="notification-badge" aria-hidden="true">
+                    !
+                  </span>
                 )}
               </span>
             </label>


### PR DESCRIPTION
## Summary

Parity fix noted in #40: the mobile `AppSwitcher` pill switcher (≤480px) had the same notification-badge accessibility gap the desktop `DesktopIcons` wheel had. This brings it in line.

## Change

The Contact `!` badge was a purely visual `<span>` with no accessible name, so screen-reader users on mobile had no signal that Contact had a pending notification. It's now folded into the option's existing screen-reader label — `"Contact, new notification"` instead of just `"Contact"` — and the decorative glyph is marked `aria-hidden`. This matches the desktop wheel's behavior so the experience is consistent across the breakpoint.

## Verification

- `npx tsc --noEmit` passes.
- `npx next lint` on the component reports no warnings or errors.
- `npm run build` compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151DTJXRkDB6XKrwdHBxZww)_