### PR TITLE
Fix AppSwitcher mobile dock styling and UX

### DIFF
--- a/src/components/layout/LandingPage/components/AppSwitcher.css
+++ b/src/components/layout/LandingPage/components/AppSwitcher.css
@@ -18,7 +18,7 @@
   display: none;
   position: absolute;
   left: 50%;
-  bottom: 22px;
+  bottom: calc(22px + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
   z-index: 4;
 }
@@ -65,7 +65,7 @@
   width: calc((100% - 8px) / var(--n-options));
   border-radius: 999px;
   background: var(--noir-accent);
-  box-shadow: 0 2px 10px var(--noir-accent-glow);
+  box-shadow: 0 2px 8px var(--noir-accent-glow);
   transform: translateX(calc(var(--active-index) * 100%));
   transform-origin: var(--pill-origin, center);
   transition: transform 0.4s cubic-bezier(1, 0, 0.4, 1);
@@ -84,7 +84,7 @@
   border-radius: 999px;
   color: var(--noir-muted);
   cursor: pointer;
-  transition: color 0.2s ease;
+  transition: color 0.2s ease, transform 0.15s ease;
 }
 
 .app-switcher-option:has(.app-switcher-input:checked) {
@@ -93,6 +93,10 @@
 
 .app-switcher-option:hover:not(:has(.app-switcher-input:checked)) {
   color: var(--app-accent, var(--noir-text));
+}
+
+.app-switcher-option:active {
+  transform: scale(0.92);
 }
 
 .app-switcher-input {
@@ -116,14 +120,38 @@
   overflow: hidden;
 }
 
-.app-switcher-icon-image {
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
+/* Matches .app-switcher-option's own 44px box exactly, so the icon tile and
+   the sliding accent capsule underneath it share the same circular footprint
+   — a smaller/squarer tile floating inside the larger pill-shaped capsule
+   read as a mismatched, blown-out glow around the active icon. Scoped through
+   the parent option because LandingPage.css's ".icon-image" base rule (48px,
+   10px radius) ties this class on specificity, so cascade order alone can't
+   be trusted to pick this override. */
+.app-switcher-option .app-switcher-icon-image {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
 }
 
 .app-switcher-icon-image .icon-glass-content {
-  font-size: 0.9rem;
+  font-size: 1.1rem;
+}
+
+/* LandingPage.css's shared ".icon-image svg" rule hardcodes a dark navy
+   fill for the desktop wheel's light icon surface; it otherwise silences
+   .app-switcher-option's own muted/white/accent color states above, which
+   is why every glyph — including the "active" one — rendered dark-on-dark. */
+.app-switcher-option .app-switcher-icon-image .icon-glass-content svg {
+  color: inherit;
+}
+
+.app-switcher-icon-image .notification-badge {
+  top: -2px;
+  right: -2px;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--lg-tint-solid);
+  box-sizing: content-box;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

The mobile AppSwitcher dock (≤480px) had several bugs, visible in a screenshot of the live site:

- **Icon glyphs were nearly invisible.** `LandingPage.css`'s shared `.icon-image svg` rule hardcodes a dark navy fill for the desktop wheel's light icon surface. That same rule was silencing `.app-switcher-option`'s intended muted/white/accent color states on the dock, so every glyph — including the "active" one — rendered dark-on-dark against the glass tile and busy wallpaper.
- **The active/selected state looked like a blown-out glow blob.** The icon tile was a small 30px square (8px radius) floating inside the much larger, fully-rounded (999px) accent capsule behind it, so selecting an app produced a mismatched, hazy orange smear instead of a crisp highlight.
- **The Contact notification badge clipped off the dock.** Anchored to that small inner tile with a negative offset, it poked past the pill's curved right edge into the background image on the rightmost icon.
- No `env(safe-area-inset-bottom)` handling on the dock's position.

## Changes

All changes are scoped to `AppSwitcher.css` (no logic/markup changes):

- Icon tile resized from 30px/8px-radius to 44px/999px-radius, matching the sliding capsule's own circular footprint exactly (scoped through the parent selector since the two competing base rules tie on specificity).
- Added a targeted override so the icon `<svg>`'s color inherits from `.app-switcher-option` instead of the hardcoded navy, reactivating the already-written (but previously dead) muted/white/accent color states.
- Repositioned/resized the notification badge and added a tint-matched ring so it reads as attached to its icon rather than clipped.
- Added `env(safe-area-inset-bottom)` to the dock's bottom offset.
- Added a tactile `:active` press-scale for touch feedback; tightened the capsule's glow radius slightly.

## Test plan

- [x] `npm run build` — compiles and type-checks cleanly
- [x] Verified visually with Playwright at an iPhone 13 mobile viewport: default state, each active-icon state (including Contact's notification badge), and full-page context — icons are now legible, the active capsule matches its tile with no overflow, and the badge sits fully within the dock's rounded silhouette
- [x] Confirmed the CSS changes are scoped to classes only used by `AppSwitcher.tsx` (`app-switcher-icon-image`), so the desktop/tablet `DesktopIcons` wheel picker (which shares the base `.icon-image` class) is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3PooauKqLdw5HS1PRE4Nm)_