### PR TITLE
Invert desktop wheel label/icon color against the background

### DIFF
--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -21,11 +21,18 @@
   filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.5));
 }
 
+/* mix-blend-mode: difference makes the glyph the photographic negative of
+   whatever is directly behind it (the per-app glass tint, and — since
+   .desktop-items no longer isolates its own stacking context, see below —
+   the animated rain/photo through it), so it self-adjusts to stay legible
+   against any background color instead of relying on a fixed light/dark
+   choice. A solid, fully opaque color is what makes that inversion read as a
+   clean invert rather than a partial, muddy one. */
 .desktop-wheel-row .icon-image svg {
   width: 58%;
   height: 58%;
-  color: #f8fafc;
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.65));
+  color: #ffffff;
+  mix-blend-mode: difference;
 }
 
 /* Per-app accent (see --app-accent, set inline from DESKTOP_APPS) lifts the
@@ -201,7 +208,11 @@
    centered row launches that app. */
 .desktop-items {
   position: absolute;
-  z-index: 1;
+  /* Deliberately no z-index: DOM order alone already keeps this painted above
+     .desktop-rain (see that rule's own comment), and giving it one would form
+     a stacking context that traps the wheel-label/icon mix-blend-mode below
+     inside it — blending them against each other instead of against the real
+     rain/photo behind the whole wheel. */
   right: 20px;
   top: 0;
   width: 320px;
@@ -209,20 +220,6 @@
   height: 100%;
   overflow: hidden;
   touch-action: none;
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    black 12%,
-    black 88%,
-    transparent
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    black 12%,
-    black 88%,
-    transparent
-  );
 }
 
 .desktop-wheel-rail {
@@ -270,10 +267,12 @@
 }
 
 .desktop-wheel-row {
+  /* top/right are set inline per row (see DesktopIcons.tsx) — deliberately
+     not transform, which would force a stacking context here and trap the
+     label/icon mix-blend-mode below into blending with only this row's own
+     contents instead of the real desktop behind it. */
   position: absolute;
-  top: 50%;
   left: 0;
-  right: 0;
   height: 120px;
   padding: 0 12px 0 0;
   display: flex;
@@ -286,15 +285,18 @@
 /* Promote the rows to their own layer only while a gesture is actively moving
    them, rather than compositing all four rows permanently at rest. */
 .desktop-items.is-animating .desktop-wheel-row {
-  will-change: transform, opacity;
+  will-change: top, right;
 }
 
+/* Same self-adjusting-contrast trick as the icon glyph above: a solid color
+   blended via "difference" against whatever's behind it, rather than a fixed
+   light color plus a shadow to fake contrast. */
 .desktop-wheel-label {
-  color: rgba(241, 245, 249, 0.75);
+  color: #ffffff;
   font-size: 16px;
   font-weight: 500;
   white-space: nowrap;
-  text-shadow: 0 2px 6px rgba(2, 6, 23, 0.72);
+  mix-blend-mode: difference;
 }
 
 .desktop-wheel-label-active {
@@ -310,6 +312,7 @@
   white-space: nowrap;
   box-shadow: inset 1px 1px 1px rgba(255, 255, 255, 0.3),
     0 4px 12px rgba(0, 0, 0, 0.2);
+  mix-blend-mode: difference;
 }
 
 .icon-image {
@@ -413,9 +416,9 @@
   justify-content: center;
   border: 2px solid white;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  /* Above .icon-glass-content's z-index: 30 (both scoped within
-     .desktop-items' stacking context) so the "!" always renders in front of
-     the icon glyph instead of being occluded wherever the two overlap. */
+  /* Above .icon-glass-content's z-index: 30 so the "!" always renders in
+     front of the icon glyph instead of being occluded wherever the two
+     overlap. */
   z-index: 40;
   animation: pulse 2s infinite;
 }

--- a/src/components/layout/LandingPage/components/DesktopIcons.tsx
+++ b/src/components/layout/LandingPage/components/DesktopIcons.tsx
@@ -366,6 +366,9 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
           const iconSize = isActive ? ACTIVE_ICON_SIZE : Math.round(BASE_ICON_SIZE * scale);
           const hasNotification = app.name === "Contact" && showContactNotification;
 
+          const fadeTransition =
+            isDragging || isWheeling || prefersReducedMotion ? "none" : "opacity 0.35s ease";
+
           return (
             <div
               key={app.name}
@@ -379,20 +382,30 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
               className="desktop-wheel-row"
               style={
                 {
-                  transform: `translateY(-50%) translate(${-curveX}px, ${translateY}px)`,
-                  opacity,
+                  // Positioned with top/right (plain layout offsets) rather
+                  // than transform: translate(...) — a transformed ancestor
+                  // would force its own stacking context, trapping the label/
+                  // icon's mix-blend-mode (see LandingPage.css) into blending
+                  // against only this row's own contents instead of the real
+                  // desktop behind it. Same reason opacity lives on the icon/
+                  // label below instead of here.
+                  top: `calc(50% - ${ROW_HEIGHT / 2}px + ${translateY}px)`,
+                  right: `${curveX}px`,
                   "--app-accent": app.color,
                   transition:
                     isDragging || isWheeling || prefersReducedMotion
                       ? "none"
-                      : "transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.35s ease",
+                      : "top 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), right 0.45s cubic-bezier(0.34, 1.56, 0.64, 1)",
                 } as CSSProperties
               }
               onClick={() => pickApp(index)}
               onMouseEnter={() => maybePreloadByPath(app.path)}
               onTouchStart={() => maybePreloadByPath(app.path)}
             >
-              <div className="icon-image" style={{ width: iconSize, height: iconSize }}>
+              <div
+                className="icon-image"
+                style={{ width: iconSize, height: iconSize, opacity, transition: fadeTransition }}
+              >
                 <div className="icon-glass">
                   <div className="icon-glass-distortion" />
                   <div className="icon-glass-base" />
@@ -409,11 +422,16 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
               </div>
 
               {isActive ? (
-                <span className="desktop-wheel-label-active">{app.name}</span>
+                <span
+                  className="desktop-wheel-label-active"
+                  style={{ opacity, transition: fadeTransition }}
+                >
+                  {app.name}
+                </span>
               ) : (
                 <span
                   className="desktop-wheel-label"
-                  style={{ fontSize: `${16 + 6 * (1 - t)}px` }}
+                  style={{ fontSize: `${16 + 6 * (1 - t)}px`, opacity, transition: fadeTransition }}
                 >
                   {app.name}
                 </span>


### PR DESCRIPTION
## Summary
- Apply `mix-blend-mode: difference` to the desktop wheel's labels and icon glyphs, so their color is the photographic negative of whatever's directly behind them (the per-app glass tint, and the animated rain/photo through it) instead of a fixed light color — the text/icon color now self-adjusts as it moves across different background colors.
- Getting the blend to actually see the real desktop background (rather than a no-op) required removing every stacking-context trigger sitting between the label/icon and that background:
  - `.desktop-items`: dropped the unneeded `z-index` (DOM order alone already keeps it painted above `.desktop-rain`) and the top/bottom fade `mask-image` (which also forces a stacking context; the 4-app wheel comfortably fits its container without the fade).
  - `.desktop-wheel-row`: switched from `transform: translate(...)` to `top`/`right` layout offsets for positioning — a transformed ancestor isolates descendants' blend modes the same way. `opacity` moved down onto the icon/label elements themselves for the same reason.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — clean
- [x] `npm run build` — succeeds
- [x] Verified in a browser via Playwright: forced a solid red backdrop behind the wheel and confirmed the active label/icon render cyan (the true difference-blend inversion of red), confirmed the effect against the real animated rain/photo background (colors shift across each glyph/label as they move), confirmed drag/scroll/keyboard positioning still animates correctly with the new top/right-based layout, confirmed dragging to each extreme still keeps all rows on-screen without the removed fade mask causing any hard clipping, confirmed the Contact toggle still opens/closes correctly, and confirmed the mobile `AppSwitcher` pill (a separate component) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015ABa7hquTdFQk1iWQX9doa)_