### PR TITLE
Redesign mobile AppSwitcher as a full-width labeled tab bar

### DIFF
--- a/src/components/layout/LandingPage/components/AppSwitcher.css
+++ b/src/components/layout/LandingPage/components/AppSwitcher.css
@@ -1,7 +1,10 @@
 /* ===== Mobile App Switcher (≤480px) =====
-   Adapted from codepenz's "Apple Liquid Glass Switcher": a glass-refraction
-   pill with a sliding capsule indicator. The pen hardcodes exactly 3 option
-   positions via one CSS selector block per option; here the pill's position
+   A labeled, full-width bottom tab bar — not the small icon-only floating
+   pill this used to be. Spans the framed screen edge-to-edge (minus a small
+   margin) so each of the 4 tabs gets a real touch target and a visible name,
+   instead of 4 unlabeled glyphs squeezed into an auto-width pill. Still
+   built on the same "Apple Liquid Glass Switcher" codepen technique for the
+   glass-refraction pill and sliding capsule indicator — the pill's position
    is driven generically for any N by two custom properties set from JS
    (--n-options, --active-index) — translateX(<active-index> * 100%) moves
    the indicator by exactly its own width per step, since percentage
@@ -17,9 +20,9 @@
 .app-switcher-dock {
   display: none;
   position: absolute;
-  left: 50%;
-  bottom: calc(22px + env(safe-area-inset-bottom, 0px));
-  transform: translateX(-50%);
+  left: 14px;
+  right: 14px;
+  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
   z-index: 4;
 }
 
@@ -32,12 +35,13 @@
 .app-switcher {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: stretch;
+  width: 100%;
   gap: 4px;
   margin: 0;
-  padding: 4px;
+  padding: 8px;
   border: 1px solid var(--lg-edge);
-  border-radius: 999px;
+  border-radius: 22px;
   background: var(--lg-tint);
   box-shadow: var(--lg-shadow);
   box-sizing: border-box;
@@ -55,15 +59,18 @@
   overflow: hidden;
 }
 
-/* Sliding capsule indicator — one generic rule instead of one per option. */
+/* Sliding capsule indicator — one generic rule instead of one per option.
+   Rounded-rect (not a stadium) so it matches each tab cell's own footprint;
+   a stadium capsule behind a taller icon+label cell would overshoot the
+   cell's corners the same way the old undersized icon tile did. */
 .app-switcher::after {
   content: "";
   position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 4px;
-  width: calc((100% - 8px) / var(--n-options));
-  border-radius: 999px;
+  top: 8px;
+  bottom: 8px;
+  left: 8px;
+  width: calc((100% - 16px) / var(--n-options));
+  border-radius: 16px;
   background: var(--noir-accent);
   box-shadow: 0 2px 8px var(--noir-accent-glow);
   transform: translateX(calc(var(--active-index) * 100%));
@@ -76,12 +83,15 @@
   position: relative;
   z-index: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   flex: 1 1 0;
-  min-width: 44px;
-  min-height: 44px;
-  border-radius: 999px;
+  min-width: 0;
+  min-height: 52px;
+  gap: 3px;
+  padding: 6px 2px;
+  border-radius: 16px;
   color: var(--noir-muted);
   cursor: pointer;
   transition: color 0.2s ease, transform 0.15s ease;
@@ -120,21 +130,27 @@
   overflow: hidden;
 }
 
-/* Matches .app-switcher-option's own 44px box exactly, so the icon tile and
-   the sliding accent capsule underneath it share the same circular footprint
-   — a smaller/squarer tile floating inside the larger pill-shaped capsule
-   read as a mismatched, blown-out glow around the active icon. Scoped through
-   the parent option because LandingPage.css's ".icon-image" base rule (48px,
-   10px radius) ties this class on specificity, so cascade order alone can't
-   be trusted to pick this override. */
+/* Sized to sit above the label within the option's 52px cell, with room
+   left for the sliding capsule's own padding. Scoped through the parent
+   option because LandingPage.css's ".icon-image" base rule (48px, 10px
+   radius) ties this class on specificity, so cascade order alone can't be
+   trusted to pick this override. */
 .app-switcher-option .app-switcher-icon-image {
-  width: 44px;
-  height: 44px;
+  width: 30px;
+  height: 30px;
   border-radius: 999px;
 }
 
 .app-switcher-icon-image .icon-glass-content {
-  font-size: 1.1rem;
+  font-size: 1rem;
+}
+
+.app-switcher-label {
+  font-family: var(--font-secondary);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
 }
 
 /* LandingPage.css's shared ".icon-image svg" rule hardcodes a dark navy

--- a/src/components/layout/LandingPage/components/AppSwitcher.tsx
+++ b/src/components/layout/LandingPage/components/AppSwitcher.tsx
@@ -134,6 +134,9 @@ const AppSwitcher: React.FC<AppSwitcherProps> = ({
                   </span>
                 )}
               </span>
+              <span className="app-switcher-label" aria-hidden="true">
+                {app.name}
+              </span>
             </label>
           );
         })}


### PR DESCRIPTION
## Summary

Follow-up to #46. A screenshot of the live mobile UI showed the AppSwitcher dock reading as squished and under-designed: four unlabeled icon glyphs squeezed into a small auto-width pill floating in the middle of the screen, with a lot of unused space on either side and no indication of what each icon meant beyond a screen-reader-only label.

- Rebuilt it as a proper full-width bottom tab bar — spans the framed screen edge-to-edge (minus a small margin) instead of an auto-width centered pill, giving each tab a real touch target.
- Added a visible label under each icon (Mindset / Skillset / Projects / Contact), reusing the existing `DESKTOP_APPS` names. The label is `aria-hidden` so the existing screen-reader-only span remains the sole accessible name (no double announcement).
- The sliding active-state highlight is now a rounded-rect capsule sized to each tab's full icon+label cell, instead of a stadium shape sized only for the old icon-only pill — selection now reads as one clean highlight behind the whole tab rather than a mismatched shape behind just the icon.

## Changes

All changes are scoped to `AppSwitcher.tsx` (one new label `<span>`) and `AppSwitcher.css` (layout/sizing only, no other logic changes).

## Test plan

- [x] `npm run build` — compiles and type-checks cleanly
- [x] Verified visually with Playwright at an iPhone 13 mobile viewport: default state, each active-tab state (Mindset/Skillset/Contact, including the notification badge), full-page context, and with the "Welcome to My Portfolio" window still open (matching the reported scenario) — the bar now reads as a real tab bar with legible labels and a clean active-state highlight
- [x] Confirmed the accessible name (including the "new notification" suffix for Contact) is unaffected — the new label is `aria-hidden`


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3PooauKqLdw5HS1PRE4Nm)_