### PR TITLE
Polish AppSwitcher: real active state, focus ring, per-app color

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.tsx
+++ b/src/components/layout/LandingPage/LandingPage.tsx
@@ -32,6 +32,20 @@ const LandingPage = () => {
   // Initialize desktop with preloading
   // useDesktopInitialization();
 
+  // Whichever app is genuinely open right now, matched against DESKTOP_APPS'
+  // own path strings — the single source of truth AppSwitcher's active tab
+  // is derived from, instead of tracking taps locally and going stale once
+  // the user navigates back to the home screen by some other means.
+  const activeAppPath = modalState.showAboutMe
+    ? "/mindset"
+    : modalState.showSkillset
+    ? "/skillset"
+    : modalState.showProjects
+    ? "/projects"
+    : modalState.showContactForm
+    ? "/contact"
+    : null;
+
   return (
     <div className="macintosh-container">
       <FlyingBirds />
@@ -61,6 +75,7 @@ const LandingPage = () => {
 
         <AppSwitcher
           showContactNotification={modalState.showContactNotification}
+          activeAppPath={activeAppPath}
           handleAppClick={handleAppClick}
           maybePreloadByPath={maybePreloadByPath}
         />

--- a/src/components/layout/LandingPage/components/AppSwitcher.css
+++ b/src/components/layout/LandingPage/components/AppSwitcher.css
@@ -73,10 +73,18 @@
   border-radius: 16px;
   background: var(--noir-accent);
   box-shadow: 0 2px 8px var(--noir-accent-glow);
+  opacity: 1;
   transform: translateX(calc(var(--active-index) * 100%));
   transform-origin: var(--pill-origin, center);
-  transition: transform 0.4s cubic-bezier(1, 0, 0.4, 1);
+  transition: transform 0.4s cubic-bezier(1, 0, 0.4, 1), opacity 0.25s ease;
   z-index: 0;
+}
+
+/* No app is currently open (home/welcome screen) — fade the capsule out in
+   place rather than parking it on a default tab, since none is genuinely
+   active. Set on the fieldset from React once activeAppPath is null. */
+.app-switcher[data-idle]::after {
+  opacity: 0;
 }
 
 .app-switcher-option {
@@ -109,6 +117,15 @@
   transform: scale(0.92);
 }
 
+/* The radio input itself is visually hidden (see .app-switcher-input
+   below), so the focus ring is drawn on the label instead — matching the
+   outline/outline-offset every other interactive control in the app uses
+   on :focus-visible (.glass-tab, .glass-chip, menu items). */
+.app-switcher-option:has(.app-switcher-input:focus-visible) {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: 2px;
+}
+
 .app-switcher-input {
   position: absolute;
   clip-path: inset(100%);
@@ -134,11 +151,17 @@
    left for the sliding capsule's own padding. Scoped through the parent
    option because LandingPage.css's ".icon-image" base rule (48px, 10px
    radius) ties this class on specificity, so cascade order alone can't be
-   trusted to pick this override. */
+   trusted to pick this override.
+   The ring gives each tab a permanent hint of its own DESKTOP_APPS color
+   (purple/gold/blue/red) regardless of active state — a safer way to surface
+   that per-app identity than tinting the active capsule itself, since a few
+   of those colors (Skillset's gold in particular) don't hold up as a
+   white-text background at this component's proven ~3:1 contrast. */
 .app-switcher-option .app-switcher-icon-image {
   width: 30px;
   height: 30px;
   border-radius: 999px;
+  box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--app-accent, transparent) 45%, transparent);
 }
 
 .app-switcher-icon-image .icon-glass-content {
@@ -146,7 +169,7 @@
 }
 
 .app-switcher-label {
-  font-family: var(--font-secondary);
+  font-family: inherit;
   font-size: 10.5px;
   font-weight: 600;
   line-height: 1;

--- a/src/components/layout/LandingPage/components/AppSwitcher.tsx
+++ b/src/components/layout/LandingPage/components/AppSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, type CSSProperties } from "react";
+import React, { useEffect, useRef, useState, type CSSProperties } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { DESKTOP_APPS } from "@/lib/constants/desktopApps";
 import { DISPLACEMENT_MAP } from "@/lib/constants/displacementMap";
@@ -8,6 +8,9 @@ import "./AppSwitcher.css";
 
 interface AppSwitcherProps {
   showContactNotification: boolean;
+  /** Path of whichever app is genuinely open right now (drives the active
+   *  tab), or null when the user is at the home/welcome screen. */
+  activeAppPath: string | null;
   handleAppClick: (path: string, isToggle?: boolean) => void;
   maybePreloadByPath: (path: string) => void;
 }
@@ -30,29 +33,41 @@ const PILL_FILTER_ID = "app-switcher-pill-glass-refraction";
  */
 const AppSwitcher: React.FC<AppSwitcherProps> = ({
   showContactNotification,
+  activeAppPath,
   handleAppClick,
   maybePreloadByPath,
 }) => {
-  const [activeIndex, setActiveIndex] = useState(0);
+  // Derived from the real app state (not local tap-tracking) so the
+  // highlighted tab never goes stale: it reflects "nothing is open" on
+  // first load and again whenever the user closes back out to the home
+  // screen, instead of freezing on whichever tab was tapped last.
+  const activeIndex = DESKTOP_APPS.findIndex((app) => app.path === activeAppPath);
+  const hasActiveTab = activeIndex !== -1;
+
+  // The capsule's own position/slide-direction bookkeeping — kept pinned to
+  // the last real index while idle (no active tab) so it fades out in place
+  // instead of sliding to a default position first.
   const [previousIndex, setPreviousIndex] = useState(0);
+  const [capsuleIndex, setCapsuleIndex] = useState(Math.max(activeIndex, 0));
+  const lastActiveIndex = useRef(activeIndex);
 
-  const setVisualIndex = (index: number) => {
-    if (index === activeIndex) return;
-    setPreviousIndex(activeIndex);
-    setActiveIndex(index);
-  };
+  useEffect(() => {
+    if (activeIndex !== -1 && activeIndex !== lastActiveIndex.current) {
+      setPreviousIndex(capsuleIndex);
+      setCapsuleIndex(activeIndex);
+    }
+    if (activeIndex !== -1) lastActiveIndex.current = activeIndex;
+    // capsuleIndex intentionally excluded: it's the value being set here,
+    // re-running on its own change would fight this effect's own update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeIndex]);
 
-  // Fires on every tap, including a re-tap of the already-active option —
-  // native radios don't emit onChange for that case, and Contact (isToggle)
-  // needs a re-tap to close it, so the real app action lives only here, not
-  // in onChange (which would otherwise double-fire alongside this).
   const handleTap = (index: number) => {
-    setVisualIndex(index);
     const app = DESKTOP_APPS[index];
     handleAppClick(app.path, app.isToggle);
   };
 
-  const pillOrigin = activeIndex > previousIndex ? "left" : "right";
+  const pillOrigin = capsuleIndex > previousIndex ? "left" : "right";
 
   return (
     <div className="app-switcher-dock">
@@ -83,10 +98,11 @@ const AppSwitcher: React.FC<AppSwitcherProps> = ({
 
       <fieldset
         className="app-switcher"
+        data-idle={hasActiveTab ? undefined : ""}
         style={
           {
             "--n-options": DESKTOP_APPS.length,
-            "--active-index": activeIndex,
+            "--active-index": capsuleIndex,
             "--pill-origin": pillOrigin,
             backdropFilter: `blur(8px) url(#${PILL_FILTER_ID}) saturate(150%)`,
             WebkitBackdropFilter: `blur(8px) saturate(150%)`,
@@ -110,7 +126,12 @@ const AppSwitcher: React.FC<AppSwitcherProps> = ({
                 name="app-switcher"
                 className="app-switcher-input"
                 checked={isActive}
-                onChange={() => setVisualIndex(index)}
+                // onChange is a required no-op for the controlled `checked`
+                // prop; the real action lives only in onClick, since native
+                // radios don't emit onChange for a re-tap of the already-
+                // checked option, and Contact (isToggle) needs that re-tap
+                // to close it.
+                onChange={() => {}}
                 onClick={() => handleTap(index)}
               />
               <span className="app-switcher-sr-only">


### PR DESCRIPTION
## Summary

A UI/UX review of the mobile tab bar (follow-up to #46/#50) surfaced four fixable gaps in styling, design, and interactivity:

- **Stale active-tab state (highest priority).** The active tab was purely local tap-tracking, never synced with which app view was genuinely open. On first load it defaulted to highlighting "Mindset" even though nothing was open, and after closing any app view it kept showing the last-tapped tab as active even though the user was back at the home screen. This was directly visible in a live screenshot ("Projects" highlighted while the welcome window was open) and I reproduced it empirically (open Projects → close via its own "Back to desktop" button → the tab stayed checked). Fixed by deriving the active tab from the real `modalState` booleans in `LandingPage.tsx`, passed down as a single `activeAppPath`, with the capsule fading out entirely when nothing is open instead of parking on a stale tab.
- **No keyboard focus indicator.** `AppSwitcher.css` had zero `:focus-visible` styling, unlike every other interactive control in the app (`.glass-tab`, `.glass-chip`, menu items, About-view rail items) which all use `outline: 2px solid var(--noir-accent); outline-offset: 2px;`. Added the same treatment via the `:has()` pattern already used in this file. (Keyboard arrow-key navigation itself was already working correctly — verified before assuming otherwise.)
- **Per-app accent colors were defined but unused.** `DESKTOP_APPS` already assigns each app its own color (purple/gold/blue/red), but it was only wired to a mouse-`:hover`-only tint that rarely fires on touch. Added a permanent subtle colored ring around each icon instead of recoloring the active capsule itself — a couple of those colors (Skillset's gold in particular) fail contrast as a white-text background at this component's already-borderline ~3:1 ratio, so tinting the capsule would have been a regression.
- **Minor consistency nit**: the label's hardcoded `font-family` now matches the closest sibling pattern (`.glass-tab` uses `font-family: inherit`).

## Changes

- `LandingPage.tsx`: derives `activeAppPath` from `modalState` and passes it to `AppSwitcher`.
- `AppSwitcher.tsx`: active tab is now derived from props instead of local tap state; capsule position/slide-direction bookkeeping preserved for the animation.
- `AppSwitcher.css`: idle-state capsule fade, `:focus-visible` ring, per-app icon ring, label `font-family` fix.

## Test plan

- [x] `npm run build` — compiles and type-checks cleanly
- [x] Verified with Playwright at an iPhone 13 viewport: capsule is idle (hidden) on first load; opening Projects then closing it via its real close button returns to idle instead of staying stuck on "Projects"; opening/closing Contact (a modal, not a full-screen view) behaves correctly too; each icon shows its own colored ring; keyboard Tab navigation shows a visible focus ring matching the rest of the app's convention


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3PooauKqLdw5HS1PRE4Nm)_