### PR TITLE
Make Toolbelt leaf nodes interactive, fix mobile touch targets

### DIFF
--- a/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
+++ b/src/components/features/skills/SkillsetAppView/SkillsetAppView.tsx
@@ -10,6 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
 import services from "@/data/services";
+import projects from "@/data/projects";
 import tools from "@/data/toolbelt";
 import { TECH_ICON_MAP, TECH_ICON_FALLBACK } from "@/lib/constants/techIcons";
 import { ModalProps, type Service } from "@/lib/types";
@@ -130,6 +131,18 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
     setServiceIndex(index);
     setPanelIndex(0);
     setVDirection(1);
+  };
+
+  // Wired up to a tool's "used in" chip in the Toolbelt details card — jumps
+  // to that service on the Services tab, even if it's already the active one.
+  const handleSelectServiceFromTool = (serviceId: string) => {
+    const index = services.findIndex((s) => s.id === serviceId);
+    if (index === -1) return;
+    setDirection(index > serviceIndex ? 1 : index < serviceIndex ? -1 : 1);
+    setServiceIndex(index);
+    setPanelIndex(0);
+    setVDirection(1);
+    setActiveTab("services");
   };
 
   const navigatePanel = (dir: 1 | -1) => {
@@ -429,7 +442,10 @@ const SkillsetAppView: React.FC<SkillsetAppViewProps> = ({
             tools={tools}
             orderedCategories={orderedCategories}
             signatureStack={signatureStack}
+            services={services}
+            projects={projects}
             active={activeTab === "tools"}
+            onSelectService={handleSelectServiceFromTool}
           />
         </section>
       </div>

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.module.css
@@ -1,4 +1,9 @@
 .stage {
+  /* No project-wide border-box reset exists, so width:100% + padding was
+     silently rendering 24-36px wider than its container (content-box is the
+     CSS default) — harmless while nothing inside hugged the edge, but it
+     clips the new controls row's rightmost button on narrow phones. */
+  box-sizing: border-box;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -9,11 +14,18 @@
   padding: 16px 20px 20px;
 }
 
+.controlsRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .search {
   display: flex;
   align-items: center;
   gap: 10px;
-  width: min(360px, 100%);
+  flex: 1;
+  min-width: 0;
   padding: 8px 14px;
   border: 1px solid var(--noir-border);
   border-radius: 999px;
@@ -44,6 +56,38 @@
 
 .search input::placeholder {
   color: var(--noir-faint);
+}
+
+.expandToggle {
+  flex-shrink: 0;
+  white-space: nowrap;
+  border: 1px solid var(--noir-border);
+  border-radius: 999px;
+  background: var(--noir-panel);
+  color: var(--noir-muted);
+  font-family: var(--font-body, inherit);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: border-color 0.18s ease, color 0.18s ease, background-color 0.18s ease;
+}
+
+.expandToggle:hover {
+  border-color: var(--noir-accent-line);
+  color: var(--noir-text);
+}
+
+.expandToggle:focus-visible {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: 2px;
+}
+
+.expandToggle[aria-pressed="true"] {
+  border-color: var(--noir-accent-line);
+  background: var(--noir-accent-soft);
+  color: var(--noir-text);
 }
 
 .hint {
@@ -95,22 +139,30 @@
   user-select: none;
 }
 
-.node circle {
+.mainCircle {
   stroke: var(--noir-border);
   stroke-width: 1px;
   transition: stroke 0.18s ease, stroke-width 0.18s ease;
 }
 
-.node:hover circle {
+/* Invisible circle layered under .mainCircle so small leaf nodes still get a
+   ~44px tap/drag target — see ToolbeltGraph.tsx for the radius logic. */
+.hitArea {
+  fill: transparent;
+  stroke: none;
+  pointer-events: all;
+}
+
+.node:hover .mainCircle {
   stroke: var(--noir-accent-line);
 }
 
-/* Keyboard focus ring on category nodes (SVG <g> is focusable via tabindex). */
+/* Keyboard focus ring on nodes (SVG <g> is focusable via tabindex). */
 .node:focus {
   outline: none;
 }
 
-.node:focus-visible circle {
+.node:focus-visible .mainCircle {
   stroke: var(--noir-accent);
   stroke-width: 3px;
 }
@@ -124,7 +176,7 @@
   color: var(--noir-text);
 }
 
-.node.signature circle {
+.node.signature .mainCircle {
   stroke: var(--noir-accent);
   stroke-width: 2.5px;
   filter: drop-shadow(0 0 5px var(--noir-accent-glow));
@@ -135,9 +187,172 @@
   font-weight: 600;
 }
 
-.node.hasHiddenChildren circle {
+.node.hasHiddenChildren .mainCircle {
   stroke-dasharray: 3 2;
   stroke: var(--noir-accent-line);
+}
+
+/* The leaf whose details card is currently open. */
+.node.selected .mainCircle {
+  stroke: var(--noir-accent);
+  stroke-width: 3px;
+  filter: drop-shadow(0 0 6px var(--noir-accent-glow));
+}
+
+/* ── Tool details card — bottom sheet over the graph ──── */
+
+.toolCard {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 60%;
+  overflow-y: auto;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--lg-edge);
+  /* --noir-panel(-strong) is a subtle tint meant for panels sitting on an
+     already-solid surface (5% white overlay) — nearly invisible here, where
+     the card floats directly over the busy graph. --lg-tint-solid is this
+     codebase's "no separate blur scrim behind it" token, used for exactly
+     that case. */
+  background: var(--lg-tint-solid);
+  backdrop-filter: var(--lg-blur);
+  -webkit-backdrop-filter: var(--lg-blur);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  animation: toolCardIn 0.18s ease-out;
+}
+
+@keyframes toolCardIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.toolCardHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.toolCardIcon {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--noir-accent-soft);
+  color: var(--noir-text);
+  font-size: 14px;
+}
+
+.toolCardHeading {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.toolCardTitle {
+  font-size: 0.92rem;
+  font-weight: 800;
+  color: var(--noir-text);
+  overflow-wrap: anywhere;
+}
+
+.toolCardCategory {
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--noir-faint);
+}
+
+.toolCardClose {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--noir-border);
+  background: var(--noir-panel);
+  color: var(--noir-muted);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  transition: color 0.18s ease, border-color 0.18s ease;
+}
+
+.toolCardClose:hover {
+  color: var(--noir-text);
+  border-color: var(--noir-accent-line);
+}
+
+.toolCardClose:focus-visible {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: 2px;
+}
+
+.toolCardSection {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.toolCardSectionLabel {
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--noir-faint);
+}
+
+.toolCardChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.toolCardChip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--noir-border);
+  border-radius: 999px;
+  background: var(--noir-panel);
+  color: var(--noir-text);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 5px 10px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.toolCardChip:hover {
+  border-color: var(--noir-accent-line);
+  background: var(--noir-accent-soft);
+}
+
+.toolCardChip:focus-visible {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: 2px;
+}
+
+.toolCardEmpty {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--noir-muted);
 }
 
 @media (max-width: 768px) {
@@ -156,10 +371,26 @@
   .node text {
     font-size: 8px;
   }
+
+  .expandToggle {
+    font-size: 10px;
+    padding: 7px 10px;
+  }
+
+  .toolCard {
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    padding: 12px 14px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .node circle {
+  .mainCircle {
     transition: none;
+  }
+
+  .toolCard {
+    animation: none;
   }
 }

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
@@ -3,23 +3,32 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as d3 from "d3";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { faMagnifyingGlass, faXmark } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { buildToolbeltTree, type ToolbeltToolDatum, type ToolbeltTreeNode } from "@/lib/utils/toolbeltTree";
+import { buildToolUsageIndex } from "@/lib/utils/toolUsage";
+import { pushOverlay, popOverlay, isTopmostOverlay } from "@/lib/utils/overlayStack";
+import type { Service, Project } from "@/lib/types";
 import styles from "./ToolbeltGraph.module.css";
 
 interface ToolbeltGraphProps {
   tools: ToolbeltToolDatum[];
   orderedCategories: string[];
   signatureStack: string[];
+  services: Service[];
+  projects: Project[];
   /** Whether the Toolbelt tab is currently shown. The graph only lays out /
    *  simulates while visible; hidden it pauses to spare CPU on the Services tab. */
   active: boolean;
+  /** Jumps the Services tab to the given service — wired up from a tool's
+   *  "used in" chip in the details card. */
+  onSelectService: (serviceId: string) => void;
 }
 
 interface SimNode extends d3.SimulationNodeDatum {
   id: string;
   name: string;
+  category: string;
   depth: number;
   rootIndex: number;
   hasChildren: boolean;
@@ -59,10 +68,18 @@ function truncateLabel(name: string, depth: number): string {
 interface NodeDatum {
   id: string;
   name: string;
+  category: string;
   depth: number;
   rootIndex: number;
   hasChildren: boolean;
   isSignature?: boolean;
+  icon?: IconDefinition;
+}
+
+interface SelectedTool {
+  id: string;
+  name: string;
+  category: string;
   icon?: IconDefinition;
 }
 
@@ -78,6 +95,7 @@ function flatten(tree: ToolbeltTreeNode[], collapsed: Set<string>) {
     nodes.push({
       id,
       name: item.name,
+      category: path[0],
       depth,
       rootIndex,
       hasChildren: Boolean(item.children?.length),
@@ -177,10 +195,14 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
   tools,
   orderedCategories,
   signatureStack,
+  services,
+  projects,
   active,
+  onSelectService,
 }) => {
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const simulationRef = useRef<d3.Simulation<SimNode, SimLink> | null>(null);
   const linkLayerRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
@@ -195,6 +217,8 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
   const [collapsed, setCollapsed] = useState<Set<string>>(
     () => new Set(buildToolbeltTree(tools, orderedCategories, signatureStack).map((root) => root.name))
   );
+  const [selectedTool, setSelectedTool] = useState<SelectedTool | null>(null);
+  const toolUsage = useMemo(() => buildToolUsageIndex(services, projects), [services, projects]);
   // Read synchronously so there is no post-mount state flip (which used to force
   // an extra full rebuild).
   const [prefersReducedMotion] = useState(
@@ -219,6 +243,35 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     };
   }, []);
 
+  // A new search invalidates whatever the graph looked like when the card was
+  // opened, so drop it rather than leave a details card open for a tool that
+  // may no longer be in view.
+  useEffect(() => {
+    setSelectedTool(null);
+  }, [toolQuery]);
+
+  // Esc closes the details card; opening it moves focus to its close button
+  // so keyboard/screen-reader users land somewhere sensible. Registered on
+  // the same overlayStack the enclosing AppView uses for its own Escape
+  // handler — otherwise both fire on one Escape press and closing the card
+  // closes the whole Skillset window with it.
+  useEffect(() => {
+    if (!selectedTool) return;
+    const overlayId = Symbol("toolbelt-tool-card");
+    pushOverlay(overlayId);
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isTopmostOverlay(overlayId)) {
+        setSelectedTool(null);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      popOverlay(overlayId);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [selectedTool]);
+
   const filteredTools = useMemo(() => {
     const q = toolQuery.trim().toLowerCase();
     if (!q) return tools;
@@ -231,6 +284,11 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     () => buildToolbeltTree(filteredTools, orderedCategories, signatureStack),
     [filteredTools, orderedCategories, signatureStack]
   );
+
+  const allExpanded = tree.length > 0 && collapsed.size === 0;
+  const toggleAllCategories = useCallback(() => {
+    setCollapsed((prev) => (prev.size === 0 ? new Set(tree.map((root) => root.name)) : new Set()));
+  }, [tree]);
 
   const isSearching = toolQuery.trim().length > 0;
   // Categories with zero matches are already absent from `tree` (buildToolbeltTree
@@ -311,8 +369,16 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     const nodeLayer = nodeLayerRef.current;
     if (!svgEl || !wrapEl || !simulation || !linkLayer || !nodeLayer) return;
 
-    const width = wrapEl.clientWidth;
-    const height = wrapEl.clientHeight;
+    // Measured from the <svg> itself, not the .stage wrapper: .stage also
+    // contains the search row and legend above it, so its clientHeight is
+    // taller than the svg's actual flex:1 share. Sizing the viewBox off the
+    // wrapper made the viewBox aspect ratio not match the svg's own — the
+    // browser's default preserveAspectRatio then uniformly downscaled and
+    // pillarboxed everything to fit (observed ~72% of true size on a phone
+    // viewport), silently shrinking every node's real touch target along
+    // with it.
+    const width = svgEl.clientWidth;
+    const height = svgEl.clientHeight;
     // Hidden panel (or not yet laid out) — pause the sim and wait for the
     // ResizeObserver / `active` to report real dimensions.
     if (!active || width === 0 || height === 0) {
@@ -384,25 +450,38 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
       .data(nodes, (d) => d.id)
       .join((enter) => {
         const g = enter.append("g").attr("class", styles.node).style("cursor", "pointer");
-        g.append("circle");
+        // Larger invisible circle under the visible one so small leaf nodes
+        // still meet a ~44px touch target without changing how dense the
+        // graph looks.
+        g.append("circle").attr("class", styles.hitArea);
+        g.append("circle").attr("class", styles.mainCircle);
         g.append("svg").attr("class", styles.nodeIcon).append("path");
         g.append("title");
         g.append("text").attr("text-anchor", "middle");
 
-        g.on("click", (_event, d) => {
-          if (d.hasChildren) toggleCategory(d.id);
-        });
+        const activate = (d: SimNode) => {
+          if (d.hasChildren) {
+            toggleCategory(d.id);
+          } else {
+            setSelectedTool({ id: d.id, name: d.name, category: d.category, icon: d.icon });
+          }
+        };
+
+        g.on("click", (_event, d) => activate(d));
         g.on("keydown", (event, d) => {
-          if (!d.hasChildren) return;
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
-            toggleCategory(d.id);
+            activate(d);
           }
         });
 
         g.call(
           d3
             .drag<SVGGElement, SimNode>()
+            // Without a click-distance threshold, any sub-pixel finger
+            // movement during a tap is captured as a drag and swallows the
+            // click — the default is 0px, which is unusable on touchscreens.
+            .clickDistance(6)
             .on("start", (event, d) => {
               if (!prefersReducedMotion && !event.active) simulation.alphaTarget(0.3).restart();
               d.fx = d.x;
@@ -427,18 +506,25 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     nodeSel.classed(styles.signature, (d) => Boolean(d.isSignature));
     nodeSel.classed(styles.hasHiddenChildren, (d) => effectiveCollapsed.has(d.id));
 
-    // Category nodes are keyboard-operable buttons; leaves stay non-focusable
-    // (exposed via their <title>). aria-expanded refreshes on every update.
+    // Every node is a keyboard-operable button now: category roots toggle
+    // expand/collapse, leaves open the details card. aria-expanded only
+    // applies to roots; aria-expanded refreshes on every update.
     nodeSel
-      .attr("tabindex", (d) => (d.hasChildren ? 0 : null))
-      .attr("role", (d) => (d.hasChildren ? "button" : null))
-      .attr("aria-label", (d) => (d.hasChildren ? d.name : null))
+      .attr("tabindex", 0)
+      .attr("role", "button")
+      .attr("aria-label", (d) => (d.hasChildren ? d.name : `${d.name}, show details`))
       .attr("aria-expanded", (d) =>
         d.hasChildren ? String(!effectiveCollapsed.has(d.id)) : null
       );
 
+    // Larger, invisible circle so leaf nodes get a ~44px tap target without
+    // growing visually — see the comment on `.hitArea` in the enter block.
     nodeSel
-      .select<SVGCircleElement>("circle")
+      .select<SVGCircleElement>(`.${styles.hitArea}`)
+      .attr("r", (d) => Math.max(radiusFor(d.depth), 22));
+
+    nodeSel
+      .select<SVGCircleElement>(`.${styles.mainCircle}`)
       .attr("r", (d) => radiusFor(d.depth))
       .attr("fill", (d) => {
         const base = d3.hsl(rootColor(d.rootIndex, tree.length));
@@ -470,20 +556,43 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
     simulation.alpha(0.3).restart();
   }, [tree, effectiveCollapsed, resizeTick, active, prefersReducedMotion, toggleCategory]);
 
+  // Ring-highlight the selected leaf. Kept separate from the layout effect
+  // above so opening the details card never re-heats/re-jiggles the graph.
+  useEffect(() => {
+    nodeSelRef.current?.classed(styles.selected, (d) => d.id === selectedTool?.id);
+  }, [selectedTool]);
+
+  const usage = selectedTool ? toolUsage.get(selectedTool.name) : undefined;
+
   return (
     <div ref={wrapRef} className={styles.stage}>
-      <label className={styles.search}>
-        <FontAwesomeIcon icon={faMagnifyingGlass} className={styles.searchIcon} aria-hidden="true" />
-        <input
-          type="search"
-          value={toolQuery}
-          onChange={(event) => setToolQuery(event.target.value)}
-          placeholder="Search tools or categories"
-          aria-label="Search tools or categories"
-        />
-      </label>
+      <div className={styles.controlsRow}>
+        <label className={styles.search}>
+          <FontAwesomeIcon icon={faMagnifyingGlass} className={styles.searchIcon} aria-hidden="true" />
+          <input
+            type="search"
+            value={toolQuery}
+            onChange={(event) => setToolQuery(event.target.value)}
+            placeholder="Search tools or categories"
+            aria-label="Search tools or categories"
+          />
+        </label>
 
-      <p className={styles.hint}>Click a category to expand or collapse it. Drag any node to reposition it.</p>
+        {!isSearching && tree.length > 0 && (
+          <button
+            type="button"
+            className={styles.expandToggle}
+            onClick={toggleAllCategories}
+            aria-pressed={allExpanded}
+          >
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </button>
+        )}
+      </div>
+
+      <p className={styles.hint}>
+        Click a category to expand or collapse it. Click a tool for details. Drag any node to reposition it.
+      </p>
 
       <div className={styles.legend}>
         {tree.map((root, i) => (
@@ -504,6 +613,72 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
         role="group"
         aria-label="Toolbelt skills graph"
       />
+
+      {selectedTool && (
+        <div className={styles.toolCard} role="dialog" aria-label={`${selectedTool.name} details`}>
+          <div className={styles.toolCardHeader}>
+            {selectedTool.icon && (
+              <span className={styles.toolCardIcon} aria-hidden="true">
+                <FontAwesomeIcon icon={selectedTool.icon} />
+              </span>
+            )}
+            <div className={styles.toolCardHeading}>
+              <span className={styles.toolCardTitle}>{selectedTool.name}</span>
+              <span className={styles.toolCardCategory}>{selectedTool.category}</span>
+            </div>
+            <button
+              type="button"
+              ref={closeButtonRef}
+              className={styles.toolCardClose}
+              onClick={() => setSelectedTool(null)}
+              aria-label="Close tool details"
+            >
+              <FontAwesomeIcon icon={faXmark} />
+            </button>
+          </div>
+
+          {usage?.services.length ? (
+            <div className={styles.toolCardSection}>
+              <span className={styles.toolCardSectionLabel}>Used in</span>
+              <div className={styles.toolCardChips}>
+                {usage.services.map((service) => (
+                  <button
+                    key={service.id}
+                    type="button"
+                    className={styles.toolCardChip}
+                    onClick={() => onSelectService(service.id)}
+                  >
+                    {service.title}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {usage?.projects.length ? (
+            <div className={styles.toolCardSection}>
+              <span className={styles.toolCardSectionLabel}>Shipped in</span>
+              <div className={styles.toolCardChips}>
+                {usage.projects.map((project) => (
+                  <a
+                    key={project.id}
+                    href={project.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.toolCardChip}
+                  >
+                    {project.name}
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {!usage?.services.length && !usage?.projects.length && (
+            <p className={styles.toolCardEmpty}>Part of the {selectedTool.category} toolkit.</p>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/lib/utils/toolUsage.ts
+++ b/src/lib/utils/toolUsage.ts
@@ -1,0 +1,57 @@
+import type { Service, Project } from "@/lib/types";
+
+export interface ToolUsageService {
+  id: string;
+  title: string;
+}
+
+export interface ToolUsageProject {
+  id: number;
+  name: string;
+  link: string;
+}
+
+export interface ToolUsage {
+  services: ToolUsageService[];
+  projects: ToolUsageProject[];
+}
+
+/**
+ * Cross-references toolbelt tool names against the "Tech & tools" tags on
+ * each service and the stackPreview on each project, so a tapped tool node
+ * can show where it's actually used instead of floating as decoration.
+ * Matching is exact-string (e.g. "React" won't match "React Native") since
+ * both source lists are hand-authored and already use consistent naming.
+ */
+export function buildToolUsageIndex(
+  services: Service[],
+  projects: Project[]
+): Map<string, ToolUsage> {
+  const index = new Map<string, ToolUsage>();
+
+  const ensure = (tool: string): ToolUsage => {
+    let entry = index.get(tool);
+    if (!entry) {
+      entry = { services: [], projects: [] };
+      index.set(tool, entry);
+    }
+    return entry;
+  };
+
+  for (const service of services) {
+    const tags = (service.panels ?? [])
+      .filter((p) => p.kind === "tags")
+      .flatMap((p) => p.points ?? []);
+    for (const tag of tags) {
+      ensure(tag).services.push({ id: service.id, title: service.title });
+    }
+  }
+
+  for (const project of projects) {
+    for (const tech of project.stackPreview ?? []) {
+      ensure(tech).projects.push({ id: project.id, name: project.name, link: project.link });
+    }
+  }
+
+  return index;
+}


### PR DESCRIPTION
## Summary

Follows up on a mobile UX review of the Skillset → Toolbelt graph with three targeted fixes:

- **Tool details on tap.** Leaf nodes (React, AWS, Figma, etc.) previously did nothing when tapped — no info, and truncated labels (`Google Clou…`, `Creative To…`) had no way to be read on a touch device (the fallback was a hover-only SVG `<title>`). Tapping a tool now opens a details card with its full name, category, which **services** actually use it (tap to jump to that service on the Services tab), and which **projects** it shipped in (link out).
- **Touch targets + click/drag reliability.** Leaf nodes rendered at a ~26px hit target, well under the 44px minimum. Added a larger invisible hit circle per node, and set `clickDistance` on the d3-drag behavior so small touch jitter during a tap no longer gets swallowed as a drag instead of a click.
- **Expand all / Collapse all.** Reaching the fully-expanded graph previously required tapping all 9 categories individually. Added a toggle next to search.

## Bugs found and fixed while verifying in a real mobile viewport

Driving this end-to-end with Playwright at an iPhone viewport (not just typecheck/build) surfaced three real, pre-existing/latent issues:

1. **The graph's `viewBox` was sized from the whole `.stage` wrapper** (search bar + legend + svg) instead of the `<svg>` element's own rendered box. Since the aspect ratios didn't match, the browser's default `preserveAspectRatio` silently downscaled and pillarboxed the *entire* graph to ~72% of the available canvas on a phone-width viewport — shrinking every node's real on-screen touch target well below its intended size, and wasting horizontal space. Fixed by measuring off the `<svg>` element directly.
2. **`.stage` had no `box-sizing: border-box`**, so `width: 100%` + padding rendered ~24–36px wider than its container. Harmless until the new search+toggle row hugged the edge and got clipped on a 390px-wide phone. Fixed.
3. **The details card's Escape handler collided with the enclosing `AppView`'s own Escape-to-close handler** — both fired on one keypress, so closing the tool card also closed the entire Skillset window. Fixed by registering it on the existing `overlayStack` utility the codebase already uses for exactly this nested-overlay case.

Also swapped the card's background from a token meant for subtle panels-on-solid-surface (`--noir-panel-strong`, ~5% opacity) to this codebase's existing "liquid glass, no separate blur scrim" token (`--lg-tint-solid` + `--lg-blur`), since the card floats directly over the busy graph and needed to read as solid.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Playwright-driven verification at an iPhone 13 mobile viewport: collapsed → single-category expand → tap a signature tool (React) → details card shows full name + correct "used in"/"shipped in" data → tap a service chip jumps to that service on the Services tab → switch back to Toolbelt, graph state (expanded category) persisted → close card via the × button and via Escape (confirmed it no longer closes the whole Skillset window) → confirm touch targets render at true ~44px scale (previously ~32px due to the viewBox bug) → Expand all / Collapse all toggle


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9ZHeeuucHtPrCr5ryY4n8)_