### PR TITLE
Fix "I build" hero cascade not clipping to its peek window on mobile

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.module.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.module.css
@@ -675,6 +675,13 @@
   }
 
   .aboutHeroScroll {
+    /* The base rule's `flex: 1` (flex-basis: 0%) still applies here, and in a
+       column-direction flex item a definite flex-basis overrides `height` for
+       main-axis sizing — so `height: 6rem` alone was silently ignored and the
+       list grew to its full content height instead of clipping. `flex: none`
+       makes flex-basis resolve to `auto`, restoring `height` as authoritative
+       so overflow/scroll-snap/the mask-gradient peek window work again. */
+    flex: none;
     height: 6rem;
     width: 100%;
     align-self: stretch;


### PR DESCRIPTION
## Summary

Follow-up to #48. A new device screenshot showed the About screen's "I build ___" word cascade still broken on mobile: instead of a small, scroll-snapped "peek window" showing one bright/focused word with dim neighbors fading above/below, **all 11 words rendered stacked at full height, spanning nearly the entire screen**.

## Root cause

In `AboutAppView.module.css`:
- The base `.aboutHeroScroll` rule sets `flex: 1; height: 8rem; overflow-y: auto`. On desktop `.aboutHero` is row-direction, so `flex: 1`'s `flex-basis: 0%` governs *width* while `height: 8rem` governs the *cross* axis untouched — this works correctly.
- The `@media (max-width: 768px)` block (added in #48) sets `.aboutHero { flex-direction: column }`, flipping the main axis to vertical. The mobile override added `height: 6rem` but never reset `flex` — so the inherited `flex: 1` (`flex-basis: 0%`) still governs main-axis sizing in column direction, and **a definite flex-basis overrides the `height` property**. Since `.aboutHero` itself has only a `min-height` (not fixed), the flex algorithm fell back to sizing the list by its full content height instead of clipping it — so `overflow-y: auto` had nothing to clip and `scroll-snap` never engaged.
- This also silently broke the mount-time centering logic in `AboutAppView.tsx` (`centerHeroList`), which computes `scrollTop` from `clientHeight` — with no real overflow, it had no visible effect.

This was a regression exposed by the #48 fix that extended `flex-direction: column` from ≤580px up to ≤768px.

## Fix

Add `flex: none;` to the mobile `.aboutHeroScroll` rule. This makes `flex-basis` resolve to `auto`, so the explicit `height: 6rem` becomes authoritative again for main-axis sizing — restoring the clipped overflow, scroll-snap, mask-gradient peek effect, and mount-time centering on the starting word ("Platforms"). Single-property, mobile-only change; desktop is untouched.

## Testing
- `npm run build` — passes (compile, type-check, lint).
- Visually verified with headless Chromium at three widths:
  - **390px (phone):** compact ~3-line window, "Platforms" bright/centered, neighbors fading — Profile content directly below, not pushed off-screen.
  - **700px (tablet, still ≤768px):** same compact carousel behavior; 2-column highlight grid correctly preserved above the 580px threshold.
  - **1440px (desktop):** unchanged row-direction layout, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8CpF8zt3P6koM4WFuc8oL

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8CpF8zt3P6koM4WFuc8oL)_