### PR TITLE
Improve DesktopIcons wheel UI/UX

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -11,14 +11,48 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* The per-row icon size is set inline by JS; only the rounding is styled here. */
+/* The per-row icon size is set inline by JS; only the rounding is styled here.
+   The drop-shadow and glyph recoloring below exist so the icon reads as a
+   solid object against the animated rain/photo backdrop behind it (DesktopRain)
+   instead of blending into whatever colors happen to be behind it at a given
+   moment. */
 .desktop-wheel-row .icon-image {
   border-radius: 16px;
+  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.5));
 }
 
 .desktop-wheel-row .icon-image svg {
   width: 58%;
   height: 58%;
+  color: #f8fafc;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.65));
+}
+
+/* Per-app accent (see --app-accent, set inline from DESKTOP_APPS) lifts the
+   glass surface off the background with a colored glow, and gives each row
+   its own identity beyond the generic frosted look. */
+.desktop-wheel-row .icon-glass {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3),
+    0 0 16px 1px var(--app-accent, rgba(255, 255, 255, 0.35));
+  transition: box-shadow 200ms ease;
+}
+
+.desktop-wheel-row .icon-glass-base {
+  background: linear-gradient(
+    155deg,
+    rgba(255, 255, 255, 0.4),
+    rgba(255, 255, 255, 0.16)
+  );
+}
+
+.desktop-wheel-row .icon-glass-border {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6),
+    inset 0 1px 2px rgba(255, 255, 255, 0.4);
+}
+
+.desktop-wheel-row:hover .icon-glass {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35),
+    0 0 22px 3px var(--app-accent, rgba(255, 255, 255, 0.5));
 }
 
 /* tighter sizing for dock icons */
@@ -197,8 +231,42 @@
   right: 90px;
   height: 100%;
   width: 130px;
-  color: rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.4);
+  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.35));
   pointer-events: none;
+}
+
+/* Per-app position markers (see desktop-wheel-tick below), sharing the rail's
+   own box so a tick's percentage-based (left, top) lands on the exact curve
+   point RAIL_PATH draws through. */
+.desktop-wheel-rail-ticks {
+  position: absolute;
+  top: 0;
+  right: 90px;
+  height: 100%;
+  width: 130px;
+  pointer-events: none;
+}
+
+.desktop-wheel-tick {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+  transform: translate(-50%, -50%);
+}
+
+/* The active tick sits almost exactly under its (much bigger) icon — sized up
+   and lit with the app's own accent color so it reads as the glowing "anchor"
+   the icon rests on, rather than vanishing underneath it. */
+.desktop-wheel-tick.is-active {
+  width: 11px;
+  height: 11px;
+  background: var(--tick-accent, #ffffff);
+  box-shadow: 0 0 12px 3px var(--tick-accent, rgba(255, 255, 255, 0.85)),
+    0 0 0 2px rgba(255, 255, 255, 0.65);
 }
 
 .desktop-wheel-row {
@@ -321,7 +389,11 @@
 }
 
 .desktop-wheel-row:hover .icon-glass-base {
-  background: rgba(255, 255, 255, 0.22);
+  background: linear-gradient(
+    155deg,
+    rgba(255, 255, 255, 0.46),
+    rgba(255, 255, 255, 0.22)
+  );
 }
 
 /* Notification Badge */
@@ -341,7 +413,10 @@
   justify-content: center;
   border: 2px solid white;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  z-index: 20;
+  /* Above .icon-glass-content's z-index: 30 (both scoped within
+     .desktop-items' stacking context) so the "!" always renders in front of
+     the icon glyph instead of being occluded wherever the two overlap. */
+  z-index: 40;
   animation: pulse 2s infinite;
 }
 

--- a/src/components/layout/LandingPage/components/DesktopIcons.tsx
+++ b/src/components/layout/LandingPage/components/DesktopIcons.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type React from "react";
-import type { PointerEvent as ReactPointerEvent } from "react";
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import DesktopRain from "./DesktopRain";
 import { DESKTOP_APPS } from "@/lib/constants/desktopApps";
@@ -46,6 +46,22 @@ const RAIL_PATH = Array.from({ length: 21 }, (_, i) => {
   const x = 8 + 87 * easeRound(t);
   return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
 }).join(" ");
+
+// Shared by both the row layout and the rail tick markers below, so the two
+// stay in lockstep: a tick rides the exact (x, y) point on RAIL_PATH that its
+// row's curve/scale/opacity were derived from, instead of drifting out of
+// sync with a second copy of the same math.
+function getRowMetrics(index: number, active: number, dragY: number) {
+  const raw = index - active;
+  const continuous = raw + dragY / ROW_HEIGHT;
+  const translateY = continuous * ROW_HEIGHT;
+  const abs = clamp(Math.abs(continuous), 0, CURVE_RANGE);
+  const t = abs / CURVE_RANGE;
+  const curveX = CURVE_AMPLITUDE * (1 - easeRound(t));
+  const scale = 1 - 0.4 * t;
+  const opacity = clamp(1 - 0.65 * t, 0.35, 1);
+  return { continuous, translateY, t, curveX, scale, opacity };
+}
 
 /**
  * A tailored take on the "Curved Activity Picker" codepen: the desktop
@@ -309,22 +325,43 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
             d={RAIL_PATH}
             fill="none"
             stroke="currentColor"
-            strokeWidth={1}
+            strokeWidth={1.5}
+            strokeLinecap="round"
             vectorEffect="non-scaling-stroke"
           />
         </svg>
 
+        {/* Per-app position markers riding the same curve as the rows
+            themselves (see getRowMetrics), so the rail reads as a live "N
+            items, you are here" indicator instead of pure decoration. */}
+        <div className="desktop-wheel-rail-ticks" aria-hidden="true">
+          {DESKTOP_APPS.map((app, index) => {
+            const { continuous, t } = getRowMetrics(index, active, dragY);
+            const railX = 8 + 87 * easeRound(t);
+            const railY = 50 + Math.sign(continuous) * t * 50;
+            const isActive = index === active;
+            return (
+              <span
+                key={app.name}
+                className={`desktop-wheel-tick${isActive ? " is-active" : ""}`}
+                style={
+                  {
+                    left: `${railX}%`,
+                    top: `${railY}%`,
+                    "--tick-accent": app.color,
+                    transition:
+                      isDragging || isWheeling || prefersReducedMotion
+                        ? "none"
+                        : "left 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), top 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s ease, box-shadow 0.3s ease, width 0.3s ease, height 0.3s ease",
+                  } as CSSProperties
+                }
+              />
+            );
+          })}
+        </div>
+
         {DESKTOP_APPS.map((app, index) => {
-          const raw = index - active;
-          const continuous = raw + dragY / ROW_HEIGHT;
-          const translateY = continuous * ROW_HEIGHT;
-          const abs = clamp(Math.abs(continuous), 0, CURVE_RANGE);
-          const t = abs / CURVE_RANGE;
-          // Inverted from a plain easeRound(t): full inward swing at t=0
-          // (active), settling back to the edge baseline as t nears 1.
-          const curveX = CURVE_AMPLITUDE * (1 - easeRound(t));
-          const scale = 1 - 0.4 * t;
-          const opacity = clamp(1 - 0.65 * t, 0.35, 1);
+          const { translateY, t, curveX, opacity, scale } = getRowMetrics(index, active, dragY);
           const isActive = index === active;
           const iconSize = isActive ? ACTIVE_ICON_SIZE : Math.round(BASE_ICON_SIZE * scale);
           const hasNotification = app.name === "Contact" && showContactNotification;
@@ -340,29 +377,21 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
               // tech by folding it into the option's accessible name.
               aria-label={hasNotification ? `${app.name}, new notification` : undefined}
               className="desktop-wheel-row"
-              style={{
-                transform: `translateY(-50%) translate(${-curveX}px, ${translateY}px)`,
-                opacity,
-                transition:
-                  isDragging || isWheeling || prefersReducedMotion
-                    ? "none"
-                    : "transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.35s ease",
-              }}
+              style={
+                {
+                  transform: `translateY(-50%) translate(${-curveX}px, ${translateY}px)`,
+                  opacity,
+                  "--app-accent": app.color,
+                  transition:
+                    isDragging || isWheeling || prefersReducedMotion
+                      ? "none"
+                      : "transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.35s ease",
+                } as CSSProperties
+              }
               onClick={() => pickApp(index)}
               onMouseEnter={() => maybePreloadByPath(app.path)}
               onTouchStart={() => maybePreloadByPath(app.path)}
             >
-              {isActive ? (
-                <span className="desktop-wheel-label-active">{app.name}</span>
-              ) : (
-                <span
-                  className="desktop-wheel-label"
-                  style={{ fontSize: `${16 + 6 * (1 - t)}px` }}
-                >
-                  {app.name}
-                </span>
-              )}
-
               <div className="icon-image" style={{ width: iconSize, height: iconSize }}>
                 <div className="icon-glass">
                   <div className="icon-glass-distortion" />
@@ -378,6 +407,17 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
                   </div>
                 )}
               </div>
+
+              {isActive ? (
+                <span className="desktop-wheel-label-active">{app.name}</span>
+              ) : (
+                <span
+                  className="desktop-wheel-label"
+                  style={{ fontSize: `${16 + 6 * (1 - t)}px` }}
+                >
+                  {app.name}
+                </span>
+              )}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- Boost icon visibility on the desktop wheel: each icon now gets a per-app accent glow (using the existing `DESKTOP_APPS` color), a stronger drop shadow, and a lighter glyph color so it reads as a solid object against the animated rain/photo backdrop instead of blending into it.
- Swap the icon/label order in each wheel row (icon now leads, label trails).
- Improve the wheel rail's UX: added live position "tick" markers that ride the same curve math as the rows (`getRowMetrics`), so the rail now shows item count + current position (with the active tick glowing in that app's accent color) instead of being purely decorative. Also bumped the rail line's own stroke width/visibility.
- Fixed the Contact "!" notification badge rendering behind the icon glyph — raised `.notification-badge`'s z-index above `.icon-glass-content`'s so it always renders in front.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — clean
- [x] `npm run build` — succeeds
- [x] Verified visually in a browser (desktop wheel + mobile pill switcher) via Playwright screenshots: icon glow/contrast, icon/label swap, rail tick markers tracking drag position, and the Contact "!" badge rendering in front of the icon on both the desktop wheel and the mobile `AppSwitcher` pill (shares the same CSS classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015ABa7hquTdFQk1iWQX9doa)_