### PR TITLE
Add vertical swipe for per-service detail panels in Skillset → Services

### DIFF
--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
@@ -68,9 +68,18 @@
 .skillTab:focus-visible,
 .plateArrow:focus-visible,
 .plateDot:focus-visible,
+.plateVArrow:focus-visible,
+.plateVDot:focus-visible,
 .skillStudioByline:focus-visible {
   outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
+}
+
+/* The stage itself is keyboard-focusable (arrow-key nav); draw the ring inset
+   so it isn't clipped by the panel edges or the top/bottom bars. */
+.plateStage:focus-visible {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: -2px;
 }
 
 .skillStudioByline {
@@ -208,6 +217,89 @@
   max-width: 52ch;
 }
 
+/* ── Vertical info panels ─────────────────────────────── */
+
+/* Fixed-height viewport so the pinned header never shifts as panels of
+   different heights swap; clips the vertical slide. */
+.panelViewport {
+  position: relative;
+  width: 100%;
+  max-width: 52ch;
+  min-height: 138px;
+  margin-top: 0.1rem;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.panelSlide {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.panelEyebrow {
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--noir-faint);
+}
+
+.panelPoints {
+  margin: 0.1rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.42rem;
+  text-align: left;
+  max-width: 46ch;
+}
+
+.panelPoint {
+  position: relative;
+  padding-left: 1.1rem;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--skill-muted);
+}
+
+.panelPoint::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.6em;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--skill-accent);
+}
+
+.panelTags {
+  margin: 0.2rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+  max-width: 44ch;
+}
+
+.panelTag {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--skill-text);
+  background: var(--lg-tint);
+  border: 1px solid var(--lg-edge);
+  border-radius: 999px;
+  padding: 0.26rem 0.66rem;
+}
+
 /* ── Plate nav ────────────────────────────────────────── */
 
 .plateNav {
@@ -283,6 +375,88 @@
   background: var(--noir-muted);
 }
 
+/* ── Vertical rail (info-panel nav, right edge of the stage) ──── */
+
+.plateVRail {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem;
+  z-index: 2;
+}
+
+.plateVArrow {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--skill-panel);
+  border: 1px solid rgba(240, 236, 232, 0.14);
+  color: rgba(240, 236, 232, 0.45);
+  font-size: 0.68rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    transform 0.15s ease, opacity 0.2s ease;
+  flex-shrink: 0;
+}
+
+.plateVArrow:hover:not(:disabled) {
+  background: var(--noir-accent-soft);
+  border-color: var(--noir-accent-line);
+  color: var(--skill-accent);
+  transform: scale(1.05);
+}
+
+.plateVArrow:active:not(:disabled) {
+  transform: scale(0.94);
+}
+
+.plateVArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.plateVDots {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.44rem;
+}
+
+.plateVDot {
+  position: relative;
+  height: 6px;
+  width: 6px;
+  border-radius: 999px;
+  background: var(--noir-faint);
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.22s ease, height 0.22s ease;
+}
+
+/* Keep the 6px visual but expand the tap target for touch. */
+.plateVDot::after {
+  content: "";
+  position: absolute;
+  inset: -7px -9px;
+}
+
+.plateVDot.active {
+  background: var(--skill-accent);
+  height: 22px;
+}
+
+.plateVDot:hover:not(.active) {
+  background: var(--noir-muted);
+}
+
 /* ── Toolbelt: force-directed graph ───────────────────── */
 
 .skillTools {
@@ -307,8 +481,9 @@
     display: none;
   }
 
+  /* Extra right padding keeps body text clear of the vertical rail. */
   .servicePlate {
-    padding: 1.4rem 1.25rem;
+    padding: 1.4rem 2.2rem;
   }
 
   .plateIconHalo {
@@ -327,12 +502,29 @@
   .plateDescription {
     font-size: 0.84rem;
   }
+
+  .panelViewport {
+    min-height: 120px;
+  }
+
+  .plateVRail {
+    right: 0.35rem;
+    gap: 0.5rem;
+  }
+
+  .plateVArrow {
+    width: 26px;
+    height: 26px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .servicePlate,
   .plateDot,
-  .plateArrow {
+  .plateArrow,
+  .plateVArrow,
+  .plateVDot,
+  .panelSlide {
     transition: none;
   }
 }

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
@@ -1,11 +1,16 @@
 import React, { useMemo, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { motion, AnimatePresence, useReducedMotion, type Variants } from "framer-motion";
-import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronLeft,
+  faChevronRight,
+  faChevronUp,
+  faChevronDown,
+} from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
 import services from "@/data/services";
 import tools from "@/data/toolbelt";
-import { ModalProps } from "@/lib/types";
+import { ModalProps, type Service } from "@/lib/types";
 import { AppView } from "@/components/features/shell";
 import ToolbeltGraph from "./ToolbeltGraph";
 import styles from "./SkillsetAppView.module.css";
@@ -24,15 +29,21 @@ const orderedCategories = [
   "Documentation",
 ];
 
-const serviceOutcomes: Record<string, string> = {
-  sb1: "Conversion-focused web experiences with production analytics.",
-  sb2: "App flows that feel native, fast, and easy to learn.",
-  sb3: "Accessible, responsive interfaces that scale in codebase and team size.",
-  sb4: "Predictable integrations and stable system-to-system communication.",
-  sb5: "Repeatable releases with deployment confidence and lower operational drag.",
-  sb6: "Clean domain models, faster queries, and durable data governance.",
-  sb7: "Less manual overhead through targeted automation and scripting.",
+// A service renders as a vertical stack of panels. Panel 0 ("Overview") is
+// synthesized from the service's outcome + description; any extra panels defined
+// in the data follow it and are reached by swiping vertically.
+type RenderPanel = {
+  label: string;
+  outcome?: string;
+  body?: string;
+  points?: string[];
+  kind?: "list" | "tags";
 };
+
+const buildPanels = (s: Service): RenderPanel[] => [
+  { label: "Overview", outcome: s.outcome, body: s.description },
+  ...(s.panels ?? []),
+];
 
 // Tools highlighted with the signature stroke/glow in the toolbelt graph.
 const signatureStack = ["React", "JavaScript", "Next.js", "Node.js", "AWS"];
@@ -53,9 +64,17 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
     return idx === -1 ? 0 : idx;
   });
   const [direction, setDirection] = useState<1 | -1>(1);
+
+  // Vertical carousel state — which info panel within the current service.
+  const [panelIndex, setPanelIndex] = useState(0);
+  const [vDirection, setVDirection] = useState<1 | -1>(1);
+
   const reduceMotion = useReducedMotion();
 
   const service = services[serviceIndex];
+  const panels = useMemo(() => buildPanels(service), [service]);
+  const panelCount = panels.length;
+  const panel = panels[panelIndex] ?? panels[0];
 
   // Plate slide timings collapse to instant under prefers-reduced-motion; the
   // enter/exit offsets stay so AnimatePresence still swaps plates correctly.
@@ -76,16 +95,73 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
     [reduceMotion]
   );
 
+  // Vertical panel slide — the y-axis mirror of plateVariants.
+  const panelVariants: Variants = useMemo(
+    () => ({
+      enter: (dir: number) => ({ opacity: 0, y: dir > 0 ? 24 : -24 }),
+      center: {
+        opacity: 1,
+        y: 0,
+        transition: reduceMotion ? { duration: 0 } : { duration: 0.28, ease: [0.16, 1, 0.3, 1] },
+      },
+      exit: (dir: number) => ({
+        opacity: 0,
+        y: dir > 0 ? -20 : 20,
+        transition: reduceMotion ? { duration: 0 } : { duration: 0.14, ease: "easeIn" },
+      }),
+    }),
+    [reduceMotion]
+  );
+
   const navigateService = (dir: 1 | -1) => {
     if (services.length <= 1) return;
     setDirection(dir);
     setServiceIndex((prev) => (prev + dir + services.length) % services.length);
+    // Reset the vertical axis whenever the service changes.
+    setPanelIndex(0);
+    setVDirection(1);
   };
 
   const goToService = (index: number) => {
     if (index === serviceIndex) return;
     setDirection(index > serviceIndex ? 1 : -1);
     setServiceIndex(index);
+    setPanelIndex(0);
+    setVDirection(1);
+  };
+
+  const navigatePanel = (dir: 1 | -1) => {
+    const next = panelIndex + dir;
+    if (next < 0 || next > panelCount - 1) return; // clamp — no wrap
+    setVDirection(dir);
+    setPanelIndex(next);
+  };
+
+  const goToPanel = (index: number) => {
+    if (index === panelIndex) return;
+    setVDirection(index > panelIndex ? 1 : -1);
+    setPanelIndex(index);
+  };
+
+  const onStageKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowLeft":
+        e.preventDefault();
+        navigateService(-1);
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        navigateService(1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        navigatePanel(-1);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        navigatePanel(1);
+        break;
+    }
   };
 
   return (
@@ -145,7 +221,15 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
           aria-labelledby="services-tab"
           hidden={activeTab !== "services"}
         >
-              <div className={styles.plateStage} aria-live="polite">
+              <div
+                className={styles.plateStage}
+                aria-live="polite"
+                tabIndex={0}
+                role="group"
+                aria-roledescription="carousel"
+                aria-label="Services — swipe or use arrow keys: left/right to change service, up/down for details"
+                onKeyDown={onStageKeyDown}
+              >
                 <AnimatePresence mode="wait" custom={direction}>
                   <motion.article
                     key={serviceIndex}
@@ -155,12 +239,20 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
                     animate="center"
                     exit="exit"
                     className={styles.servicePlate}
-                    drag="x"
-                    dragConstraints={{ left: 0, right: 0 }}
+                    drag
+                    dragConstraints={{ top: 0, bottom: 0, left: 0, right: 0 }}
                     dragElastic={0.08}
+                    dragDirectionLock
                     onDragEnd={(_, { offset, velocity }) => {
-                      const power = Math.abs(offset.x) + Math.abs(velocity.x) * 0.25;
-                      if (power > 70) navigateService(offset.x > 0 ? -1 : 1);
+                      // dragDirectionLock keeps the off-axis offset ~0, so the
+                      // larger absolute offset tells us which axis the user meant.
+                      if (Math.abs(offset.x) >= Math.abs(offset.y)) {
+                        const power = Math.abs(offset.x) + Math.abs(velocity.x) * 0.25;
+                        if (power > 70) navigateService(offset.x > 0 ? -1 : 1);
+                      } else {
+                        const power = Math.abs(offset.y) + Math.abs(velocity.y) * 0.25;
+                        if (power > 70) navigatePanel(offset.y > 0 ? -1 : 1);
+                      }
                     }}
                   >
                     <div className={styles.plateIconHalo} aria-hidden="true">
@@ -188,13 +280,95 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
 
                     <h2 className={styles.plateTitle}>{service.title}</h2>
 
-                    {serviceOutcomes[service.id] && (
-                      <p className={styles.plateOutcome}>{serviceOutcomes[service.id]}</p>
-                    )}
+                    {/* Vertical panel viewport — pinned header stays above this. */}
+                    <div className={styles.panelViewport}>
+                      <AnimatePresence mode="wait" custom={vDirection} initial={false}>
+                        <motion.div
+                          key={panelIndex}
+                          custom={vDirection}
+                          variants={panelVariants}
+                          initial="enter"
+                          animate="center"
+                          exit="exit"
+                          className={styles.panelSlide}
+                          role="group"
+                          aria-roledescription="slide"
+                          aria-label={`Panel ${panelIndex + 1} of ${panelCount}: ${panel.label}`}
+                        >
+                          {panelIndex > 0 && (
+                            <span className={styles.panelEyebrow}>{panel.label}</span>
+                          )}
 
-                    <p className={styles.plateDescription}>{service.description}</p>
+                          {panel.outcome && (
+                            <p className={styles.plateOutcome}>{panel.outcome}</p>
+                          )}
+
+                          {panel.body && (
+                            <p className={styles.plateDescription}>{panel.body}</p>
+                          )}
+
+                          {panel.points &&
+                            (panel.kind === "tags" ? (
+                              <ul className={styles.panelTags}>
+                                {panel.points.map((pt) => (
+                                  <li key={pt} className={styles.panelTag}>
+                                    {pt}
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : (
+                              <ul className={styles.panelPoints}>
+                                {panel.points.map((pt) => (
+                                  <li key={pt} className={styles.panelPoint}>
+                                    {pt}
+                                  </li>
+                                ))}
+                              </ul>
+                            ))}
+                        </motion.div>
+                      </AnimatePresence>
+                    </div>
                   </motion.article>
                 </AnimatePresence>
+
+                {/* Vertical rail — sibling of the draggable article to avoid
+                    tap-vs-drag conflicts. Hidden when a service has only Overview. */}
+                {panelCount > 1 && (
+                  <div className={styles.plateVRail} aria-label="Service details">
+                    <button
+                      type="button"
+                      className={styles.plateVArrow}
+                      onClick={() => navigatePanel(-1)}
+                      disabled={panelIndex === 0}
+                      aria-label="Previous detail"
+                    >
+                      <FontAwesomeIcon icon={faChevronUp} />
+                    </button>
+
+                    <div className={styles.plateVDots}>
+                      {panels.map((p, i) => (
+                        <button
+                          key={p.label}
+                          type="button"
+                          className={`${styles.plateVDot} ${i === panelIndex ? styles.active : ""}`}
+                          aria-current={i === panelIndex ? "true" : undefined}
+                          aria-label={`Show ${p.label}`}
+                          onClick={() => goToPanel(i)}
+                        />
+                      ))}
+                    </div>
+
+                    <button
+                      type="button"
+                      className={styles.plateVArrow}
+                      onClick={() => navigatePanel(1)}
+                      disabled={panelIndex === panelCount - 1}
+                      aria-label="Next detail"
+                    >
+                      <FontAwesomeIcon icon={faChevronDown} />
+                    </button>
+                  </div>
+                )}
               </div>
 
               <div className={styles.plateNav}>

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,10 +1,37 @@
-const services = [
+import type { Service } from "@/lib/types";
+
+const services: Service[] = [
   {
     id: "sb1",
     title: "Web Apps & Corporate Sites",
     description:
       "I craft websites and web apps that don't just look good — they serve a function. Whether it's a responsive marketing site or a fully-interactive dashboard, I merge aesthetic with utility to create experiences that work across browsers, devices, and humans.",
     icon: "/icons/services/WACS.png",
+    outcome: "Conversion-focused web experiences with production analytics.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "Responsive marketing sites & interactive dashboards",
+          "Consistent behavior across browsers and devices",
+          "Analytics & conversion tracking wired in from day one",
+          "Clean, handoff-ready code you actually own",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "Design-first and component-driven — I set performance budgets and accessibility checks early, then build in small, reviewable increments.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["React", "Next.js", "TypeScript", "Tailwind", "Vercel"],
+      },
+      {
+        label: "Ideal for",
+        body: "Founders and teams who need a site that looks sharp and does real work — not just a pretty brochure.",
+      },
+    ],
   },
   {
     id: "sb2",
@@ -12,6 +39,31 @@ const services = [
     description:
       "From napkin sketch to high-fidelity prototype, I design mobile experiences that feel intuitive and intentional. I keep platform guidelines and real-world users in mind, making sure the interface supports the story your app wants to tell (on iOS or Android).",
     icon: "/icons/services/MAD.png",
+    outcome: "App flows that feel native, fast, and easy to learn.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "Wireframes through high-fidelity prototypes",
+          "Platform-aware iOS & Android flows",
+          "Prototypes you can test with real users",
+          "A design system your devs can build from",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "I start from the user's job-to-be-done, sketch the flow, then raise fidelity only once the structure holds up.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["Figma", "Framer", "Prototyping", "Design Systems"],
+      },
+      {
+        label: "Ideal for",
+        body: "Teams turning a concept into something testable before committing engineering time.",
+      },
+    ],
   },
   {
     id: "sb3",
@@ -19,6 +71,31 @@ const services = [
     description:
       "I convert ideas and interfaces into responsive, accessible, production-ready code. My code is thoughtful, maintainable, and responsive. Think smooth transitions, semantic structure, and a UI that actually feels like it was built for people.",
     icon: "/icons/services/FED.png",
+    outcome: "Accessible, responsive interfaces that scale in codebase and team size.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "Production-ready, accessible components",
+          "Responsive layouts that hold up anywhere",
+          "Smooth, intentional transitions & states",
+          "Maintainable, clearly-structured code",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "Semantic markup first, then styling and motion — I keep components small, typed, and easy for the next dev to read.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["React", "Next.js", "TypeScript", "CSS", "Framer Motion"],
+      },
+      {
+        label: "Ideal for",
+        body: "Teams who need designs translated into code that stays clean as the product grows.",
+      },
+    ],
   },
   {
     id: "sb4",
@@ -26,6 +103,31 @@ const services = [
     description:
       "Good software needs solid structure. I design APIs that act like reliable messengers: fast, secure, and easy to work with. Whether it's building microservices or wiring up third-party integrations, the goal is clean communication between systems, no drama.",
     icon: "/icons/services/AM.png",
+    outcome: "Predictable integrations and stable system-to-system communication.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "REST/GraphQL APIs with clear contracts",
+          "Third-party integrations that just work",
+          "Auth, validation & error handling built in",
+          "Docs your team can actually follow",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "I model the data and contracts first, keep services focused, and make failure modes explicit instead of surprising.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["Node.js", "Express", "REST", "GraphQL", "PostgreSQL"],
+      },
+      {
+        label: "Ideal for",
+        body: "Products that need reliable communication between systems, services, or third parties.",
+      },
+    ],
   },
   {
     id: "sb5",
@@ -33,6 +135,31 @@ const services = [
     description:
       "I set up infrastructure that doesn't get in your way. I help take projects from 'it works on my machine..' to 'it works everywhere!'. I automate the tedious stuff so your ideas ship faster and more reliably. Out of sight but not out of mind - infrastructure as it should be.",
     icon: "/icons/services/CDO.png",
+    outcome: "Repeatable releases with deployment confidence and lower operational drag.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "CI/CD pipelines for repeatable releases",
+          "Infrastructure as code, not tribal knowledge",
+          "Environments that match from dev to prod",
+          "Monitoring so you hear about issues first",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "I automate the tedious, error-prone steps so shipping is boring in the best way — predictable and low-drama.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["AWS", "Docker", "GitHub Actions", "Terraform", "CI/CD"],
+      },
+      {
+        label: "Ideal for",
+        body: "Teams tired of manual deploys and 'works on my machine' surprises.",
+      },
+    ],
   },
   {
     id: "sb6",
@@ -40,6 +167,31 @@ const services = [
     description:
       "We expect our data to be cleanly organized, quickly accessible, and securely protected. Whether it's MongoDB, PostgreSQL, or something in between, I organize data in a way that makes it easy to find, secure to store, and fast to query.",
     icon: "/icons/services/DDD.png",
+    outcome: "Clean domain models, faster queries, and durable data governance.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "Schemas modeled around real access patterns",
+          "Indexes & queries tuned for speed",
+          "Migrations that won't wake you at 2am",
+          "Sensible backups & access controls",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "I map how the data is actually read and written first, then design a schema that stays fast and sane as it grows.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["PostgreSQL", "MongoDB", "SQL", "Prisma", "Redis"],
+      },
+      {
+        label: "Ideal for",
+        body: "Products where data is getting messy, slow, or hard to trust.",
+      },
+    ],
   },
   {
     id: "sb7",
@@ -47,6 +199,31 @@ const services = [
     description:
       "If it's repetitive, it likely can/should be automated and if I can automate it, I will. I build lightweight scripts and tools that cut down on repetitive tasks, reduce human error, and free up time for the stuff that actually needs a human.",
     icon: "/icons/services/AS.png",
+    outcome: "Less manual overhead through targeted automation and scripting.",
+    panels: [
+      {
+        label: "What you get",
+        points: [
+          "Scripts that kill repetitive manual work",
+          "Scheduled jobs & one-click tasks",
+          "Fewer human errors in routine processes",
+          "Time back for work that needs a human",
+        ],
+      },
+      {
+        label: "How I work",
+        body: "I find the repetitive, error-prone steps, script them, and leave you something small, documented, and easy to rerun.",
+      },
+      {
+        label: "Tech & tools",
+        kind: "tags",
+        points: ["Python", "Bash", "Node.js", "Cron", "GitHub Actions"],
+      },
+      {
+        label: "Ideal for",
+        body: "Anyone doing the same manual task over and over that a machine could handle.",
+      },
+    ],
   },
 ];
 

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -25,7 +25,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["React", "Next.js", "TypeScript", "Tailwind", "Vercel"],
+        points: [
+          "React",
+          "Next.js",
+          "TypeScript",
+          "JavaScript",
+          "HTML5",
+          "CSS3",
+          "Tailwind CSS",
+          "Figma",
+          "Vercel",
+          "Analytics",
+        ],
       },
       {
         label: "Ideal for",
@@ -57,7 +68,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["Figma", "Framer", "Prototyping", "Design Systems"],
+        points: [
+          "Figma",
+          "Framer",
+          "Prototyping",
+          "Wireframing",
+          "Design Systems",
+          "User Testing",
+          "iOS Guidelines",
+          "Material Design",
+          "Motion Design",
+          "Accessibility",
+        ],
       },
       {
         label: "Ideal for",
@@ -89,7 +111,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["React", "Next.js", "TypeScript", "CSS", "Framer Motion"],
+        points: [
+          "React",
+          "Vue.js",
+          "Next.js",
+          "TypeScript",
+          "JavaScript",
+          "HTML5",
+          "CSS3",
+          "Tailwind CSS",
+          "Framer Motion",
+          "Accessibility",
+        ],
       },
       {
         label: "Ideal for",
@@ -121,7 +154,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["Node.js", "Express", "REST", "GraphQL", "PostgreSQL"],
+        points: [
+          "Node.js",
+          "Express",
+          "REST",
+          "GraphQL",
+          "PostgreSQL",
+          "Redis",
+          "Docker",
+          "JWT Auth",
+          "Swagger",
+          "Webhooks",
+        ],
       },
       {
         label: "Ideal for",
@@ -153,7 +197,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["AWS", "Docker", "GitHub Actions", "Terraform", "CI/CD"],
+        points: [
+          "AWS",
+          "Google Cloud",
+          "Docker",
+          "Kubernetes",
+          "GitHub Actions",
+          "Terraform",
+          "CI/CD",
+          "Linux",
+          "Nginx",
+          "Monitoring",
+        ],
       },
       {
         label: "Ideal for",
@@ -185,7 +240,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["PostgreSQL", "MongoDB", "SQL", "Prisma", "Redis"],
+        points: [
+          "PostgreSQL",
+          "MongoDB",
+          "SQL",
+          "Prisma",
+          "Redis",
+          "Neon",
+          "Data Modeling",
+          "Query Optimization",
+          "Migrations",
+          "Backups",
+        ],
       },
       {
         label: "Ideal for",
@@ -217,7 +283,18 @@ const services: Service[] = [
       {
         label: "Tech & tools",
         kind: "tags",
-        points: ["Python", "Bash", "Node.js", "Cron", "GitHub Actions"],
+        points: [
+          "Python",
+          "Bash",
+          "Node.js",
+          "Cron",
+          "GitHub Actions",
+          "CLI Tools",
+          "Shell Scripting",
+          "Web Scraping",
+          "Task Scheduling",
+          "APIs",
+        ],
       },
       {
         label: "Ideal for",

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -27,13 +27,21 @@ export interface Project {
     gif?: string; // Optional field for GIFs
 }
 
+export interface ServicePanel {
+    label: string;              // eyebrow heading, e.g. "What you get"
+    body?: string;              // paragraph copy
+    points?: string[];          // bullet list / chip list
+    kind?: "list" | "tags";     // "tags" renders points as inline chips (used by Tech & tools)
+}
+
 export interface Service {
     id: string;
     title: string;
-    subtitle: string;
+    subtitle?: string;
     description: string;
     icon: string;
-    details?: string[];
+    outcome?: string;           // accent one-liner shown on the Overview panel
+    panels?: ServicePanel[];    // extra vertical panels; the "Overview" panel is synthesized from outcome + description
 }
 
 export interface TimelineItem {


### PR DESCRIPTION
## Summary

The Skillset app's **Services** tab already lets you swipe **horizontally** between the 7 services. This adds a **vertical** swipe *within each service* so you can navigate a small stack of corresponding info panels:

**Overview → What you get → How I work → Tech & tools → Ideal for**

Two independent axes: horizontal = which service (unchanged), vertical = which detail panel within the current service. During a vertical swipe the service's icon + counter + title stay **pinned**; only the info body slides.

## What changed

- **Dual-axis drag** on the service plate — `drag` + `dragDirectionLock` (framer-motion, already a dependency). `onDragEnd` picks the axis by the dominant offset and reuses the existing power threshold to dispatch either horizontal (`navigateService`, wraps) or vertical (`navigatePanel`, clamps at ends) navigation.
- **Nested `AnimatePresence`** — an inner presence keyed by `panelIndex` slides the info body on the y-axis while the header stays fixed. The vertical position **resets to Overview** whenever the service changes.
- **Vertical rail** on the right edge (up/down arrows + a dot indicator, disabled at the ends) as a sibling of the drag surface to avoid tap-vs-drag conflicts. Hidden for any service with only an Overview panel.
- **Keyboard nav** — the stage is focusable; ←/→ change service, ↑/↓ change panel, with aria labels and `aria-live` announcements. Reduced-motion and `<640px` layouts are handled.
- **Data-driven content** — the extra panels live in `src/data/services.ts`; "Tech & tools" renders as chips. The component's old `serviceOutcomes` side-map was migrated into an `outcome` field, and the `Service` type was reconciled (`subtitle` made optional, unused `details?` removed, new `outcome?`/`panels?` + a `ServicePanel` interface).

### Files

| File | Change |
|---|---|
| `src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx` | Dual-axis drag, nested `AnimatePresence`, panel state/handlers, reset-on-service-change, vertical rail, keyboard + a11y |
| `src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css` | Panel + vertical-rail styles; extended focus/responsive/reduced-motion blocks |
| `src/data/services.ts` | `outcome` + `panels` (4 each) for all 7 services; typed as `Service[]` |
| `src/lib/types/index.ts` | New `ServicePanel`; `Service` gains `outcome?`/`panels?` |

## Testing

- `npx tsc --noEmit` — clean
- `npx next lint` — no warnings or errors
- Drove the app in a real browser (Playwright): opened Skillset → Services and ran **30 functional checks, all passing, zero console/page errors** — Overview renders unchanged; vertical rail/dots/arrows move through the 5 panels with the header pinned; up/down disable at the ends; "Tech & tools" renders as chips; changing service resets the vertical axis to Overview; keyboard ←/→ and ↑/↓ work for both axes. Verified layout at desktop (1280px) and narrow (400px) widths — the rail never overlaps body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URBDdRHaEjStdx76jdohwv

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBDdRHaEjStdx76jdohwv)_