### PR TITLE
Migrate About + Skillset to CSS Modules (pass 5)

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.module.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.module.css
@@ -1,6 +1,6 @@
 /* ===== ABOUT — "THE DOSSIER" / CHAPTERED NARRATIVE ===== */
 
-.about-dossier {
+.aboutDossier {
   --about-accent: var(--noir-accent);
   --about-accent-soft: var(--noir-accent-soft);
   --about-accent-glow: var(--noir-accent-glow);
@@ -20,7 +20,7 @@
 
 /* ── Chapter rail ─────────────────────────────────────── */
 
-.about-rail {
+.aboutRail {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
@@ -31,7 +31,7 @@
   overscroll-behavior: contain;
 }
 
-.about-rail-item {
+.aboutRailItem {
   display: flex;
   align-items: center;
   gap: 0.6rem;
@@ -47,7 +47,7 @@
   transition: background 0.2s ease, color 0.2s ease;
 }
 
-.about-rail-item::before {
+.aboutRailItem::before {
   content: "";
   position: absolute;
   left: 0;
@@ -60,21 +60,21 @@
   transition: transform 0.22s ease;
 }
 
-.about-rail-item:hover:not(.active) {
+.aboutRailItem:hover:not(.active) {
   background: var(--about-panel);
   color: rgba(240, 236, 232, 0.78);
 }
 
-.about-rail-item.active {
+.aboutRailItem.active {
   background: var(--about-accent-soft);
   color: var(--about-text);
 }
 
-.about-rail-item.active::before {
+.aboutRailItem.active::before {
   transform: translateY(-50%) scaleY(1);
 }
 
-.about-rail-num {
+.aboutRailNum {
   font-size: 0.64rem;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -82,33 +82,33 @@
   flex-shrink: 0;
 }
 
-.about-rail-item.active .about-rail-num {
+.aboutRailItem.active .aboutRailNum {
   color: var(--about-accent);
 }
 
-.about-rail-label {
+.aboutRailLabel {
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: -0.01em;
   line-height: 1.2;
 }
 
-.about-rail-item:focus-visible,
-.about-prog-arrow:focus-visible,
-.about-pill:focus-visible {
+.aboutRailItem:focus-visible,
+.aboutProgArrow:focus-visible,
+.aboutPill:focus-visible {
   outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
 }
 
 /* ── Stage ────────────────────────────────────────────── */
 
-.about-stage-wrap {
+.aboutStageWrap {
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
-.about-stage {
+.aboutStage {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -116,14 +116,14 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.about-chapter {
+.aboutChapter {
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
   padding: 1.8rem 1.9rem;
 }
 
-.about-eyebrow {
+.aboutEyebrow {
   margin: 0;
   font-size: 0.66rem;
   font-weight: 700;
@@ -132,7 +132,7 @@
   color: var(--about-accent);
 }
 
-.about-chapter-title {
+.aboutChapterTitle {
   margin: 0;
   font-size: 1.7rem;
   font-weight: 800;
@@ -141,7 +141,7 @@
   color: var(--about-text);
 }
 
-.about-lede {
+.aboutLede {
   margin: 0;
   font-size: 0.92rem;
   line-height: 1.6;
@@ -154,7 +154,7 @@
    animation-timeline: view() brightens/scales it as it crosses the visual
    center of the scrollable list, independent of any shared scroll position. */
 
-.about-hero {
+.aboutHero {
   display: flex;
   align-items: stretch;
   gap: 1.25rem;
@@ -162,7 +162,7 @@
   margin: -0.2rem 0 0.4rem;
 }
 
-.about-hero-phrase {
+.aboutHeroPhrase {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
@@ -174,7 +174,7 @@
   white-space: nowrap;
 }
 
-.about-hero-scroll {
+.aboutHeroScroll {
   position: relative;
   flex: 1;
   min-width: 0;
@@ -188,15 +188,15 @@
   scrollbar-width: none;
 }
 
-.about-hero-scroll::-webkit-scrollbar {
+.aboutHeroScroll::-webkit-scrollbar {
   display: none;
 }
 
-.about-hero-pad {
+.aboutHeroPad {
   height: calc(50% - 1.1rem);
 }
 
-.about-hero-word {
+.aboutHeroWord {
   scroll-snap-align: center;
   padding: 0.4rem 0;
   font-family: var(--font-display);
@@ -210,7 +210,7 @@
 }
 
 @supports (animation-timeline: scroll()) {
-  .about-hero-word {
+  .aboutHeroWord {
     animation: about-hero-word-focus linear both;
     animation-timeline: view(y);
     animation-range: cover;
@@ -233,14 +233,14 @@
 
 /* ── Profile highlights ───────────────────────────────── */
 
-.about-highlight-grid {
+.aboutHighlightGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
   margin-top: 0.35rem;
 }
 
-.about-highlight-card {
+.aboutHighlightCard {
   border: 1px solid var(--about-border);
   border-radius: 0.82rem;
   background: var(--about-panel);
@@ -248,13 +248,13 @@
   transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
 }
 
-.about-highlight-card:hover {
+.aboutHighlightCard:hover {
   border-color: var(--noir-accent-line);
   transform: translateY(-2px);
   background: var(--noir-accent-soft);
 }
 
-.about-highlight-card h3 {
+.aboutHighlightCard h3 {
   margin: 0;
   font-size: 0.66rem;
   font-weight: 700;
@@ -263,7 +263,7 @@
   color: var(--about-accent);
 }
 
-.about-highlight-card p {
+.aboutHighlightCard p {
   margin: 0.4rem 0 0;
   font-size: 0.84rem;
   line-height: 1.46;
@@ -272,7 +272,7 @@
 
 /* ── Working-style points ─────────────────────────────── */
 
-.about-points {
+.aboutPoints {
   margin: 0.4rem 0 0;
   padding: 0;
   list-style: none;
@@ -281,7 +281,7 @@
   gap: 0.7rem;
 }
 
-.about-points li {
+.aboutPoints li {
   position: relative;
   padding-left: 1.5rem;
   font-size: 0.92rem;
@@ -289,7 +289,7 @@
   color: rgba(240, 236, 232, 0.72);
 }
 
-.about-points li::before {
+.aboutPoints li::before {
   content: counter(list-item, decimal-leading-zero);
   position: absolute;
   left: 0;
@@ -302,14 +302,14 @@
 
 /* ── Strengths pills ──────────────────────────────────── */
 
-.about-pills {
+.aboutPills {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
   margin-top: 0.35rem;
 }
 
-.about-pill {
+.aboutPill {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -326,29 +326,29 @@
     background 0.2s ease, color 0.2s ease;
 }
 
-.about-pill.clickable {
+.aboutPill.clickable {
   border-color: var(--noir-accent-line);
 }
 
-.about-pill:hover {
+.aboutPill:hover {
   border-color: var(--noir-accent-line);
   color: rgba(240, 236, 232, 0.9);
   transform: translateY(-1px);
 }
 
-.about-pill.active {
+.aboutPill.active {
   color: #fff;
   border-color: var(--noir-accent);
   background: var(--about-accent);
   box-shadow: 0 3px 12px var(--about-accent-glow);
 }
 
-.about-pill-link-icon {
+.aboutPillLinkIcon {
   font-size: 0.6rem;
   opacity: 0.7;
 }
 
-.about-strength-detail {
+.aboutStrengthDetail {
   margin-top: 0.5rem;
   border: 1px solid var(--noir-accent-line);
   border-radius: 0.78rem;
@@ -359,7 +359,7 @@
   box-shadow: 0 8px 24px rgba(22, 20, 18, 0.12);
 }
 
-.about-strength-detail-title {
+.aboutStrengthDetailTitle {
   margin: 0;
   font-size: 0.7rem;
   font-weight: 800;
@@ -368,21 +368,21 @@
   color: var(--about-accent);
 }
 
-.about-strength-detail-copy {
+.aboutStrengthDetailCopy {
   margin: 0.35rem 0 0;
   font-size: 0.84rem;
   line-height: 1.5;
   color: var(--about-muted);
 }
 
-.about-link-hint {
+.aboutLinkHint {
   color: var(--about-accent);
   font-weight: 700;
 }
 
 /* ── Progress footer ──────────────────────────────────── */
 
-.about-progress {
+.aboutProgress {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -393,7 +393,7 @@
   flex-shrink: 0;
 }
 
-.about-prog-arrow {
+.aboutProgArrow {
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -410,52 +410,52 @@
   flex-shrink: 0;
 }
 
-.about-prog-arrow:hover:not(:disabled) {
+.aboutProgArrow:hover:not(:disabled) {
   background: var(--noir-accent-soft);
   border-color: var(--noir-accent-line);
   color: var(--about-accent);
   transform: scale(1.05);
 }
 
-.about-prog-arrow:active:not(:disabled) {
+.aboutProgArrow:active:not(:disabled) {
   transform: scale(0.94);
 }
 
-.about-prog-arrow:disabled {
+.aboutProgArrow:disabled {
   opacity: 0.22;
   cursor: default;
 }
 
-.about-prog-counter {
+.aboutProgCounter {
   font-size: 0.66rem;
   font-weight: 700;
   letter-spacing: 0.16em;
   line-height: 1;
 }
 
-.about-prog-current {
+.aboutProgCurrent {
   color: var(--noir-accent);
 }
 
-.about-prog-sep {
+.aboutProgSep {
   color: rgba(240, 236, 232, 0.18);
   margin: 0 0.15em;
 }
 
-.about-prog-total {
+.aboutProgTotal {
   color: rgba(240, 236, 232, 0.25);
 }
 
 /* ── Featured chapter ─────────────────────────────────── */
 
-.about-featured-cards {
+.aboutFeaturedCards {
   display: flex;
   flex-direction: column;
   gap: 1rem;
   margin-top: 0.35rem;
 }
 
-.about-featured-card {
+.aboutFeaturedCard {
   border: 1px solid var(--about-border);
   border-radius: 0.82rem;
   background: var(--about-panel);
@@ -463,12 +463,12 @@
   transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
-.about-featured-card:hover {
+.aboutFeaturedCard:hover {
   border-color: var(--noir-accent-line);
   transform: translateY(-2px);
 }
 
-.about-featured-thumbnail {
+.aboutFeaturedThumbnail {
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -476,14 +476,14 @@
   background: #0f0f0f;
 }
 
-.about-featured-thumb-img {
+.aboutFeaturedThumbImg {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.about-featured-thumb-overlay {
+.aboutFeaturedThumbOverlay {
   position: absolute;
   inset: 0;
   display: flex;
@@ -499,45 +499,45 @@
   cursor: pointer;
 }
 
-.about-featured-thumb-overlay:focus-visible {
+.aboutFeaturedThumbOverlay:focus-visible {
   background: rgba(0, 0, 0, 0.22);
   outline: 2px solid var(--noir-accent, #d4845a);
   outline-offset: -2px;
 }
 
-.about-featured-card:hover .about-featured-thumb-overlay {
+.aboutFeaturedCard:hover .aboutFeaturedThumbOverlay {
   background: rgba(0, 0, 0, 0.22);
 }
 
-.about-featured-play-icon {
+.aboutFeaturedPlayIcon {
   font-size: 2rem;
   color: rgba(255, 255, 255, 0.9);
   filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.5));
   transition: transform 0.2s ease;
 }
 
-.about-featured-card:hover .about-featured-play-icon {
+.aboutFeaturedCard:hover .aboutFeaturedPlayIcon {
   transform: scale(1.12);
 }
 
-.about-featured-info {
+.aboutFeaturedInfo {
   padding: 0.85rem;
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
 }
 
-.about-featured-info--full {
+.aboutFeaturedInfoFull {
   padding: 1rem;
 }
 
-.about-featured-badges {
+.aboutFeaturedBadges {
   display: flex;
   gap: 0.4rem;
   flex-wrap: wrap;
 }
 
-.about-featured-badge {
+.aboutFeaturedBadge {
   display: inline-block;
   font-size: 0.6rem;
   font-weight: 700;
@@ -550,19 +550,19 @@
   background: var(--about-faint, rgba(43, 42, 40, 0.04));
 }
 
-.about-featured-badge--pbs {
+.aboutFeaturedBadgePbs {
   background: #1569b8;
   color: #fff;
   border-color: transparent;
 }
 
-.about-featured-badge--sxsw {
+.aboutFeaturedBadgeSxsw {
   background: #e94c3d;
   color: #fff;
   border-color: transparent;
 }
 
-.about-featured-title {
+.aboutFeaturedTitle {
   margin: 0;
   font-size: 0.88rem;
   font-weight: 700;
@@ -571,14 +571,14 @@
   letter-spacing: -0.01em;
 }
 
-.about-featured-desc {
+.aboutFeaturedDesc {
   margin: 0;
   font-size: 0.78rem;
   line-height: 1.52;
   color: var(--about-muted);
 }
 
-.about-featured-cta {
+.aboutFeaturedCta {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -598,7 +598,7 @@
   width: fit-content;
 }
 
-.about-featured-cta:hover {
+.aboutFeaturedCta:hover {
   background: var(--about-accent);
   color: #fff;
   transform: translateY(-1px);
@@ -606,16 +606,16 @@
 
 /* ── Responsive ───────────────────────────────────────── */
 
-/* AppView gives About the full .mac-screen width (up to 1500px) instead of a
+/* AppView gives About the full .macScreen width (up to 1500px) instead of a
    floating card's constrained width, so the rail can stay vertical down to a
    narrower breakpoint than the old modal used (720px). */
 @media (max-width: 580px) {
-  .about-dossier {
+  .aboutDossier {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
   }
 
-  .about-rail {
+  .aboutRail {
     flex-direction: row;
     gap: 0.3rem;
     padding: 0.55rem 0.7rem;
@@ -626,7 +626,7 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  .about-rail-item {
+  .aboutRailItem {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.1rem;
@@ -635,7 +635,7 @@
     flex-shrink: 0;
   }
 
-  .about-rail-item::before {
+  .aboutRailItem::before {
     left: 0;
     top: auto;
     bottom: 0;
@@ -645,54 +645,54 @@
     border-radius: 2px 2px 0 0;
   }
 
-  .about-rail-item.active::before {
+  .aboutRailItem.active::before {
     transform: translateY(0) scaleX(1);
   }
 
-  .about-chapter {
+  .aboutChapter {
     padding: 1.4rem 1.25rem;
   }
 
-  .about-chapter-title {
+  .aboutChapterTitle {
     font-size: 1.4rem;
   }
 
-  .about-highlight-grid {
+  .aboutHighlightGrid {
     grid-template-columns: 1fr;
   }
 
-  .about-hero {
+  .aboutHero {
     flex-direction: column;
     gap: 0.5rem;
     min-height: 7rem;
   }
 
-  .about-hero-scroll {
+  .aboutHeroScroll {
     height: 6rem;
   }
 }
 
 @media (max-width: 480px) {
-  .about-chapter-title {
+  .aboutChapterTitle {
     font-size: 1.24rem;
   }
 
-  .about-lede,
-  .about-points li {
+  .aboutLede,
+  .aboutPoints li {
     font-size: 0.86rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .about-rail-item,
-  .about-rail-item::before,
-  .about-highlight-card,
-  .about-pill,
-  .about-prog-arrow {
+  .aboutRailItem,
+  .aboutRailItem::before,
+  .aboutHighlightCard,
+  .aboutPill,
+  .aboutProgArrow {
     transition: none;
   }
 
-  .about-hero-word {
+  .aboutHeroWord {
     animation: none;
     opacity: 1;
     filter: none;

--- a/src/components/features/about/AboutAppView/AboutAppView.tsx
+++ b/src/components/features/about/AboutAppView/AboutAppView.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { aboutMePills } from "@/data/aboutMePills";
 import { AboutMePill } from "@/lib/types";
 import { AppView } from "@/components/features/shell";
-import "./AboutAppView.css";
+import styles from "./AboutAppView.module.css";
 
 interface AboutAppViewProps {
   onClose: () => void;
@@ -153,44 +153,44 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
 
   const renderFeaturedChapter = () => (
     <>
-      <p className="about-eyebrow">In The Press</p>
-      <h2 className="about-chapter-title">Featured Work</h2>
-      <p className="about-lede">
+      <p className={styles.aboutEyebrow}>In The Press</p>
+      <h2 className={styles.aboutChapterTitle}>Featured Work</h2>
+      <p className={styles.aboutLede}>
         Selected appearances and speaking engagements.
       </p>
 
-      <div className="about-featured-cards">
+      <div className={styles.aboutFeaturedCards}>
         {/* Tech For Us — PBS Documentary */}
-        <div className="about-featured-card">
-          <div className="about-featured-thumbnail">
+        <div className={styles.aboutFeaturedCard}>
+          <div className={styles.aboutFeaturedThumbnail}>
             <Image
               src="https://image.pbs.org/video-assets/5Q3iQAC-asset-mezzanine-16x9-luFIYQ7.jpg?crop=1440x810&format=auto"
               alt="Tech For Us — Breaking Barriers on PBS"
               width={480}
               height={270}
-              className="about-featured-thumb-img"
+              className={styles.aboutFeaturedThumbImg}
             />
             <button
               type="button"
-              className="about-featured-thumb-overlay"
+              className={styles.aboutFeaturedThumbOverlay}
               onClick={() => onOpenDocumentary?.()}
               aria-label="Play Tech For Us — Breaking Barriers documentary"
             >
-              <FontAwesomeIcon icon={faPlay} className="about-featured-play-icon" />
+              <FontAwesomeIcon icon={faPlay} className={styles.aboutFeaturedPlayIcon} />
             </button>
           </div>
-          <div className="about-featured-info">
-            <div className="about-featured-badges">
-              <span className="about-featured-badge about-featured-badge--pbs">PBS</span>
-              <span className="about-featured-badge">Documentary</span>
+          <div className={styles.aboutFeaturedInfo}>
+            <div className={styles.aboutFeaturedBadges}>
+              <span className={`${styles.aboutFeaturedBadge} ${styles.aboutFeaturedBadgePbs}`}>PBS</span>
+              <span className={styles.aboutFeaturedBadge}>Documentary</span>
             </div>
-            <h3 className="about-featured-title">Tech For Us — Breaking Barriers</h3>
-            <p className="about-featured-desc">
+            <h3 className={styles.aboutFeaturedTitle}>Tech For Us — Breaking Barriers</h3>
+            <p className={styles.aboutFeaturedDesc}>
               Featured in a Roadtrip Nation documentary exploring technology, innovation, and career development through public interest technology stories.
             </p>
             <button
               type="button"
-              className="about-featured-cta"
+              className={styles.aboutFeaturedCta}
               onClick={() => onOpenDocumentary?.()}
             >
               <FontAwesomeIcon icon={faPlay} />
@@ -200,21 +200,21 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
         </div>
 
         {/* SXSW EDU 2025 Panel */}
-        <div className="about-featured-card">
-          <div className="about-featured-info about-featured-info--full">
-            <div className="about-featured-badges">
-              <span className="about-featured-badge about-featured-badge--sxsw">SXSW EDU</span>
-              <span className="about-featured-badge">2025 Panel</span>
+        <div className={styles.aboutFeaturedCard}>
+          <div className={`${styles.aboutFeaturedInfo} ${styles.aboutFeaturedInfoFull}`}>
+            <div className={styles.aboutFeaturedBadges}>
+              <span className={`${styles.aboutFeaturedBadge} ${styles.aboutFeaturedBadgeSxsw}`}>SXSW EDU</span>
+              <span className={styles.aboutFeaturedBadge}>2025 Panel</span>
             </div>
-            <h3 className="about-featured-title">Behind the Wheel: Youth Driving Tech &amp; Media</h3>
-            <p className="about-featured-desc">
+            <h3 className={styles.aboutFeaturedTitle}>Behind the Wheel: Youth Driving Tech &amp; Media</h3>
+            <p className={styles.aboutFeaturedDesc}>
               Panelist at SXSW EDU 2025 in Austin, TX — discussing how young people are shaping the future of technology and media.
             </p>
             <a
               href="https://schedule.sxswedu.com/2025/events/PP156313"
               target="_blank"
               rel="noopener noreferrer"
-              className="about-featured-cta about-featured-cta--link"
+              className={styles.aboutFeaturedCta}
             >
               <FontAwesomeIcon icon={faExternalLinkAlt} />
               View Session
@@ -233,32 +233,32 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
     if (chapter.kind === "profile") {
       return (
         <>
-          <div className="about-hero">
-            <div className="about-hero-phrase">I build</div>
-            <ul className="about-hero-scroll" ref={centerHeroList}>
-              <li className="about-hero-pad" aria-hidden="true" />
+          <div className={styles.aboutHero}>
+            <div className={styles.aboutHeroPhrase}>I build</div>
+            <ul className={styles.aboutHeroScroll} ref={centerHeroList}>
+              <li className={styles.aboutHeroPad} aria-hidden="true" />
               {ABOUT_HERO_WORDS.map((word, i) => (
                 <li
                   key={word}
                   data-index={i}
-                  className="about-hero-word"
+                  className={styles.aboutHeroWord}
                   style={{ "--i": i } as CSSProperties}
                 >
                   {word}
                 </li>
               ))}
-              <li className="about-hero-pad" aria-hidden="true" />
+              <li className={styles.aboutHeroPad} aria-hidden="true" />
             </ul>
           </div>
 
-          <p className="about-eyebrow">Profile</p>
-          <h2 className="about-chapter-title">Hello, I&apos;m Demaceo Vincent</h2>
-          <p className="about-lede">
+          <p className={styles.aboutEyebrow}>Profile</p>
+          <h2 className={styles.aboutChapterTitle}>Hello, I&apos;m Demaceo Vincent</h2>
+          <p className={styles.aboutLede}>
             Software Engineer, Designer, and systems-minded problem solver.
           </p>
-          <div className="about-highlight-grid">
+          <div className={styles.aboutHighlightGrid}>
             {profileHighlights.map((item) => (
-              <article key={item.label} className="about-highlight-card">
+              <article key={item.label} className={styles.aboutHighlightCard}>
                 <h3>{item.label}</h3>
                 <p>{item.value}</p>
               </article>
@@ -272,9 +272,9 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
       const section = collaborationSections[chapter.sectionIndex];
       return (
         <>
-          <p className="about-eyebrow">Working Style</p>
-          <h2 className="about-chapter-title">{section.title}</h2>
-          <ul className="about-points">
+          <p className={styles.aboutEyebrow}>Working Style</p>
+          <h2 className={styles.aboutChapterTitle}>{section.title}</h2>
+          <ul className={styles.aboutPoints}>
             {section.points.map((point) => (
               <li key={point}>{point}</li>
             ))}
@@ -286,21 +286,21 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
     // strengths
     return (
       <>
-        <p className="about-eyebrow">What I Bring</p>
-        <h2 className="about-chapter-title">Core Strengths</h2>
-        <p className="about-lede">
+        <p className={styles.aboutEyebrow}>What I Bring</p>
+        <h2 className={styles.aboutChapterTitle}>Core Strengths</h2>
+        <p className={styles.aboutLede}>
           Select a strength for detail. Click again to open external links.
         </p>
 
-        <div className="about-pills">
+        <div className={styles.aboutPills}>
           {aboutMePills.map((pill) => {
             const isActive = activeTooltip === pill.label;
             return (
               <button
                 key={pill.label}
                 type="button"
-                className={`about-pill ${pill.link ? "clickable" : ""} ${
-                  isActive ? "active" : ""
+                className={`${styles.aboutPill} ${pill.link ? styles.clickable : ""} ${
+                  isActive ? styles.active : ""
                 }`}
                 onClick={() => handlePillClick(pill)}
                 aria-expanded={isActive}
@@ -310,7 +310,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
                 {pill.link && (
                   <FontAwesomeIcon
                     icon={faArrowUpRightFromSquare}
-                    className="about-pill-link-icon"
+                    className={styles.aboutPillLinkIcon}
                     aria-hidden="true"
                   />
                 )}
@@ -324,7 +324,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
             <motion.div
               key={activeTooltip}
               id="about-strength-detail"
-              className="about-strength-detail"
+              className={styles.aboutStrengthDetail}
               role="status"
               aria-live="polite"
               initial={{ opacity: 0, y: 8 }}
@@ -332,11 +332,11 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
               exit={{ opacity: 0, y: -8 }}
               transition={reduceMotion ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }}
             >
-              <p className="about-strength-detail-title">{activeTooltip}</p>
-              <p className="about-strength-detail-copy">
+              <p className={styles.aboutStrengthDetailTitle}>{activeTooltip}</p>
+              <p className={styles.aboutStrengthDetailCopy}>
                 {pillsByLabel[activeTooltip]?.tooltip}
                 {pillsByLabel[activeTooltip]?.link && (
-                  <span className="about-link-hint"> Click again to open.</span>
+                  <span className={styles.aboutLinkHint}> Click again to open.</span>
                 )}
               </p>
             </motion.div>
@@ -348,26 +348,26 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
 
   return (
     <AppView onClose={onClose} title="About" titleId="about-title">
-      <div className="about-dossier">
+      <div className={styles.aboutDossier}>
         {/* ── Chapter rail (table of contents) ─────────── */}
-        <nav className="about-rail" aria-label="About chapters">
+        <nav className={styles.aboutRail} aria-label="About chapters">
           {chapters.map((c, i) => (
             <button
               key={c.id}
               type="button"
-              className={`about-rail-item ${i === chapterIndex ? "active" : ""}`}
+              className={`${styles.aboutRailItem} ${i === chapterIndex ? styles.active : ""}`}
               onClick={() => goToChapter(i)}
               aria-current={i === chapterIndex ? "true" : undefined}
             >
-              <span className="about-rail-num">{String(i + 1).padStart(2, "0")}</span>
-              <span className="about-rail-label">{c.label}</span>
+              <span className={styles.aboutRailNum}>{String(i + 1).padStart(2, "0")}</span>
+              <span className={styles.aboutRailLabel}>{c.label}</span>
             </button>
           ))}
         </nav>
 
         {/* ── Stage ────────────────────────────────────── */}
-        <div className="about-stage-wrap">
-          <div className="about-stage">
+        <div className={styles.aboutStageWrap}>
+          <div className={styles.aboutStage}>
             <AnimatePresence mode="wait" custom={direction}>
               <motion.section
                 key={chapter.id}
@@ -377,7 +377,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
                 animate="center"
                 exit="exit"
                 transition={reduceMotion ? { duration: 0 } : { duration: 0.26, ease: [0.25, 0.46, 0.45, 0.94] }}
-                className="about-chapter"
+                className={styles.aboutChapter}
                 aria-labelledby="about-title"
               >
                 {renderChapter()}
@@ -386,10 +386,10 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
           </div>
 
           {/* ── Progress footer ────────────────────────── */}
-          <div className="about-progress">
+          <div className={styles.aboutProgress}>
             <button
               type="button"
-              className="about-prog-arrow"
+              className={styles.aboutProgArrow}
               onClick={() => navigate(-1)}
               disabled={chapterIndex === 0}
               aria-label="Previous chapter"
@@ -397,19 +397,19 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
               <FontAwesomeIcon icon={faChevronLeft} />
             </button>
 
-            <span className="about-prog-counter" aria-hidden="true">
-              <span className="about-prog-current">
+            <span className={styles.aboutProgCounter} aria-hidden="true">
+              <span className={styles.aboutProgCurrent}>
                 {String(chapterIndex + 1).padStart(2, "0")}
               </span>
-              <span className="about-prog-sep"> / </span>
-              <span className="about-prog-total">
+              <span className={styles.aboutProgSep}> / </span>
+              <span className={styles.aboutProgTotal}>
                 {String(chapters.length).padStart(2, "0")}
               </span>
             </span>
 
             <button
               type="button"
-              className="about-prog-arrow"
+              className={styles.aboutProgArrow}
               onClick={() => navigate(1)}
               disabled={chapterIndex === chapters.length - 1}
               aria-label="Next chapter"

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
@@ -20,7 +20,7 @@
 
 /* ── Top bar: tabs + studio byline ────────────────────── */
 
-.skill-topbar {
+.skillTopbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -31,7 +31,7 @@
   flex-shrink: 0;
 }
 
-.skill-tabs {
+.skillTabs {
   display: flex;
   gap: 0.28rem;
   background: var(--lg-tint);
@@ -42,7 +42,7 @@
   padding: 0.24rem;
 }
 
-.skill-tab {
+.skillTab {
   border: 0;
   border-radius: 999px;
   background: transparent;
@@ -55,25 +55,25 @@
   transition: background 0.2s ease, color 0.2s ease;
 }
 
-.skill-tab.active {
+.skillTab.active {
   background: var(--skill-accent);
   color: #fff;
   box-shadow: 0 2px 10px var(--skill-accent-glow);
 }
 
-.skill-tab:hover:not(.active) {
+.skillTab:hover:not(.active) {
   color: rgba(240, 236, 232, 0.7);
 }
 
-.skill-tab:focus-visible,
-.plate-arrow:focus-visible,
-.plate-dot:focus-visible,
-.skill-studio-byline:focus-visible {
+.skillTab:focus-visible,
+.plateArrow:focus-visible,
+.plateDot:focus-visible,
+.skillStudioByline:focus-visible {
   outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
 }
 
-.skill-studio-byline {
+.skillStudioByline {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -89,27 +89,27 @@
   transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
-.skill-studio-byline:hover {
+.skillStudioByline:hover {
   color: var(--skill-accent);
   border-color: var(--noir-accent-line);
   background: var(--skill-accent-soft);
 }
 
-.skill-studio-logo {
+.skillStudioLogo {
   border-radius: 6px;
   background: var(--skill-panel);
 }
 
 /* ── Services: capability plates ──────────────────────── */
 
-.skill-services {
+.skillServices {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
 }
 
-.plate-stage {
+.plateStage {
   flex: 1;
   min-height: 300px;
   position: relative;
@@ -118,7 +118,7 @@
   overflow: hidden;
 }
 
-.service-plate {
+.servicePlate {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -130,7 +130,7 @@
   width: 100%;
 }
 
-.plate-icon-halo {
+.plateIconHalo {
   position: relative;
   display: grid;
   place-items: center;
@@ -146,7 +146,7 @@
   margin-bottom: 0.2rem;
 }
 
-.plate-icon-halo::after {
+.plateIconHalo::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -154,34 +154,34 @@
   border: 1px solid var(--noir-accent-line);
 }
 
-.plate-icon {
+.plateIcon {
   width: 72px;
   height: auto;
   object-fit: contain;
   filter: drop-shadow(0 8px 24px rgba(212, 132, 90, 0.28));
 }
 
-.plate-counter {
+.plateCounter {
   font-size: 0.66rem;
   font-weight: 700;
   letter-spacing: 0.16em;
   line-height: 1;
 }
 
-.counter-current {
+.counterCurrent {
   color: var(--noir-accent);
 }
 
-.counter-sep {
+.counterSep {
   color: rgba(240, 236, 232, 0.18);
   margin: 0 0.15em;
 }
 
-.counter-total {
+.counterTotal {
   color: rgba(240, 236, 232, 0.25);
 }
 
-.plate-title {
+.plateTitle {
   margin: 0;
   font-size: 1.6rem;
   font-weight: 800;
@@ -190,7 +190,7 @@
   color: var(--skill-text);
 }
 
-.plate-outcome {
+.plateOutcome {
   margin: 0;
   font-size: 0.78rem;
   font-weight: 700;
@@ -200,7 +200,7 @@
   max-width: 40ch;
 }
 
-.plate-description {
+.plateDescription {
   margin: 0.2rem 0 0;
   font-size: 0.88rem;
   line-height: 1.62;
@@ -210,7 +210,7 @@
 
 /* ── Plate nav ────────────────────────────────────────── */
 
-.plate-nav {
+.plateNav {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -221,7 +221,7 @@
   flex-shrink: 0;
 }
 
-.plate-arrow {
+.plateArrow {
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -238,24 +238,24 @@
   flex-shrink: 0;
 }
 
-.plate-arrow:hover {
+.plateArrow:hover {
   background: var(--noir-accent-soft);
   border-color: var(--noir-accent-line);
   color: var(--skill-accent);
   transform: scale(1.05);
 }
 
-.plate-arrow:active {
+.plateArrow:active {
   transform: scale(0.94);
 }
 
-.plate-dots {
+.plateDots {
   display: flex;
   align-items: center;
   gap: 0.44rem;
 }
 
-.plate-dot {
+.plateDot {
   position: relative;
   height: 6px;
   width: 6px;
@@ -268,24 +268,24 @@
 }
 
 /* Keep the 6px visual but expand the tap target to ~24x20px for touch. */
-.plate-dot::after {
+.plateDot::after {
   content: "";
   position: absolute;
   inset: -9px -7px;
 }
 
-.plate-dot.active {
+.plateDot.active {
   background: var(--skill-accent);
   width: 22px;
 }
 
-.plate-dot:hover:not(.active) {
+.plateDot:hover:not(.active) {
   background: var(--noir-muted);
 }
 
 /* ── Toolbelt: force-directed graph ───────────────────── */
 
-.skill-tools {
+.skillTools {
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -295,44 +295,44 @@
 /* Both tab panels stay mounted (to preserve Toolbelt graph state); the
    inactive one is hidden. Needed because the panels' own `display: flex`
    would otherwise override the UA `[hidden] { display: none }` rule. */
-.skill-services[hidden],
-.skill-tools[hidden] {
+.skillServices[hidden],
+.skillTools[hidden] {
   display: none;
 }
 
 /* ── Responsive ───────────────────────────────────────── */
 
 @media (max-width: 640px) {
-  .skill-studio-byline span {
+  .skillStudioByline span {
     display: none;
   }
 
-  .service-plate {
+  .servicePlate {
     padding: 1.4rem 1.25rem;
   }
 
-  .plate-icon-halo {
+  .plateIconHalo {
     width: 92px;
     height: 92px;
   }
 
-  .plate-icon {
+  .plateIcon {
     width: 56px;
   }
 
-  .plate-title {
+  .plateTitle {
     font-size: 1.3rem;
   }
 
-  .plate-description {
+  .plateDescription {
     font-size: 0.84rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .service-plate,
-  .plate-dot,
-  .plate-arrow {
+  .servicePlate,
+  .plateDot,
+  .plateArrow {
     transition: none;
   }
 }

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
@@ -8,7 +8,7 @@ import tools from "@/data/toolbelt";
 import { ModalProps } from "@/lib/types";
 import { AppView } from "@/components/features/shell";
 import ToolbeltGraph from "./ToolbeltGraph";
-import "./SkillsetAppView.css";
+import styles from "./SkillsetAppView.module.css";
 
 type SkillsetTab = "services" | "tools";
 
@@ -90,12 +90,12 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
 
   return (
     <AppView onClose={onClose} title="Skillset" titleId="skillset-title">
-      <div className="skillset">
+      <div className={styles.skillset}>
         {/* ── Tabs ─────────────────────────────────────── */}
-        <div className="skill-topbar">
-          <div className="skill-tabs" role="tablist" aria-label="Skillset sections">
+        <div className={styles.skillTopbar}>
+          <div className={styles.skillTabs} role="tablist" aria-label="Skillset sections">
             <button
-              className={`skill-tab ${activeTab === "services" ? "active" : ""}`}
+              className={`${styles.skillTab} ${activeTab === "services" ? styles.active : ""}`}
               onClick={() => setActiveTab("services")}
               role="tab"
               id="services-tab"
@@ -106,7 +106,7 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
               Services
             </button>
             <button
-              className={`skill-tab ${activeTab === "tools" ? "active" : ""}`}
+              className={`${styles.skillTab} ${activeTab === "tools" ? styles.active : ""}`}
               onClick={() => setActiveTab("tools")}
               role="tab"
               id="tools-tab"
@@ -119,7 +119,7 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
           </div>
 
           <a
-            className="skill-studio-byline"
+            className={styles.skillStudioByline}
             href="https://www.anappidea.llc"
             target="_blank"
             rel="noopener noreferrer"
@@ -129,7 +129,7 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
               alt="An App Idea, LLC"
               width={22}
               height={22}
-              className="skill-studio-logo"
+              className={styles.skillStudioLogo}
             />
             <span>An App Idea, LLC</span>
           </a>
@@ -139,13 +139,13 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
             expanded / dragged / search state across tab switches. The inactive
             panel is hidden — see .skill-services[hidden] / .skill-tools[hidden]. */}
         <section
-          className="skill-services"
+          className={styles.skillServices}
           role="tabpanel"
           id="services-panel"
           aria-labelledby="services-tab"
           hidden={activeTab !== "services"}
         >
-              <div className="plate-stage" aria-live="polite">
+              <div className={styles.plateStage} aria-live="polite">
                 <AnimatePresence mode="wait" custom={direction}>
                   <motion.article
                     key={serviceIndex}
@@ -154,7 +154,7 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
                     initial="enter"
                     animate="center"
                     exit="exit"
-                    className="service-plate"
+                    className={styles.servicePlate}
                     drag="x"
                     dragConstraints={{ left: 0, right: 0 }}
                     dragElastic={0.08}
@@ -163,56 +163,56 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
                       if (power > 70) navigateService(offset.x > 0 ? -1 : 1);
                     }}
                   >
-                    <div className="plate-icon-halo" aria-hidden="true">
+                    <div className={styles.plateIconHalo} aria-hidden="true">
                       <Image
                         src={service.icon}
                         alt={service.title}
                         width={72}
                         height={72}
-                        className="plate-icon"
+                        className={styles.plateIcon}
                       />
                     </div>
 
                     <span
-                      className="plate-counter"
+                      className={styles.plateCounter}
                       aria-label={`Service ${serviceIndex + 1} of ${services.length}`}
                     >
-                      <span className="counter-current">
+                      <span className={styles.counterCurrent}>
                         {String(serviceIndex + 1).padStart(2, "0")}
                       </span>
-                      <span className="counter-sep"> / </span>
-                      <span className="counter-total">
+                      <span className={styles.counterSep}> / </span>
+                      <span className={styles.counterTotal}>
                         {String(services.length).padStart(2, "0")}
                       </span>
                     </span>
 
-                    <h2 className="plate-title">{service.title}</h2>
+                    <h2 className={styles.plateTitle}>{service.title}</h2>
 
                     {serviceOutcomes[service.id] && (
-                      <p className="plate-outcome">{serviceOutcomes[service.id]}</p>
+                      <p className={styles.plateOutcome}>{serviceOutcomes[service.id]}</p>
                     )}
 
-                    <p className="plate-description">{service.description}</p>
+                    <p className={styles.plateDescription}>{service.description}</p>
                   </motion.article>
                 </AnimatePresence>
               </div>
 
-              <div className="plate-nav">
+              <div className={styles.plateNav}>
                 <button
                   type="button"
-                  className="plate-arrow"
+                  className={styles.plateArrow}
                   onClick={() => navigateService(-1)}
                   aria-label="Previous service"
                 >
                   <FontAwesomeIcon icon={faChevronLeft} />
                 </button>
 
-                <div className="plate-dots" aria-label="Service navigation">
+                <div className={styles.plateDots} aria-label="Service navigation">
                   {services.map((s, i) => (
                     <button
                       key={s.id}
                       type="button"
-                      className={`plate-dot ${i === serviceIndex ? "active" : ""}`}
+                      className={`${styles.plateDot} ${i === serviceIndex ? styles.active : ""}`}
                       aria-current={i === serviceIndex ? "true" : undefined}
                       aria-label={`Go to ${s.title}`}
                       onClick={() => goToService(i)}
@@ -222,7 +222,7 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
 
                 <button
                   type="button"
-                  className="plate-arrow"
+                  className={styles.plateArrow}
                   onClick={() => navigateService(1)}
                   aria-label="Next service"
                 >
@@ -233,7 +233,7 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
 
         {/* ── Toolbelt: collapsible force-directed graph ─ */}
         <section
-          className="skill-tools"
+          className={styles.skillTools}
           role="tabpanel"
           id="tools-panel"
           aria-labelledby="tools-tab"


### PR DESCRIPTION
## Summary

Follow-up requested after the audit series: bring About + Skillset in line with the rest of the codebase. They were the only feature components still importing a **global plain stylesheet**; the shell, Projects, `ToolbeltGraph`, and `ui/*` all already use CSS Modules. This scopes their class names (no more global leakage) and matches convention.

Purely mechanical and **pixel-identical** — no UX change:
- `AboutAppView.css` → `AboutAppView.module.css`, `SkillsetAppView.css` → `SkillsetAppView.module.css` (git-tracked renames).
- Class selectors converted kebab→camel **1:1** (`about-rail-item` → `aboutRailItem`, `plate-dot` → `plateDot`, …); every `className` rewritten to `styles.*`, including the template-string toggles (`active`/`clickable`).
- Dropped the dead `about-featured-cta--link` class (it had no CSS rule).
- Preserved literally: `id`/`aria-*`/`data-index`/`[hidden]` attributes, all `--about-*`/`--skill-*`/`--noir-*`/`--lg-*` CSS custom properties, and the hero `@keyframes` (CSS Modules scopes those itself).
- `ToolbeltGraph` (already a module, shares no class names) is untouched.

Confirmed safe by an inventory pass: every class is uniquely prefixed, used only within its own component (zero external references), no cross-file collisions, and neither component uses any global `glass-*` class.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Before/after Playwright screenshots (using class-independent selectors post-migration): About **Profile**, **Strengths** (active pill + detail panel — exercises the `active`/`clickable` toggles), **Featured**, and Skillset **Services** (tabs, plate, `01/07` counter, pager dots, byline) — all pixel-identical to baseline.

Part of the requested follow-ups; PR 6 (ResumeHighlightsModal cleanup) is next.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RQXP7RGdphM6GegaWkBVND)_