### PR TITLE
Recover from stale-chunk load errors, fix unrecoverable WebGL context loss

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import { recoverFromChunkError } from "@/lib/utils/chunkErrorRecovery";
+
+// Catches render-time failures anywhere under this page — including a
+// stale chunk (from a tab left open across a new deployment) failing to
+// load when a lazily-loaded view (Projects, About, Services, ...) actually
+// opens, not just during a hover preload. Chunk errors self-heal via a
+// one-time reload; anything else falls back to a manual retry.
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    recoverFromChunkError(error);
+  }, [error]);
+
+  return (
+    <div
+      role="alert"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1rem",
+        minHeight: "100vh",
+        padding: "2rem",
+        textAlign: "center",
+        fontFamily: "var(--font-primary, sans-serif)",
+        color: "#e4e2e2",
+        background: "#1e1e1e",
+      }}
+    >
+      <p>Something went wrong loading this view.</p>
+      <button
+        type="button"
+        onClick={() => reset()}
+        style={{
+          padding: "0.5rem 1.25rem",
+          borderRadius: "6px",
+          border: "1px solid currentColor",
+          background: "transparent",
+          color: "inherit",
+          cursor: "pointer",
+        }}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import ChunkErrorRecoveryListener from "@/components/ChunkErrorRecoveryListener";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://demaceovincent.com"),
@@ -65,6 +66,7 @@ export default function RootLayout({
         />
       </head>
       <body>
+        <ChunkErrorRecoveryListener />
         {children}
         <SpeedInsights />
       </body>

--- a/src/components/ChunkErrorRecoveryListener.tsx
+++ b/src/components/ChunkErrorRecoveryListener.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+import { initChunkErrorRecovery } from "@/lib/utils/chunkErrorRecovery";
+
+// Mounted once at the root so a stale tab (left open across a new
+// deployment) recovers automatically instead of leaving dead
+// hover/click interactions and console errors behind.
+export default function ChunkErrorRecoveryListener() {
+  useEffect(() => initChunkErrorRecovery(), []);
+  return null;
+}

--- a/src/components/layout/LandingPage/components/DesktopRain.tsx
+++ b/src/components/layout/LandingPage/components/DesktopRain.tsx
@@ -135,35 +135,49 @@ export default function DesktopRain() {
     const gl = renderer.gl;
     gl.clearColor(0, 0, 0, 0);
 
-    const geometry = new Triangle(gl);
-    const texture = new Texture(gl, {
-      generateMipmaps: false,
-      minFilter: gl.LINEAR,
-    });
-
-    const program = new Program(gl, {
-      vertex: vertexShader,
-      fragment: fragmentShader,
-      transparent: true,
-      uniforms: {
-        uTime: { value: 0 },
-        tMap: { value: texture },
-        uResolution: { value: [container.clientWidth, container.clientHeight] },
-        uImageResolution: { value: [1, 1] },
-      },
-    });
-
-    const mesh = new Mesh(gl, { geometry, program });
-
     const image = new Image();
+    image.src = "/images/palmtreeleaves-5.jpg";
+
+    // GPU-side objects (buffers, textures, compiled programs) don't survive
+    // a WebGL context loss — everything here gets rebuilt from scratch both
+    // on first mount and again after "webglcontextrestored".
+    let program: Program;
+    let mesh: Mesh;
+    function setupScene() {
+      const geometry = new Triangle(gl);
+      const texture = new Texture(gl, {
+        generateMipmaps: false,
+        minFilter: gl.LINEAR,
+      });
+      if (image.complete && image.naturalWidth) texture.image = image;
+
+      program = new Program(gl, {
+        vertex: vertexShader,
+        fragment: fragmentShader,
+        transparent: true,
+        uniforms: {
+          uTime: { value: 0 },
+          tMap: { value: texture },
+          uResolution: { value: [container.clientWidth, container.clientHeight] },
+          uImageResolution: {
+            value: image.complete
+              ? [image.naturalWidth, image.naturalHeight]
+              : [1, 1],
+          },
+        },
+      });
+
+      mesh = new Mesh(gl, { geometry, program });
+    }
+    setupScene();
+
     image.onload = () => {
-      texture.image = image;
+      (program.uniforms.tMap.value as Texture).image = image;
       program.uniforms.uImageResolution.value = [
         image.naturalWidth,
         image.naturalHeight,
       ];
     };
-    image.src = "/images/palmtreeleaves-5.jpg";
 
     function resize() {
       renderer.setSize(container.clientWidth, container.clientHeight);
@@ -198,9 +212,10 @@ export default function DesktopRain() {
     // size (so the IntersectionObserver reports it as off-screen).
     let tabVisible = document.visibilityState === "visible";
     let onScreen = true;
+    let contextLost = false;
 
     function sync() {
-      const shouldRun = !disposed && tabVisible && onScreen;
+      const shouldRun = !disposed && !contextLost && tabVisible && onScreen;
       if (shouldRun && animationId === null) {
         animationId = requestAnimationFrame(update);
       } else if (!shouldRun && animationId !== null) {
@@ -221,6 +236,24 @@ export default function DesktopRain() {
     });
     observer.observe(container);
 
+    // A lost context (GPU driver reset, tab backgrounded a long time, too
+    // many WebGL contexts open) is unrecoverable unless the loss event is
+    // told to allow restoration — without this, "webglcontextrestored"
+    // never fires and the canvas stays blank for the rest of the session.
+    function onContextLost(event: Event) {
+      event.preventDefault();
+      contextLost = true;
+      sync();
+    }
+    function onContextRestored() {
+      contextLost = false;
+      setupScene();
+      resize();
+      sync();
+    }
+    gl.canvas.addEventListener("webglcontextlost", onContextLost, false);
+    gl.canvas.addEventListener("webglcontextrestored", onContextRestored, false);
+
     sync();
 
     return () => {
@@ -229,6 +262,8 @@ export default function DesktopRain() {
       document.removeEventListener("visibilitychange", onVisibilityChange);
       observer.disconnect();
       window.removeEventListener("resize", resize);
+      gl.canvas.removeEventListener("webglcontextlost", onContextLost);
+      gl.canvas.removeEventListener("webglcontextrestored", onContextRestored);
       image.onload = null;
       if (gl.canvas.parentNode === container) {
         container.removeChild(gl.canvas);

--- a/src/lib/utils/chunkErrorRecovery.ts
+++ b/src/lib/utils/chunkErrorRecovery.ts
@@ -1,0 +1,42 @@
+// A tab left open across a new deployment still references the previous
+// build's content-hashed chunk filenames, which no longer exist on the
+// server once the next deploy replaces them — surfacing as 404s and
+// "ChunkLoadError". Recovering just means getting the tab onto the current
+// deployment.
+const RELOAD_FLAG_KEY = "chunk-error-reload-attempted";
+
+export const isChunkLoadError = (error: unknown): boolean => {
+    if (!error || typeof error !== "object") return false;
+    const { name, message } = error as { name?: unknown; message?: unknown };
+    if (name === "ChunkLoadError") return true;
+    return typeof message === "string" && /Loading (chunk|CSS chunk) [\w.-]+ failed/i.test(message);
+};
+
+// Reloads once per tab session on a chunk load error so a stale client
+// self-heals. Guarded by sessionStorage so a persistent failure (e.g. an
+// actual outage) can't loop the tab on repeated reloads.
+export const recoverFromChunkError = (error: unknown): boolean => {
+    if (typeof window === "undefined" || !isChunkLoadError(error)) return false;
+    if (window.sessionStorage.getItem(RELOAD_FLAG_KEY)) return false;
+    window.sessionStorage.setItem(RELOAD_FLAG_KEY, "1");
+    window.location.reload();
+    return true;
+};
+
+// Safety net for chunk load failures that surface as unhandled rejections
+// or global errors rather than being caught by a React error boundary
+// (e.g. a background preload, or a loader promise no one awaits).
+export const initChunkErrorRecovery = () => {
+    if (typeof window === "undefined") return () => {};
+
+    const onError = (event: ErrorEvent) => recoverFromChunkError(event.error);
+    const onRejection = (event: PromiseRejectionEvent) => recoverFromChunkError(event.reason);
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+
+    return () => {
+        window.removeEventListener("error", onError);
+        window.removeEventListener("unhandledrejection", onRejection);
+    };
+};

--- a/src/lib/utils/preload.ts
+++ b/src/lib/utils/preload.ts
@@ -1,4 +1,6 @@
 // Idle and intent-based preloading to improve INP on first open
+import { recoverFromChunkError } from "./chunkErrorRecovery";
+
 type RequestIdleCallback = (cb: () => void) => number | undefined;
 
 const idle: RequestIdleCallback = (cb) => {
@@ -11,16 +13,28 @@ const idle: RequestIdleCallback = (cb) => {
     return window.setTimeout(cb, 1);
 };
 
+// Callers fire these on hover/focus and never await the result, so an
+// uncaught rejection (e.g. a stale chunk 404ing after a new deploy) would
+// otherwise surface only as an unhandled promise rejection in the console.
+// Catch it here, and hand chunk load failures to the reload recovery so the
+// tab self-heals instead of leaving preloading permanently broken.
+const withRecovery = <T>(loader: () => Promise<T>) => (): Promise<T | void> =>
+    loader().catch((error) => {
+        if (!recoverFromChunkError(error)) throw error;
+    });
+
 // Dynamic import preloaders for code splitting
 export const preloadModules = {
-    contact: () => import("@/components/features/contact/ContactForm/ContactForm"),
-    about: () => import("@/components/features/about/AboutAppView/AboutAppView"),
-    skillset: () => import("@/components/features/skills/SkillsetAppView/SkillsetAppView"),
-    projects: () =>
-        import("@/components/features/portfolio/ProjectsAppView/ProjectsAppView"),
-    documentary: () =>
-        import("@/components/features/media").then((m) => m.DocumentaryPlayer),
-    resume: () => import("@/components/features/resume/InteractiveResume/InteractiveResume"),
+    contact: withRecovery(() => import("@/components/features/contact/ContactForm/ContactForm")),
+    about: withRecovery(() => import("@/components/features/about/AboutAppView/AboutAppView")),
+    skillset: withRecovery(() => import("@/components/features/skills/SkillsetAppView/SkillsetAppView")),
+    projects: withRecovery(() =>
+        import("@/components/features/portfolio/ProjectsAppView/ProjectsAppView")
+    ),
+    documentary: withRecovery(() =>
+        import("@/components/features/media").then((m) => m.DocumentaryPlayer)
+    ),
+    resume: withRecovery(() => import("@/components/features/resume/InteractiveResume/InteractiveResume")),
 };
 
 // On-intent network warmup for PBS iframe origin


### PR DESCRIPTION
## Summary

- Fixes the reported `ChunkLoadError: Loading chunk 229 failed` bug: a tab left open across a new deployment references build chunks that no longer exist on the server (content-hashed filenames rotate every build). Hovering "Projects" in the menu bar (which calls `preload.projects()`) hit this and silently broke — the promise rejection went unhandled and the view never opened.
- Adds `src/lib/utils/chunkErrorRecovery.ts`, a shared utility that detects chunk-load failures and reloads the tab once (guarded via `sessionStorage` so a genuine outage can't loop the tab on repeated reloads).
- Wires that recovery into:
  - `src/lib/utils/preload.ts` — the hover/focus preloaders (`MenuBar`, `WelcomeWindow`, `DesktopIcons`, `AppSwitcher` all call these without awaiting the result), which is the actual source of the unhandled rejections in the original report.
  - `src/components/ChunkErrorRecoveryListener.tsx`, mounted in `src/app/layout.tsx` — a global safety net for chunk failures that surface as `window` `error`/`unhandledrejection` events anywhere on the site.
  - `src/app/error.tsx` — a root error boundary for failures that surface when a lazily-loaded view (Projects, About, Services, Contact, ...) actually opens rather than during a background preload; falls back to a manual "Try again" for non-chunk errors.
- While investigating, found and fixed an unrelated bug surfaced by a follow-up console error the user reported (`WebGL: CONTEXT_LOST_WEBGL`): `DesktopRain` (the rain-on-glass canvas effect) never listened for `webglcontextlost`/`webglcontextrestored`. Per the WebGL spec, a lost context stays permanently dead for the rest of the session unless the loss event calls `preventDefault()` — so any GPU reset (backgrounded tab, driver reset, low memory) silently and irrecoverably blanked the effect. Scene setup (geometry/texture/program/mesh) is now factored into a reusable function that reruns on `webglcontextrestored`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] Verified in a real headless Chromium session (Playwright) against `next start`:
  - Normal load + hover/click through the menu still works with no regressions; `DesktopRain`'s animation renders correctly.
  - Dispatched a synthetic `unhandledrejection` shaped exactly like the reported error (`name: "ChunkLoadError"`, message referencing `chunks/229...js`) — confirmed it triggers exactly one `window.location.reload()` and sets the guard flag.
  - Confirmed a second chunk error after the guard flag is set does *not* trigger a repeat reload (no reload loop).
  - Confirmed an unrelated rejection does *not* trigger a reload.
  - Confirmed `error.tsx` is bundled with the same recovery logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_011bLv3Bgk67K2ycuouK1P89)_