### PR TITLE
Rewrite AboutAppView content with specific, provable differentiators

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.module.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.module.css
@@ -233,6 +233,19 @@
 
 /* ── Profile highlights ───────────────────────────────── */
 
+.aboutCredibilityStrip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: -0.1rem 0 0.15rem;
+}
+
+.aboutCredibilityNote {
+  font-size: 0.72rem;
+  color: var(--about-faint);
+}
+
 .aboutHighlightGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/components/features/about/AboutAppView/AboutAppView.tsx
+++ b/src/components/features/about/AboutAppView/AboutAppView.tsx
@@ -15,38 +15,39 @@ interface AboutAppViewProps {
 
 // "I build ___" hero — see codepenz's scroll-timeline-word-highlight for the
 // underlying CSS mechanism (animation-timeline: view()). Words are pulled
-// from the actual services/project domains, not the pen's placeholders.
+// from the actual shipped-project domains (Pinpoint, Payback, RentHarbor,
+// Feng Shui, Yap United), not generic category nouns.
 const ABOUT_HERO_WORDS = [
-  "Websites",
+  "Civic Platforms",
+  "Privacy Systems",
+  "AI Pipelines",
+  "3D Experiences",
+  "Voice Interfaces",
+  "Realtime Apps",
+  "Secure APIs",
   "Mobile Apps",
-  "APIs",
-  "Dashboards",
-  "Pipelines",
-  "Platforms",
-  "Systems",
-  "Experiences",
+  "Design Systems",
   "Automations",
   "Products",
-  "Interfaces",
 ];
 const ABOUT_HERO_START_INDEX = 5;
 
 const profileHighlights = [
   {
-    label: "Core Role",
-    value: "Product-minded software engineer and UI-focused builder",
+    label: "Shipped Track Record",
+    value: "5 production apps, solo — civic tech, privacy AI, PropTech, spatial AI, real-time voice — in 12 months.",
   },
   {
-    label: "Operating Mode",
-    value: "Calm execution, high ownership, and strong follow-through",
+    label: "Signature Engineering Move",
+    value: "Verified Firebase tokens via Google's JWKS directly — no Admin SDK, no exposed service account.",
   },
   {
-    label: "Team Value",
-    value: "Bridges strategy, design, and implementation",
+    label: "Full-Stack Ownership",
+    value: "Architecture, security, compliance docs, and 3D graphics — end to end, not handed off.",
   },
   {
-    label: "Primary Focus",
-    value: "Human-centered systems with measurable product outcomes",
+    label: "Public Recognition",
+    value: "Featured in a PBS documentary on public interest tech; SXSW EDU 2025 panelist.",
   },
 ];
 
@@ -54,25 +55,25 @@ const collaborationSections = [
   {
     title: "How I Think",
     points: [
-      "I break complex problems into practical delivery steps.",
-      "I stay focused on user outcomes, not just feature output.",
-      "I move between detail and big picture without losing momentum.",
+      "I look for the constraint that actually breaks first — a rate limit, a token budget, a background task getting killed — before I reach for a clever solution.",
+      "I treat security and compliance as design inputs, not cleanup: an on-device AES-256-GCM vault and JWKS-based auth were both scoped in from day one, not bolted on after an incident.",
+      "I'd rather ship the smaller, correct architecture than the impressive one.",
     ],
   },
   {
     title: "How I Work",
     points: [
-      "I prefer clear constraints, clean tradeoffs, and accountable execution.",
-      "I communicate early when risk appears, then propose options with impact.",
-      "I prioritize maintainable systems that teams can extend confidently.",
+      "I've been the sole engineer, designer, and product owner on 5 shipped apps at once — I close the loop myself instead of waiting on a hand-off.",
+      "I write the deployment runbook and the compliance doc in the same sprint as the feature, not after someone asks where they are.",
+      "I default to typed, tested, CI-gated code — strict TypeScript, GitHub Actions, pre-commit hooks — so \"it works on my machine\" isn't a phase I pass through.",
     ],
   },
   {
     title: "How I Collaborate",
     points: [
-      "I work best in cooperative teams with direct, respectful feedback.",
-      "I default to alignment through context, examples, and shared language.",
-      "I balance speed and quality so decisions remain durable over time.",
+      "I hand off systems other engineers can extend without a walkthrough — documented APIs, Postman collections, and architecture diagrams included.",
+      "I mentor deliberately: years of 1:1 code reviews and mock interviews for bootcamp grads, not just filling in when a team needed an extra reviewer.",
+      "I say the risk out loud early, then bring options — not just a problem — because a team that trusts the flag will trust the fix.",
     ],
   },
 ];
@@ -254,8 +255,18 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
           <p className={styles.aboutEyebrow}>Profile</p>
           <h2 className={styles.aboutChapterTitle}>Hello, I&apos;m Demaceo Vincent</h2>
           <p className={styles.aboutLede}>
-            Software Engineer, Designer, and systems-minded problem solver.
+            Full-stack engineer who ships solo, fast, and end-to-end — from civic
+            platforms to privacy-first AI tools.
           </p>
+          <div className={styles.aboutCredibilityStrip}>
+            <span className={`${styles.aboutFeaturedBadge} ${styles.aboutFeaturedBadgePbs}`}>
+              PBS Documentary
+            </span>
+            <span className={`${styles.aboutFeaturedBadge} ${styles.aboutFeaturedBadgeSxsw}`}>
+              SXSW EDU 2025
+            </span>
+            <span className={styles.aboutCredibilityNote}>— see Featured chapter</span>
+          </div>
           <div className={styles.aboutHighlightGrid}>
             {profileHighlights.map((item) => (
               <article key={item.label} className={styles.aboutHighlightCard}>

--- a/src/components/layout/LandingPage/components/MenuBar.tsx
+++ b/src/components/layout/LandingPage/components/MenuBar.tsx
@@ -34,7 +34,7 @@ const MENU_ITEMS = [
 ] as const;
 
 const ABOUT_BIO =
-  "Product-minded software engineer who bridges strategy, design, and implementation — calm execution, high ownership, and a focus on human-centered systems with measurable outcomes.";
+  "Full-stack engineer who ships solo — 5 production apps in 12 months, from civic tech to privacy-first AI, architected end to end.";
 
 const getServicePreview = (description: string) => {
   const normalizedDescription = description.replace(/\s+/g, " ").trim();

--- a/src/data/aboutMePills.ts
+++ b/src/data/aboutMePills.ts
@@ -2,43 +2,39 @@ import { AboutMePill } from "@/lib/types";
 
 export const aboutMePills: AboutMePill[] = [
     {
-        label: "Goal-Oriented Achiever",
+        label: "Solo Full-Stack Shipper",
         tooltip:
-            "Driven by exceeding expectations with excellent follow-through on tasks and commitments.",
-        icon: "/icons/about/IPS.png",
+            "Sole engineer, designer, and product owner across 5 production apps — civic tech, privacy AI, PropTech, spatial AI, and real-time translation — shipped within a single 12-month stretch.",
     },
     {
-        label: "Intellectually Curious",
-        tooltip: "Creative and experimental, embracing new experiences and continuous learning opportunities.",
-        icon: "/icons/about/AL.png",
-    },
-    {
-        label: "Cooperative Team Player",
+        label: "Security-First Architect",
         tooltip:
-            "Values social harmony, seeks common ground, and builds collaborative relationships.",
-        icon: "/icons/about/EC.png",    
+            "Verified Firebase tokens directly against Google's JWKS endpoint instead of the Admin SDK, and built an on-device AES-256-GCM vault so raw personal data never leaves the phone.",
     },
     {
-        label: "Patient & Resilient",
+        label: "AI Systems Integrator",
         tooltip:
-            "Highly tolerant of frustrations, calm under pressure, and accepting of challenges and setbacks.",
-        icon: "/icons/about/AR.png",
+            "Shipped real-time Gemini streaming, an ElevenLabs voice pipeline, and dual-key failover with rate limiting — production AI, not a demo wrapper.",
     },
     {
-        label: "Service-Oriented Mindset",
+        label: "Compliance-Minded Builder",
         tooltip:
-            "Naturally accommodating with a strong desire to help others and contribute meaningfully to team success.",
-        icon: "/icons/about/TC.png",
+            "Wrote the privacy policy, security policy, terms of service, and data-deletion docs myself — GDPR/CCPA readiness shipped alongside the feature, not after a legal review.",
     },
     {
-        label: "Motivated Self-Starter",
+        label: "Mentor & Educator",
         tooltip:
-            "Possesses inner drive and commitment to achieving goals while maintaining high personal standards.",
-        icon: "/icons/about/PDI.png",
+            "Taught full-stack JavaScript as a bootcamp TA and ran 1:1 mentoring, mock interviews, and code reviews for Turing School alumni for over three years.",
     },
     {
-        label: "& more...",
-        tooltip: "click to learn more!",
+        label: "Public Interest Technologist",
+        tooltip:
+            "Featured in a Roadtrip Nation documentary on public interest tech and served as an SXSW EDU 2025 panelist on youth, technology, and media.",
         link: "https://roadtripnation.com/roadtrip/tech-for-us-documentary",
+    },
+    {
+        label: "Production-Grade Craftsman",
+        tooltip:
+            "Strict TypeScript, CI-gated pipelines (lint → typecheck → test → secret scan), and pre-commit hooks by default — across every shipped project, not just the polished ones.",
     },
 ];


### PR DESCRIPTION
## Summary
- Replaced generic, unfalsifiable soft-skill copy ("product-minded engineer," "calm execution, high ownership") in the Profile and "How I Think/Work/Collaborate" chapters with specific, provable claims sourced from the real shipped-project data already in the repo (`resumeProjectHighlights.ts`, `DemaceoResume.tsx`) — e.g. shipping 5 production apps solo in 12 months, verifying Firebase tokens via JWKS instead of the Admin SDK, on-device AES-256-GCM encryption.
- Replaced the `aboutMePills` personality-assessment-style traits ("Goal-Oriented Achiever," "Motivated Self-Starter") with technical/engineering strength pills, each with an evidence-backed tooltip. Folded the previously awkward standalone "& more..." link pill into a substantive "Public Interest Technologist" pill that still links to the documentary.
- Swapped the "I build ___" hero words from generic category nouns (Websites, APIs, Dashboards…) to the actual shipped-project domains (Civic Platforms, Privacy Systems, AI Pipelines, Realtime Apps…).
- Added a small credibility strip (PBS Documentary / SXSW EDU 2025 badges) to the Profile chapter so the app's most unique credibility signal isn't buried as the last of six chapters.

## Test plan
- [x] `npm install` + `npx tsc --noEmit` — no new type errors introduced by these changes.
- [x] Ran `next dev` and drove the About flow with Playwright at desktop (1280×900) and mobile (390×844) viewports: Profile, Strengths (including pill click-to-expand detail), and "How I Think" chapters all render correctly with no overflow/wrap regressions.


---
_Generated by [Claude Code](https://claude.ai/code/session_018xBg7jtav24xXfcETiugwE)_