### PR TITLE
Fix mobile UI/UX issues across landing, projects, resume, skillset & about

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.module.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.module.css
@@ -606,10 +606,12 @@
 
 /* ── Responsive ───────────────────────────────────────── */
 
-/* AppView gives About the full .macScreen width (up to 1500px) instead of a
-   floating card's constrained width, so the rail can stay vertical down to a
-   narrower breakpoint than the old modal used (720px). */
-@media (max-width: 580px) {
+/* Collapse the fixed 210px rail + 1fr content to a single column across the
+   whole tablet/phone band. Kept at two columns, the 581–768px band left the
+   short, left-aligned hero cascade and the 56ch lede stranded beside a wide
+   empty right gutter; going single-column (rail as a top strip) lets the
+   content use the full width and closes that gutter. */
+@media (max-width: 768px) {
   .aboutDossier {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
@@ -657,18 +659,37 @@
     font-size: 1.4rem;
   }
 
-  .aboutHighlightGrid {
-    grid-template-columns: 1fr;
-  }
-
+  /* Stack "I build" above the word cascade and center both, so the words sit in
+     the middle of the screen instead of hugging the left edge with a dead right
+     half (visible on phones in the original left-aligned layout). */
   .aboutHero {
     flex-direction: column;
+    align-items: center;
     gap: 0.5rem;
     min-height: 7rem;
+    text-align: center;
+  }
+
+  .aboutHeroPhrase {
+    justify-content: center;
   }
 
   .aboutHeroScroll {
     height: 6rem;
+    width: 100%;
+    align-self: stretch;
+  }
+
+  .aboutHeroWord {
+    text-align: center;
+  }
+}
+
+/* Highlight cards stay two-up through the tablet band and only go single-column
+   on phones, so tablets don't get over-wide stretched cards. */
+@media (max-width: 580px) {
+  .aboutHighlightGrid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/components/features/modal/ModalFrame.module.css
+++ b/src/components/features/modal/ModalFrame.module.css
@@ -195,7 +195,10 @@
 @media (max-width: 768px) {
   .overlay {
     padding: max(10px, env(safe-area-inset-top)) clamp(8px, 4vw, 14px) max(10px, env(safe-area-inset-bottom));
-    background: rgba(8, 5, 3, 0.72);
+    /* Blur is off on mobile (perf), so lean on a near-opaque scrim instead:
+       masks the wallpaper — and any modal stacked underneath (e.g. the Project
+       Detail behind Resume Highlights) — so nothing bleeds through the frame. */
+    background: rgba(8, 5, 3, 0.9);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
   }
@@ -204,6 +207,12 @@
     width: min(calc(100svw - 20px), var(--modal-max-width));
     max-height: min(96svh, 96vh);
     border-radius: 14px;
+    /* The overlay blur is disabled on mobile (above), so a 62%-opaque frame
+       lets the busy wallpaper read straight through — and again through any
+       translucent inner panel (e.g. the ResumeHighlights tab pill) — producing
+       a ghosted/doubled look. Use the near-solid tint so the modal reads as one
+       opaque surface. Applies to every ModalFrame consumer on phones. */
+    background: var(--lg-tint-solid);
   }
 
   .titleBar {

--- a/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.module.css
@@ -40,12 +40,25 @@
   font-size: 0.85rem;
 }
 
+/* Phone bezel (.mac-screen becomes 92dvh at ≤600px): the 320px floor makes the
+   gallery taller than the bezel, so the outer AppView .content scrolls too and
+   the last grid row lands under the fold (nested double-scroll). Drop the floor
+   so .stage shrinks to fit and becomes the sole scroller, and add bottom room so
+   the final row and the tiles' hover/focus lift clear the fold instead of
+   being clipped by overflow. */
+@media (max-width: 600px) {
+  .stage {
+    min-height: 0;
+    padding-bottom: 2rem;
+  }
+}
+
 @media (max-width: 480px) {
   .topbar {
     padding: 0.6rem 0.75rem;
   }
 
   .stage {
-    padding: 0.75rem;
+    padding: 0.75rem 0.75rem 2rem;
   }
 }

--- a/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
+++ b/src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css
@@ -338,7 +338,13 @@
 
 .resume-project-section pre {
   margin: 0.5rem 0 0 0;
-  white-space: pre-wrap;
+  /* ASCII flow diagrams are column-aligned, so wrapping (pre-wrap) destroyed
+     their layout AND long lines were clipped on the right by the detail card's
+     overflow:hidden. Keep the diagram intact and give it its own horizontal
+     scroll instead. */
+  white-space: pre;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.72rem;
@@ -436,13 +442,24 @@
     gap: 0.45rem;
   }
 
+  /* Give the tab pill its own full-width row and let it scroll horizontally
+     rather than forcing three long labels to fit. The old `flex: 1` +
+     `text-align: center` stretched each tab and made its nowrap label spill
+     past both ends, clipping mid-word ("Role Bullets" → "llets"). */
   .resume-highlights-tabs {
-    flex: 1;
+    flex: 1 1 100%;
+    overflow-x: auto;
+    justify-content: flex-start;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .resume-highlights-tabs::-webkit-scrollbar {
+    display: none;
   }
 
   .resume-highlights-tab {
-    flex: 1;
-    text-align: center;
+    flex: 0 0 auto;
   }
 
   .resume-highlights-byline {
@@ -463,6 +480,17 @@
   .resume-role-group li,
   .resume-project-section li {
     font-size: 0.8rem;
+  }
+
+  /* Slightly tighter tabs so most phones show all three without scrolling;
+     the scroll strip (≤900px) remains the fallback when they don't fit. */
+  .resume-highlights-tab {
+    font-size: 0.7rem;
+    padding: 0.34rem 0.7rem;
+  }
+
+  .resume-project-section pre {
+    font-size: 0.64rem;
   }
 
   .resume-patterns-table-wrap table {

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
@@ -149,6 +149,13 @@
   .hint {
     display: none;
   }
+
+  /* Smaller labels so category names (e.g. "Package Management" and
+     "Project Management") clear their neighbours in the tighter, narrower
+     columns used on phones. */
+  .node text {
+    font-size: 8px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
@@ -96,18 +96,51 @@ function flatten(tree: ToolbeltTreeNode[], collapsed: Set<string>) {
   return { nodes, links };
 }
 
-// Roots pinned in two staggered rows instead of the pen's single line of 4 —
-// 9 categories crowd badly on one line. Generalizes to any N.
+// Minimum horizontal room (px) a pinned category root needs so its full label
+// clears its neighbour's. Below this per-column budget we shed a column and add
+// a row instead. `forceCollide` only knows circle radii, so column spacing is
+// the only thing keeping the (wider) labels from colliding.
+const MIN_ROOT_SLOT = 116;
+
+// Roots are pinned into a grid. Wide screens keep the original balanced two-row
+// layout; narrow screens (phones / small tablets) get more rows and fewer
+// columns so labels stop overlapping and the rows fill the height instead of
+// clustering into two thin bands with an empty gap between them. Generalizes to
+// any N.
 function computeRootPositions(count: number, width: number, height: number) {
-  const topCount = Math.ceil(count / 2);
   const positions: { x: number; y: number }[] = [];
+  const fitCols = Math.max(2, Math.floor(width / MIN_ROOT_SLOT));
+
+  // Enough width for the original two-row split → keep desktop exactly as-is.
+  if (fitCols >= Math.ceil(count / 2)) {
+    const topCount = Math.ceil(count / 2);
+    for (let i = 0; i < count; i++) {
+      const inTopRow = i < topCount;
+      const row = inTopRow ? topCount : count - topCount;
+      const indexInRow = inTopRow ? i : i - topCount;
+      positions.push({
+        x: ((indexInRow + 1) / (row + 1)) * width,
+        y: height * (inTopRow ? 0.32 : 0.72),
+      });
+    }
+    return positions;
+  }
+
+  // Narrow: balanced multi-row grid (e.g. 9 → 3/3/3, not 4/4/1), spread down the
+  // full height so each label gets width/(itemsInRow+1) of room and no dead band
+  // is left below the bubbles.
+  const cols = Math.min(count, fitCols);
+  const rows = Math.ceil(count / cols);
+  const perRow = Math.ceil(count / rows);
   for (let i = 0; i < count; i++) {
-    const inTopRow = i < topCount;
-    const row = inTopRow ? topCount : count - topCount;
-    const indexInRow = inTopRow ? i : i - topCount;
+    const row = Math.floor(i / perRow);
+    const startOfRow = row * perRow;
+    const itemsInRow = Math.min(perRow, count - startOfRow);
+    const indexInRow = i - startOfRow;
+    const yFrac = rows === 1 ? 0.5 : 0.16 + (0.66 * row) / (rows - 1);
     positions.push({
-      x: ((indexInRow + 1) / (row + 1)) * width,
-      y: height * (inTopRow ? 0.32 : 0.72),
+      x: ((indexInRow + 1) / (itemsInRow + 1)) * width,
+      y: yFrac * height,
     });
   }
   return positions;

--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -389,6 +389,7 @@
 }
 
 .close-btn {
+  position: relative;
   width: 14px;
   height: 14px;
   display: flex;
@@ -438,18 +439,46 @@
   display: flex;
   gap: 10px;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .quick-links button {
   padding: 5px 10px;
   border: 1px solid #3b3a3a;
   background: #e0e0e0;
+  /* Native <button> doesn't inherit color/font-family, so without these iOS
+     falls back to its default control look (blue link-style text). Pin them to
+     keep the intended retro grayscale button with dark ink. */
+  color: #3b3a3a;
+  font-family: inherit;
+  appearance: none;
+  -webkit-appearance: none;
+  border-radius: 0;
   cursor: pointer;
   font-size: 10px;
 }
 
 .quick-links button:hover {
   background: #d0d0d0;
+}
+
+/* Touch devices: the retro buttons are far below the ~44px tap minimum. Size
+   them up (and the close control's hit area) without touching the mouse look. */
+@media (pointer: coarse) {
+  .quick-links button {
+    min-height: 44px;
+    padding: 8px 14px;
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .close-btn::before {
+    content: "";
+    position: absolute;
+    inset: -12px;
+  }
 }
 
 .taskbar {
@@ -518,6 +547,14 @@
 
   .desktop {
     padding: 16px;
+  }
+
+  /* On phones the MenuBar and desktop icons are hidden and the glass
+     AppSwitcher dock takes over navigation, so the retro taskbar has no
+     siblings above it and collapses into a stray light-gray strip at the top.
+     Hide it here — same precedent as the MenuBar hide in LandingPage.menu.css. */
+  .taskbar {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a set of mobile-specific layout bugs and polish gaps identified from device screenshots. Changes are scoped to the mobile/tablet breakpoints (and one width-aware graph tweak) — the desktop experience is unchanged. Each fix was verified visually at a 390×844 viewport with headless Chromium, and the production build passes.

## What was wrong & what changed

### ① Landing — welcome modal & top bar
- **Blue "default" buttons:** the welcome modal's *About Me / Service Spectrum / Contact* buttons set no `color`/`font-family`, so iOS fell back to its native control look (blue link-style text). Pinned the retro dark ink + `appearance: none` so they render as intended grayscale retro buttons; bumped touch sizing under `pointer: coarse`.
- **Stray gray strip at the top:** on phones the MenuBar + desktop icons are hidden and the glass AppSwitcher dock takes over, leaving the retro taskbar floating as a lone `#c0c0c0` bar at the top. Hidden on phones (same precedent as the existing MenuBar hide).
- Kept the retro Macintosh aesthetic intact — only the bugs were fixed.

### ② Projects — bottom row cut off
- `.stage` had a `min-height: 320px` floor and its own scroll nested inside AppView's scroll inside the 92dvh phone bezel → double-scroll that pushed the last grid row under the fold. On phones the floor is dropped (`min-height: 0`) so `.stage` is the sole scroller, plus bottom padding so the final row and the tiles' hover/focus lift aren't clipped.

### ③ Resume Highlights modal (most broken)
- **Tab overflow:** the tab row was `white-space: nowrap` + `flex: 1; text-align: center`, so long labels spilled past both ends and clipped mid-word ("Role Bullets" → "llets"). Now a horizontal scroll strip that keeps full labels.
- **Ghosting / bleed-through:** the mobile overlay disables blur, and the frame + tab pill were both 62%-opaque, so the wallpaper (and the Project Detail modal stacked underneath) read through. Made the mobile modal frame near-solid (`--lg-tint-solid`) and darkened the mobile scrim — benefits every `ModalFrame` consumer.
- **Clipped architecture diagram:** the ASCII `<pre>` used `pre-wrap` inside an `overflow: hidden` card, which mangled/clipped it. Switched to `white-space: pre` with its own horizontal scroll so the diagram stays column-aligned.

### ④ Skillset — Toolbelt bubble graph (most broken)
- Category labels overlapped badly (`forceCollide` reserves only circle radii, and 9 roots were packed into two tight rows). Made `computeRootPositions` width-aware: narrow screens get more rows / fewer columns so labels get horizontal room and the rows fill the height (no dead vertical band); labels shrink a step on phones. The original balanced two-row desktop layout is preserved unchanged.

### ⑤ About — wasted right-side space
- The fixed `210px` rail + `1fr` content stranded the short, left-aligned "I build" cascade and the 56ch lede beside a wide empty right gutter (worst in the 581–768px band). Collapsed to a single column through the whole tablet/phone band and centered the cascade; highlight cards stay two-up until phone width so tablet cards don't over-stretch.

## Files
- `src/components/layout/LandingPage/LandingPage.css`
- `src/components/features/portfolio/ProjectsAppView/ProjectsAppView.module.css`
- `src/components/features/portfolio/ResumeHighlightsModal/ResumeHighlightsModal.css`
- `src/components/features/modal/ModalFrame.module.css` (shared — fixes ghosting for all modals on mobile)
- `src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx` + `ToolbeltGraph.module.css`
- `src/components/features/about/AboutAppView/AboutAppView.module.css`

## Testing
- `npm run build` — passes (compile, type-check, lint).
- Visually verified each screen at 390×844 (headless Chromium): welcome buttons render dark; no stray taskbar; Projects last row reachable; Resume tabs/diagram intact with no ghosting; Skillset labels no longer overlap and fill the space; About cascade centered with no right gutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8CpF8zt3P6koM4WFuc8oL

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8CpF8zt3P6koM4WFuc8oL)_