### PR TITLE
About: rebuild as a ruled editorial index

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.module.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.module.css
@@ -1,4 +1,9 @@
-/* ===== ABOUT — "THE DOSSIER" / CHAPTERED NARRATIVE ===== */
+/* ===== ABOUT — "THE DOSSIER": RULED EDITORIAL INDEX =====
+   Three chapters (Profile · Strengths · Featured) behind a numbered rail.
+   The grammar here is print, not chrome: hairline rules and uppercase accent
+   micro-labels instead of filled pills, borrowed from ResumeHighlightsModal.css.
+   The two exceptions are deliberate and scoped to the Featured chapter
+   (.aboutFeaturedBadge / .aboutFeaturedCta keep their 999px radius). */
 
 .aboutDossier {
   --about-accent: var(--noir-accent);
@@ -40,38 +45,43 @@
   border: 0;
   background: transparent;
   color: var(--about-muted);
-  padding: 0.6rem 0.7rem;
-  border-radius: 0.62rem;
+  padding: 0.72rem 0.7rem 0.72rem 0.85rem;
+  border-radius: 0;
   cursor: pointer;
   position: relative;
   transition: background 0.2s ease, color 0.2s ease;
+}
+
+/* Hairline between entries so three items read as an index, not three buttons. */
+.aboutRailItem + .aboutRailItem {
+  border-top: 1px solid var(--about-border);
 }
 
 .aboutRailItem::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 50%;
-  transform: translateY(-50%) scaleY(0);
-  width: 3px;
-  height: 60%;
-  border-radius: 0 3px 3px 0;
+  top: 0;
+  transform: scaleY(0);
+  transform-origin: center;
+  width: 2px;
+  height: 100%;
+  border-radius: 0;
   background: var(--about-accent);
   transition: transform 0.22s ease;
 }
 
 .aboutRailItem:hover:not(.active) {
-  background: var(--about-panel);
   color: rgba(240, 236, 232, 0.78);
 }
 
 .aboutRailItem.active {
-  background: var(--about-accent-soft);
+  background: transparent;
   color: var(--about-text);
 }
 
 .aboutRailItem.active::before {
-  transform: translateY(-50%) scaleY(1);
+  transform: scaleY(1);
 }
 
 .aboutRailNum {
@@ -87,15 +97,16 @@
 }
 
 .aboutRailLabel {
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   line-height: 1.2;
 }
 
 .aboutRailItem:focus-visible,
 .aboutProgArrow:focus-visible,
-.aboutPill:focus-visible {
+.aboutIndexTrigger:focus-visible {
   outline: 2px solid var(--noir-accent);
   outline-offset: 2px;
 }
@@ -233,45 +244,51 @@
 
 /* ── Profile highlights ───────────────────────────────── */
 
-.aboutCredibilityStrip {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin: -0.1rem 0 0.15rem;
-}
-
-.aboutCredibilityNote {
-  font-size: 0.72rem;
+/* Credit line — the press signal, as type rather than two colored badges. */
+.aboutCredit {
+  margin: 0.15rem 0 0;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--about-faint);
 }
 
+.aboutCreditSep {
+  color: var(--about-accent);
+  margin: 0 0.6em;
+}
+
+/* Capped like .aboutLede is: on a 1440px stage the rules would otherwise run
+   the full width and the copy would set at ~100 characters a line. */
 .aboutHighlightGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.6rem;
-  margin-top: 0.35rem;
+  gap: 0.9rem 1.6rem;
+  margin-top: 0.9rem;
+  max-width: 82ch;
 }
 
+/* Ruled blocks, not boxed cards: a single hairline above each entry, with the
+   accent moving to that rule on hover instead of a fill + lift. */
 .aboutHighlightCard {
-  border: 1px solid var(--about-border);
-  border-radius: 0.82rem;
-  background: var(--about-panel);
-  padding: 0.85rem;
-  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  border: 0;
+  border-top: 1px solid var(--about-border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.7rem 0 0;
+  transition: border-color 0.2s ease;
 }
 
 .aboutHighlightCard:hover {
-  border-color: var(--noir-accent-line);
-  transform: translateY(-2px);
-  background: var(--noir-accent-soft);
+  border-top-color: var(--noir-accent-line);
 }
 
 .aboutHighlightCard h3 {
   margin: 0;
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   font-weight: 700;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--about-accent);
 }
@@ -279,118 +296,121 @@
 .aboutHighlightCard p {
   margin: 0.4rem 0 0;
   font-size: 0.84rem;
-  line-height: 1.46;
-  color: var(--about-muted);
-}
-
-/* ── Working-style points ─────────────────────────────── */
-
-.aboutPoints {
-  margin: 0.4rem 0 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-
-.aboutPoints li {
-  position: relative;
-  padding-left: 1.5rem;
-  font-size: 0.92rem;
-  line-height: 1.58;
-  color: rgba(240, 236, 232, 0.72);
-}
-
-.aboutPoints li::before {
-  content: counter(list-item, decimal-leading-zero);
-  position: absolute;
-  left: 0;
-  top: 0.12rem;
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  color: var(--about-accent);
-}
-
-/* ── Strengths pills ──────────────────────────────────── */
-
-.aboutPills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  margin-top: 0.35rem;
-}
-
-.aboutPill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  border: 1px solid rgba(240, 236, 232, 0.14);
-  border-radius: 999px;
-  background: var(--about-panel);
-  color: rgba(240, 236, 232, 0.68);
-  font-family: inherit;
-  font-size: 0.8rem;
-  font-weight: 600;
-  padding: 0.42rem 0.78rem;
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
-    background 0.2s ease, color 0.2s ease;
-}
-
-.aboutPill.clickable {
-  border-color: var(--noir-accent-line);
-}
-
-.aboutPill:hover {
-  border-color: var(--noir-accent-line);
-  color: rgba(240, 236, 232, 0.9);
-  transform: translateY(-1px);
-}
-
-.aboutPill.active {
-  color: #fff;
-  border-color: var(--noir-accent);
-  background: var(--about-accent);
-  box-shadow: 0 3px 12px var(--about-accent-glow);
-}
-
-.aboutPillLinkIcon {
-  font-size: 0.6rem;
-  opacity: 0.7;
-}
-
-.aboutStrengthDetail {
-  margin-top: 0.5rem;
-  border: 1px solid var(--noir-accent-line);
-  border-radius: 0.78rem;
-  padding: 0.75rem 0.85rem;
-  background:
-    radial-gradient(circle at 0% 0%, rgba(212, 132, 90, 0.08), transparent 60%),
-    var(--noir-panel);
-  box-shadow: 0 8px 24px rgba(22, 20, 18, 0.12);
-}
-
-.aboutStrengthDetailTitle {
-  margin: 0;
-  font-size: 0.7rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--about-accent);
-}
-
-.aboutStrengthDetailCopy {
-  margin: 0.35rem 0 0;
-  font-size: 0.84rem;
   line-height: 1.5;
   color: var(--about-muted);
 }
 
-.aboutLinkHint {
-  color: var(--about-accent);
+/* ── Strengths — ruled index with inline disclosure ───── */
+
+.aboutIndex {
+  margin: 0.85rem 0 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--about-border);
+  /* Same measure cap as the highlight grid — keeps the +/- affordance near the
+     label on a wide stage instead of stranding it at the far right edge. */
+  max-width: 82ch;
+}
+
+.aboutIndexRow {
+  border-bottom: 1px solid var(--about-border);
+}
+
+.aboutIndexTrigger {
+  display: flex;
+  align-items: baseline;
+  gap: 0.9rem;
+  width: 100%;
+  padding: 0.72rem 0.4rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--about-muted);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.aboutIndexTrigger:hover {
+  background: var(--about-accent-soft);
+  color: var(--about-text);
+}
+
+.aboutIndexTrigger[aria-expanded="true"] {
+  color: var(--about-text);
+}
+
+.aboutIndexNum {
+  font-size: 0.64rem;
   font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--about-faint);
+  flex-shrink: 0;
+  transition: color 0.2s ease;
+}
+
+.aboutIndexTrigger[aria-expanded="true"] .aboutIndexNum {
+  color: var(--about-accent);
+}
+
+.aboutIndexLabel {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.aboutIndexToggle {
+  flex-shrink: 0;
+  font-size: 0.95rem;
+  font-weight: 400;
+  line-height: 1;
+  color: var(--about-faint);
+  transition: color 0.2s ease;
+}
+
+.aboutIndexTrigger:hover .aboutIndexToggle,
+.aboutIndexTrigger[aria-expanded="true"] .aboutIndexToggle {
+  color: var(--about-accent);
+}
+
+/* Height is animated by framer-motion, so the padding lives on the inner
+   wrapper — otherwise it would still paint at the collapsed height of 0. */
+.aboutIndexBody {
+  overflow: hidden;
+}
+
+.aboutIndexBodyInner {
+  padding: 0 0.4rem 0.9rem 2.1rem;
+}
+
+.aboutIndexCopy {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--about-muted);
+  max-width: 62ch;
+}
+
+.aboutIndexLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.55rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: var(--about-accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.aboutIndexLink:hover,
+.aboutIndexLink:focus-visible {
+  border-bottom-color: var(--about-accent);
 }
 
 /* ── Progress footer ──────────────────────────────────── */
@@ -409,34 +429,35 @@
 .aboutProgArrow {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  background: var(--about-panel);
-  border: 1px solid rgba(240, 236, 232, 0.14);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: rgba(240, 236, 232, 0.45);
   font-size: 0.72rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
-    transform 0.15s ease;
+  transition: color 0.2s ease;
   flex-shrink: 0;
 }
 
 .aboutProgArrow:hover:not(:disabled) {
-  background: var(--noir-accent-soft);
-  border-color: var(--noir-accent-line);
   color: var(--about-accent);
-  transform: scale(1.05);
-}
-
-.aboutProgArrow:active:not(:disabled) {
-  transform: scale(0.94);
 }
 
 .aboutProgArrow:disabled {
   opacity: 0.22;
   cursor: default;
+}
+
+/* Borderless squares are still real hit targets on touch — match the 44px
+   minimum globals.css applies elsewhere under a coarse pointer. */
+@media (pointer: coarse) {
+  .aboutProgArrow {
+    width: 44px;
+    height: 44px;
+  }
 }
 
 .aboutProgCounter {
@@ -645,23 +666,35 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.1rem;
-    padding: 0.4rem 0.6rem;
+    padding: 0.4rem 0.75rem;
     white-space: nowrap;
-    flex-shrink: 0;
+    /* The base rule's `width: 100%` is sized against the rail itself. That's
+       right for the vertical desktop rail, but here the rail is a flex ROW, so
+       every entry claimed the full strip width and the three chapters scrolled
+       off to 1088px. Size to content and share the strip instead. */
+    width: auto;
+    flex: 1 1 auto;
+  }
+
+  /* The rail runs horizontally here, so the hairline between entries and the
+     active marker both rotate 90° with it. */
+  .aboutRailItem + .aboutRailItem {
+    border-top: 0;
+    border-left: 1px solid var(--about-border);
   }
 
   .aboutRailItem::before {
     left: 0;
     top: auto;
     bottom: 0;
-    transform: translateY(0) scaleX(0);
+    transform: scaleX(0);
     width: 100%;
     height: 2px;
-    border-radius: 2px 2px 0 0;
+    border-radius: 0;
   }
 
   .aboutRailItem.active::before {
-    transform: translateY(0) scaleX(1);
+    transform: scaleX(1);
   }
 
   .aboutChapter {
@@ -719,7 +752,7 @@
   }
 
   .aboutLede,
-  .aboutPoints li {
+  .aboutIndexCopy {
     font-size: 0.86rem;
   }
 }
@@ -728,7 +761,10 @@
   .aboutRailItem,
   .aboutRailItem::before,
   .aboutHighlightCard,
-  .aboutPill,
+  .aboutIndexTrigger,
+  .aboutIndexNum,
+  .aboutIndexToggle,
+  .aboutIndexLink,
   .aboutProgArrow {
     transition: none;
   }

--- a/src/components/features/about/AboutAppView/AboutAppView.tsx
+++ b/src/components/features/about/AboutAppView/AboutAppView.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useMemo, useState, type CSSProperties } from "react";
+import React, { useCallback, useState, type CSSProperties } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronLeft, faChevronRight, faArrowUpRightFromSquare, faPlay, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
 import { aboutMePills } from "@/data/aboutMePills";
-import { AboutMePill } from "@/lib/types";
 import { AppView } from "@/components/features/shell";
 import styles from "./AboutAppView.module.css";
 
@@ -34,61 +33,30 @@ const ABOUT_HERO_START_INDEX = 5;
 
 const profileHighlights = [
   {
-    label: "Shipped Track Record",
-    value: "5 production apps, solo — civic tech, privacy AI, PropTech, spatial AI, real-time voice — in 12 months.",
+    label: "Shipped",
+    value: "Five production apps in twelve months, solo — civic tech, privacy AI, PropTech, spatial AI, and real-time voice.",
   },
   {
-    label: "Signature Engineering Move",
-    value: "Verified Firebase tokens via Google's JWKS directly — no Admin SDK, no exposed service account.",
+    label: "Built",
+    value: "Firebase tokens verified straight against Google's JWKS — no Admin SDK, no service account sitting on a server to leak.",
   },
   {
-    label: "Full-Stack Ownership",
-    value: "Architecture, security, compliance docs, and 3D graphics — end to end, not handed off.",
+    label: "Owned",
+    value: "Architecture, security, compliance docs, 3D graphics. Nothing handed off because it wasn't my job.",
   },
   {
-    label: "Public Recognition",
-    value: "Featured in a PBS documentary on public interest tech; SXSW EDU 2025 panelist.",
-  },
-];
-
-const collaborationSections = [
-  {
-    title: "How I Think",
-    points: [
-      "I look for the constraint that actually breaks first — a rate limit, a token budget, a background task getting killed — before I reach for a clever solution.",
-      "I treat security and compliance as design inputs, not cleanup: an on-device AES-256-GCM vault and JWKS-based auth were both scoped in from day one, not bolted on after an incident.",
-      "I'd rather ship the smaller, correct architecture than the impressive one.",
-    ],
-  },
-  {
-    title: "How I Work",
-    points: [
-      "I've been the sole engineer, designer, and product owner on 5 shipped apps at once — I close the loop myself instead of waiting on a hand-off.",
-      "I write the deployment runbook and the compliance doc in the same sprint as the feature, not after someone asks where they are.",
-      "I default to typed, tested, CI-gated code — strict TypeScript, GitHub Actions, pre-commit hooks — so \"it works on my machine\" isn't a phase I pass through.",
-    ],
-  },
-  {
-    title: "How I Collaborate",
-    points: [
-      "I hand off systems other engineers can extend without a walkthrough — documented APIs, Postman collections, and architecture diagrams included.",
-      "I mentor deliberately: years of 1:1 code reviews and mock interviews for bootcamp grads, not just filling in when a team needed an extra reviewer.",
-      "I say the risk out loud early, then bring options — not just a problem — because a team that trusts the flag will trust the fix.",
-    ],
+    label: "On Record",
+    value: "A PBS documentary on public interest tech, and a panel at SXSW EDU 2025.",
   },
 ];
 
 type Chapter =
   | { id: string; label: string; kind: "profile" }
-  | { id: string; label: string; kind: "list"; sectionIndex: number }
   | { id: string; label: string; kind: "strengths" }
   | { id: string; label: string; kind: "featured" };
 
 const chapters: Chapter[] = [
   { id: "profile", label: "Profile", kind: "profile" },
-  { id: "think", label: "How I Think", kind: "list", sectionIndex: 0 },
-  { id: "work", label: "How I Work", kind: "list", sectionIndex: 1 },
-  { id: "collaborate", label: "How I Collaborate", kind: "list", sectionIndex: 2 },
   { id: "strengths", label: "Strengths", kind: "strengths" },
   { id: "featured", label: "Featured", kind: "featured" },
 ];
@@ -102,17 +70,10 @@ const chapterVariants = {
 const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary }) => {
   const [chapterIndex, setChapterIndex] = useState(0);
   const [direction, setDirection] = useState<1 | -1>(1);
-  const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
+  const [openStrength, setOpenStrength] = useState<string | null>(null);
   const reduceMotion = useReducedMotion();
 
   const chapter = chapters[chapterIndex];
-
-  const pillsByLabel = useMemo(() => {
-    return aboutMePills.reduce<Record<string, AboutMePill>>((acc, pill) => {
-      acc[pill.label] = pill;
-      return acc;
-    }, {});
-  }, []);
 
   // Center the "start" word within the hero list itself (not the page) each
   // time the list mounts — including when the Profile chapter is revisited.
@@ -131,7 +92,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
     if (index === chapterIndex) return;
     setDirection(index > chapterIndex ? 1 : -1);
     setChapterIndex(index);
-    setActiveTooltip(null);
+    setOpenStrength(null);
   };
 
   const navigate = (dir: 1 | -1) => {
@@ -140,16 +101,8 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
     goToChapter(next);
   };
 
-  const handlePillClick = (pill: AboutMePill) => {
-    if (activeTooltip === pill.label) {
-      if (pill.link) {
-        window.open(pill.link, "_blank", "noopener,noreferrer");
-      } else {
-        setActiveTooltip(null);
-      }
-      return;
-    }
-    setActiveTooltip(pill.label);
+  const toggleStrength = (label: string) => {
+    setOpenStrength((current) => (current === label ? null : label));
   };
 
   const renderFeaturedChapter = () => (
@@ -258,15 +211,13 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
             Full-stack engineer who ships solo, fast, and end-to-end — from civic
             platforms to privacy-first AI tools.
           </p>
-          <div className={styles.aboutCredibilityStrip}>
-            <span className={`${styles.aboutFeaturedBadge} ${styles.aboutFeaturedBadgePbs}`}>
-              PBS Documentary
+          <p className={styles.aboutCredit}>
+            PBS Documentary
+            <span className={styles.aboutCreditSep} aria-hidden="true">
+              ·
             </span>
-            <span className={`${styles.aboutFeaturedBadge} ${styles.aboutFeaturedBadgeSxsw}`}>
-              SXSW EDU 2025
-            </span>
-            <span className={styles.aboutCredibilityNote}>— see Featured chapter</span>
-          </div>
+            SXSW EDU 2025 Panel
+          </p>
           <div className={styles.aboutHighlightGrid}>
             {profileHighlights.map((item) => (
               <article key={item.label} className={styles.aboutHighlightCard}>
@@ -279,80 +230,73 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
       );
     }
 
-    if (chapter.kind === "list") {
-      const section = collaborationSections[chapter.sectionIndex];
-      return (
-        <>
-          <p className={styles.aboutEyebrow}>Working Style</p>
-          <h2 className={styles.aboutChapterTitle}>{section.title}</h2>
-          <ul className={styles.aboutPoints}>
-            {section.points.map((point) => (
-              <li key={point}>{point}</li>
-            ))}
-          </ul>
-        </>
-      );
-    }
-
     // strengths
     return (
       <>
         <p className={styles.aboutEyebrow}>What I Bring</p>
         <h2 className={styles.aboutChapterTitle}>Core Strengths</h2>
-        <p className={styles.aboutLede}>
-          Select a strength for detail. Click again to open external links.
-        </p>
+        <p className={styles.aboutLede}>Open a line for the detail behind it.</p>
 
-        <div className={styles.aboutPills}>
-          {aboutMePills.map((pill) => {
-            const isActive = activeTooltip === pill.label;
+        <ul className={styles.aboutIndex}>
+          {aboutMePills.map((pill, i) => {
+            const isOpen = openStrength === pill.label;
+            const bodyId = `about-strength-${i}`;
             return (
-              <button
-                key={pill.label}
-                type="button"
-                className={`${styles.aboutPill} ${pill.link ? styles.clickable : ""} ${
-                  isActive ? styles.active : ""
-                }`}
-                onClick={() => handlePillClick(pill)}
-                aria-expanded={isActive}
-                aria-controls={isActive ? "about-strength-detail" : undefined}
-              >
-                <span>{pill.label}</span>
-                {pill.link && (
-                  <FontAwesomeIcon
-                    icon={faArrowUpRightFromSquare}
-                    className={styles.aboutPillLinkIcon}
-                    aria-hidden="true"
-                  />
-                )}
-              </button>
+              <li key={pill.label} className={styles.aboutIndexRow}>
+                <button
+                  type="button"
+                  className={styles.aboutIndexTrigger}
+                  onClick={() => toggleStrength(pill.label)}
+                  aria-expanded={isOpen}
+                  aria-controls={bodyId}
+                >
+                  <span className={styles.aboutIndexNum}>
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                  <span className={styles.aboutIndexLabel}>{pill.label}</span>
+                  <span className={styles.aboutIndexToggle} aria-hidden="true">
+                    {isOpen ? "−" : "+"}
+                  </span>
+                </button>
+
+                <AnimatePresence initial={false}>
+                  {isOpen && (
+                    <motion.div
+                      id={bodyId}
+                      className={styles.aboutIndexBody}
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: "auto", opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={
+                        reduceMotion
+                          ? { duration: 0 }
+                          : { duration: 0.24, ease: [0.25, 0.46, 0.45, 0.94] }
+                      }
+                    >
+                      <div className={styles.aboutIndexBodyInner}>
+                        <p className={styles.aboutIndexCopy}>{pill.tooltip}</p>
+                        {pill.link && (
+                          <a
+                            href={pill.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.aboutIndexLink}
+                          >
+                            {pill.linkLabel ?? "Open link"}
+                            <FontAwesomeIcon
+                              icon={faArrowUpRightFromSquare}
+                              aria-hidden="true"
+                            />
+                          </a>
+                        )}
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </li>
             );
           })}
-        </div>
-
-        <AnimatePresence mode="wait">
-          {activeTooltip && pillsByLabel[activeTooltip] && (
-            <motion.div
-              key={activeTooltip}
-              id="about-strength-detail"
-              className={styles.aboutStrengthDetail}
-              role="status"
-              aria-live="polite"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={reduceMotion ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }}
-            >
-              <p className={styles.aboutStrengthDetailTitle}>{activeTooltip}</p>
-              <p className={styles.aboutStrengthDetailCopy}>
-                {pillsByLabel[activeTooltip]?.tooltip}
-                {pillsByLabel[activeTooltip]?.link && (
-                  <span className={styles.aboutLinkHint}> Click again to open.</span>
-                )}
-              </p>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        </ul>
       </>
     );
   };

--- a/src/data/aboutMePills.ts
+++ b/src/data/aboutMePills.ts
@@ -31,6 +31,7 @@ export const aboutMePills: AboutMePill[] = [
         tooltip:
             "Featured in a Roadtrip Nation documentary on public interest tech and served as an SXSW EDU 2025 panelist on youth, technology, and media.",
         link: "https://roadtripnation.com/roadtrip/tech-for-us-documentary",
+        linkLabel: "Watch the documentary",
     },
     {
         label: "Production-Grade Craftsman",

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -6,6 +6,8 @@ export interface AboutMePill {
     tooltip: string;
     icon?: string;
     link?: string;
+    /** Anchor text for `link` in the About strengths index. Falls back to "Open link". */
+    linkLabel?: string;
 }
 
 export interface Project {


### PR DESCRIPTION
Reworks the content, styling, and layout of `AboutAppView`. The **Featured chapter** and the **"I build ___" hero** are deliberately untouched.

## Content

**Cut the three working-style chapters.** "How I Think", "How I Work", and "How I Collaborate" were 3 of the 6 chapters and nine long first-person bullets that read as an essay. `collaborationSections`, the `kind: "list"` chapter variant, and `.aboutPoints` are all gone. Six chapters becomes three:

```
01 Profile    02 Strengths    03 Featured
```

**Rewrote `profileHighlights` off the resume headlines**, keeping the four-entry grid:

| before | after |
|---|---|
| Shipped Track Record | **Shipped** |
| Signature Engineering Move | **Built** |
| Full-Stack Ownership | **Owned** |
| Public Recognition | **On Record** |

## Styling — pills out, print grammar in

The view leaned on `border-radius: 999px` for strength chips, badges, and CTAs, plus two circular footer arrows. Replaced throughout with hairline rules and uppercase accent micro-labels, following the vocabulary already established in `ResumeHighlightsModal.css`.

**Strengths** is the core change. The 7-chip cluster and its detached detail panel become a numbered accordion of ruled rows, with the copy expanding inline under the row you open:

```
WHAT I BRING
Core Strengths
─────────────────────────────────────────────
01  Solo Full-Stack Shipper                 −
    Sole engineer, designer, and product
    owner across 5 production apps…
─────────────────────────────────────────────
02  Security-First Architect                +
─────────────────────────────────────────────
```

This also drops a UX trap: clicking an already-open pill used to open its external link in a new tab, with nothing on screen saying so. Rows now just toggle, and the expanded body renders a real anchor (`Watch the documentary ↗`) when the entry has a link. Disclosure state is styled off `[aria-expanded="true"]` on the trigger, matching the existing convention.

**Profile** highlight cards lose their boxes for a single hairline above each entry, and the credibility strip's two colored badges become one uppercase type line — which also stops Profile borrowing `.aboutFeaturedBadge` from the Featured chapter. **Rail and footer arrows** lose their radii and fills; rail entries are separated by hairlines and marked with a square accent bar.

The only two `999px` radii left in the file are `.aboutFeaturedBadge` and `.aboutFeaturedCta`, now scoped to the Featured chapter alone.

## Bug fix — mobile rail

Found while verifying at 390px. The base `.aboutRailItem` rule sets `width: 100%`, which is correct for the vertical desktop rail but is sized against the rail itself — so once the mobile query flipped the rail to a flex row, every entry claimed the full strip width. Three chapters were laying out at 352px each and scrolling off to `scrollWidth: 1088` inside a `374px` strip. Entries now size to content and share the strip (`width: auto; flex: 1 1 auto`). Pre-existing; not caused by this change.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — no warnings or errors
- `npm run build` — succeeds
- Driven in Chromium at 1440 / 768 / 580 / 480 / 390px: rail shows exactly three chapters, footer reads `01 / 03`, rows expand and collapse, the Public Interest Technologist row exposes its external link, and Featured renders unchanged. No rail overflow and no page horizontal scroll at any width.
- Re-run under `prefers-reduced-motion: reduce` — expansion settles instantly, hero cascade static.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjS839YBu2iCUtNTLJs9i)_