### PR TITLE
Add icons to Skillset Tech & tools tags and What you get bullets

### DIFF
--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
@@ -260,22 +260,20 @@
 }
 
 .panelPoint {
-  position: relative;
-  padding-left: 1.1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.38rem;
   font-size: 0.86rem;
   line-height: 1.5;
   color: var(--skill-muted);
 }
 
-.panelPoint::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.6em;
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--skill-accent);
+.panelPointIcon {
+  flex-shrink: 0;
+  width: 0.72rem;
+  font-size: 0.72rem;
+  color: var(--skill-accent);
+  margin-top: 0.3em;
 }
 
 .panelTags {
@@ -285,11 +283,14 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 0.4rem;
-  max-width: 44ch;
+  gap: 0.32rem;
+  max-width: 46ch;
 }
 
 .panelTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.34rem;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.01em;
@@ -297,7 +298,13 @@
   background: var(--lg-tint);
   border: 1px solid var(--lg-edge);
   border-radius: 999px;
-  padding: 0.26rem 0.66rem;
+  padding: 0.24rem 0.62rem;
+}
+
+.panelTagIcon {
+  font-size: 1rem;
+  color: var(--skill-text);
+  flex-shrink: 0;
 }
 
 /* ── Plate nav ────────────────────────────────────────── */

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.module.css
@@ -298,11 +298,11 @@
   background: var(--lg-tint);
   border: 1px solid var(--lg-edge);
   border-radius: 999px;
-  padding: 0.24rem 0.62rem;
+  padding: 0.2rem 0.58rem;
 }
 
 .panelTagIcon {
-  font-size: 1rem;
+  font-size: 1.5rem;
   color: var(--skill-text);
   flex-shrink: 0;
 }
@@ -488,22 +488,25 @@
     display: none;
   }
 
-  /* Extra right padding keeps body text clear of the vertical rail. */
+  /* Extra right padding keeps body text clear of the vertical rail. Padding
+     and gap are trimmed further here (vs. the pre-icon values) to make room
+     for the larger Tech & tools icons within the fixed plate height. */
   .servicePlate {
-    padding: 1.4rem 2.2rem;
+    padding: 1rem 2.2rem;
+    gap: 0.45rem;
   }
 
   .plateIconHalo {
-    width: 92px;
-    height: 92px;
+    width: 80px;
+    height: 80px;
   }
 
   .plateIcon {
-    width: 56px;
+    width: 48px;
   }
 
   .plateTitle {
-    font-size: 1.3rem;
+    font-size: 1.15rem;
   }
 
   .plateDescription {
@@ -512,6 +515,10 @@
 
   .panelViewport {
     min-height: 120px;
+  }
+
+  .panelSlide {
+    gap: 0.4rem;
   }
 
   .plateVRail {

--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
@@ -6,10 +6,12 @@ import {
   faChevronRight,
   faChevronUp,
   faChevronDown,
+  faCheck,
 } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
 import services from "@/data/services";
 import tools from "@/data/toolbelt";
+import { TECH_ICON_MAP, TECH_ICON_FALLBACK } from "@/lib/constants/techIcons";
 import { ModalProps, type Service } from "@/lib/types";
 import { AppView } from "@/components/features/shell";
 import ToolbeltGraph from "./ToolbeltGraph";
@@ -312,6 +314,11 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
                               <ul className={styles.panelTags}>
                                 {panel.points.map((pt) => (
                                   <li key={pt} className={styles.panelTag}>
+                                    <FontAwesomeIcon
+                                      icon={TECH_ICON_MAP[pt] ?? TECH_ICON_FALLBACK}
+                                      className={styles.panelTagIcon}
+                                      aria-hidden="true"
+                                    />
                                     {pt}
                                   </li>
                                 ))}
@@ -320,7 +327,12 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
                               <ul className={styles.panelPoints}>
                                 {panel.points.map((pt) => (
                                   <li key={pt} className={styles.panelPoint}>
-                                    {pt}
+                                    <FontAwesomeIcon
+                                      icon={faCheck}
+                                      className={styles.panelPointIcon}
+                                      aria-hidden="true"
+                                    />
+                                    <span>{pt}</span>
                                   </li>
                                 ))}
                               </ul>

--- a/src/lib/constants/techIcons.ts
+++ b/src/lib/constants/techIcons.ts
@@ -1,0 +1,132 @@
+import {
+  faReact,
+  faVuejs,
+  faJs,
+  faHtml5,
+  faCss3,
+  faDocker,
+  faLinux,
+  faAws,
+  faGoogle,
+  faFigma,
+  faNode,
+  faPython,
+  faGithub,
+  faApple,
+} from "@fortawesome/free-brands-svg-icons";
+import {
+  type IconDefinition,
+  faRocket,
+  faFileCode,
+  faCubes,
+  faChartLine,
+  faCloud,
+  faVectorSquare,
+  faCompassDrafting,
+  faShapes,
+  faSwatchbook,
+  faUserCheck,
+  faWandMagicSparkles,
+  faUniversalAccess,
+  faServer,
+  faRoute,
+  faDiagramProject,
+  faDatabase,
+  faBolt,
+  faKey,
+  faPlug,
+  faBoxesStacked,
+  faLayerGroup,
+  faArrowsRotate,
+  faGaugeHigh,
+  faSitemap,
+  faBoxArchive,
+  faCode,
+  faClockRotateLeft,
+  faTerminal,
+  faSpider,
+  faCalendarCheck,
+  faNetworkWired,
+  faLaptopCode,
+} from "@fortawesome/free-solid-svg-icons";
+
+// Resolves a "Tech & tools" chip label (see services.ts) to a representative
+// icon. Keyed by the exact tag string so services.ts can stay a flat
+// string[] — add a new tag there, add its lookup entry here.
+export const TECH_ICON_MAP: Record<string, IconDefinition> = {
+  // sb1 — Web Apps & Corporate Sites
+  React: faReact,
+  "Next.js": faRocket,
+  TypeScript: faFileCode,
+  JavaScript: faJs,
+  HTML5: faHtml5,
+  CSS3: faCss3,
+  "Tailwind CSS": faCubes,
+  Figma: faFigma,
+  Vercel: faCloud,
+  Analytics: faChartLine,
+
+  // sb2 — Mobile App Design
+  Framer: faVectorSquare,
+  Prototyping: faCompassDrafting,
+  Wireframing: faShapes,
+  "Design Systems": faSwatchbook,
+  "User Testing": faUserCheck,
+  "iOS Guidelines": faApple,
+  "Material Design": faGoogle,
+  "Motion Design": faWandMagicSparkles,
+  Accessibility: faUniversalAccess,
+
+  // sb3 — Front End Development (React/Next.js/TypeScript/JavaScript/
+  // HTML5/CSS3/Tailwind CSS/Accessibility already covered above)
+  "Vue.js": faVuejs,
+  "Framer Motion": faWandMagicSparkles,
+
+  // sb4 — API & Microservices
+  "Node.js": faNode,
+  Express: faServer,
+  REST: faRoute,
+  GraphQL: faDiagramProject,
+  PostgreSQL: faDatabase,
+  Redis: faBolt,
+  Docker: faDocker,
+  "JWT Auth": faKey,
+  Swagger: faFileCode,
+  Webhooks: faPlug,
+
+  // sb5 — Cloud & DevOps (Docker above)
+  AWS: faAws,
+  "Google Cloud": faGoogle,
+  Kubernetes: faBoxesStacked,
+  "GitHub Actions": faGithub,
+  Terraform: faLayerGroup,
+  "CI/CD": faArrowsRotate,
+  Linux: faLinux,
+  Nginx: faServer,
+  Monitoring: faGaugeHigh,
+
+  // sb6 — Data & Database Design (PostgreSQL/Redis above)
+  MongoDB: faLayerGroup,
+  SQL: faFileCode,
+  Prisma: faDiagramProject,
+  Neon: faDatabase,
+  "Data Modeling": faSitemap,
+  "Query Optimization": faGaugeHigh,
+  Migrations: faArrowsRotate,
+  Backups: faBoxArchive,
+
+  // sb7 — Automation & Scripting (Node.js/GitHub Actions above)
+  Python: faPython,
+  Bash: faCode,
+  Cron: faClockRotateLeft,
+  "CLI Tools": faTerminal,
+  "Shell Scripting": faFileCode,
+  "Web Scraping": faSpider,
+  "Task Scheduling": faCalendarCheck,
+  APIs: faNetworkWired,
+};
+
+// Defensive fallback for any tag string not in the map above (e.g. a new
+// tag added to services.ts without a matching entry). Mirrors
+// PROJECT_ICON_FALLBACK in projectIcons.ts for a consistent "unknown" glyph.
+export const TECH_ICON_FALLBACK: IconDefinition = faLaptopCode;


### PR DESCRIPTION
## Summary

Follow-up to #51 (the Skillset → Services vertical swipe). Feedback was that the "Tech & tools" panel — 10 plain-text chips per service — read as sparse next to the icon-rich rest of the site. This adds:

- A **matching icon on every Tech & tools chip** (React, Docker, AWS, Figma, etc.), sized to be clearly visible rather than a tiny decoration.
- A **uniform accent-colored checkmark** on every "What you get" bullet, replacing the old CSS dot marker, for visual consistency with the chip icons.

"How I work" and "Ideal for" are prose paragraphs and are unchanged.

## What changed

- **New `src/lib/constants/techIcons.ts`** — a `TECH_ICON_MAP: Record<string, IconDefinition>` name→icon lookup (mirrors the existing `PROJECT_ICON_MAP` pattern in `projectIcons.ts`) covering all 56 unique tag strings across the 7 services, plus a `TECH_ICON_FALLBACK`. Icon choices reuse the same FontAwesome icons the Toolbelt graph already uses for overlapping names (e.g. Tailwind CSS → same cube icon, PostgreSQL → same database icon), so a technology renders identically across both features. Every import name was independently verified against the installed `@fortawesome/free-{solid,brands}-svg-icons` v6.7.2 type definitions before use.
- **`SkillsetAppView.tsx`** — the tags/bullets render block now looks up each tag's icon (falling back to a generic icon if a tag is ever added without a mapping) and renders a uniform check icon per bullet. `services.ts`/`types/index.ts` are untouched — this only changes how existing content renders, keyed by a data-only lookup table.
- **`SkillsetAppView.module.css`** — `.panelTag` becomes a flex row (icon + label); new `.panelTagIcon`/`.panelPointIcon` classes; the old `.panelPoint::before` dot rule is removed (the checkmark replaces its job).

Icon sizing went through one round of adjustment: the first pass was too subtle, so icons were enlarged; that in turn pushed one service's chip row count high enough to risk clipping on a short mobile viewport, so chip padding/gaps were tightened alongside the larger icon to keep total content height within the existing layout budget.

## Testing

- `npx tsc --noEmit` — clean
- `npx next lint` — no warnings or errors
- Playwright-driven checks in a real browser:
  - All 7 services × (10 Tech & tools icons + 4 What you get checkmarks) render — 14/14 checks passed, zero console/page errors.
  - Desktop (1280px) and the worst-case mobile viewport (400×780, longest-word service "Mobile App Design") both verified — a direct per-chip bounding-box check confirmed all 10 chips render fully within the panel's visible bounds with zero clipping, down to the pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URBDdRHaEjStdx76jdohwv

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBDdRHaEjStdx76jdohwv)_