### PR TITLE
About: centre the Profile chapter, swap +/− for the repo chevron

### DIFF
--- a/src/components/features/about/AboutAppView/AboutAppView.module.css
+++ b/src/components/features/about/AboutAppView/AboutAppView.module.css
@@ -125,6 +125,8 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+  display: flex;
+  flex-direction: column;
 }
 
 .aboutChapter {
@@ -132,6 +134,17 @@
   flex-direction: column;
   gap: 0.7rem;
   padding: 1.8rem 1.9rem;
+}
+
+/* Profile is the dossier's cover page — fixed content that was left sitting
+   against the top of a tall stage once the working-style chapters were cut.
+   Auto margins centre it, and unlike `justify-content: center` they collapse
+   to 0 rather than clipping when the content outgrows the stage, so short
+   viewports still scroll from the top.
+   Deliberately Profile-only: Strengths grows every time a row opens, and
+   re-centring on each toggle would shunt the whole list up the screen. */
+.aboutChapterCentered {
+  margin-block: auto;
 }
 
 .aboutEyebrow {
@@ -363,18 +376,29 @@
   line-height: 1.3;
 }
 
+/* CSS-drawn chevron, matching the disclosure marker in ResumeHighlightsModal:
+   points down when collapsed, flips up when open. Centered across the row
+   rather than baseline-aligned, so it stays put if a label wraps. */
 .aboutIndexToggle {
   flex-shrink: 0;
-  font-size: 0.95rem;
-  font-weight: 400;
-  line-height: 1;
-  color: var(--about-faint);
-  transition: color 0.2s ease;
+  align-self: center;
+  width: 7px;
+  height: 7px;
+  margin-top: -3px;
+  border-right: 2px solid var(--about-faint);
+  border-bottom: 2px solid var(--about-faint);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
 .aboutIndexTrigger:hover .aboutIndexToggle,
 .aboutIndexTrigger[aria-expanded="true"] .aboutIndexToggle {
-  color: var(--about-accent);
+  border-color: var(--about-accent);
+}
+
+.aboutIndexTrigger[aria-expanded="true"] .aboutIndexToggle {
+  transform: rotate(225deg);
+  margin-top: 3px;
 }
 
 /* Height is animated by framer-motion, so the padding lives on the inner

--- a/src/components/features/about/AboutAppView/AboutAppView.tsx
+++ b/src/components/features/about/AboutAppView/AboutAppView.tsx
@@ -254,9 +254,7 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
                     {String(i + 1).padStart(2, "0")}
                   </span>
                   <span className={styles.aboutIndexLabel}>{pill.label}</span>
-                  <span className={styles.aboutIndexToggle} aria-hidden="true">
-                    {isOpen ? "−" : "+"}
-                  </span>
+                  <span className={styles.aboutIndexToggle} aria-hidden="true" />
                 </button>
 
                 <AnimatePresence initial={false}>
@@ -332,7 +330,9 @@ const AboutAppView: React.FC<AboutAppViewProps> = ({ onClose, onOpenDocumentary 
                 animate="center"
                 exit="exit"
                 transition={reduceMotion ? { duration: 0 } : { duration: 0.26, ease: [0.25, 0.46, 0.45, 0.94] }}
-                className={styles.aboutChapter}
+                className={`${styles.aboutChapter} ${
+                  chapter.kind === "profile" ? styles.aboutChapterCentered : ""
+                }`}
                 aria-labelledby="about-title"
               >
                 {renderChapter()}


### PR DESCRIPTION
The two follow-ups noted on #65.

## Profile sat against the top of a tall stage

Cutting the working-style chapters made Profile short enough that it hugged the top of the stage with a large gap beneath it. It now centres with `margin-block: auto`.

Auto margins rather than `justify-content: center` specifically because they collapse to `0` when the content outgrows the container instead of clipping its top — so a short viewport still scrolls from the beginning.

Scoped to Profile alone via an `.aboutChapterCentered` modifier. Strengths grows every time a row opens, and re-centring on each toggle would shunt the whole list up the screen.

| | offset from stage top | content / stage | scrolls |
|---|---|---|---|
| Profile @ 1440×900 | **66px** (= `(669−537)/2`) | 537 / 669 | no |
| Profile @ 1280×640 | **0px** | 537 / 448 | yes |
| Strengths, collapsed | 0px | 474 / 669 | no |
| Strengths, expanded | **0px — 0px shift** | 551 / 669 | no |
| Featured | 0px | 1043 / 669 | yes |

## `+`/`−` → the chevron used everywhere else

The disclosure marker was a text glyph, but every other disclosure in the app uses the CSS-drawn chevron from `ResumeHighlightsModal.css` — `rotate(45deg)` pointing down, `rotate(225deg)` when open, border-color moving to the accent.

Given `align-items: baseline` on the trigger, the chevron is `align-self: center` so it sits centred across the row and stays put if a label ever wraps to two lines.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — no warnings or errors
- `npm run build` — succeeds
- Driven in Chromium at 1440×900, 1280×640, and 390×844: measurements above, chevrons flip correctly, expanding a row does not move the list, and Featured is unaffected.
- `.aboutIndexToggle` was already in the `prefers-reduced-motion` block, so the new `transform` transition is suppressed there too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjS839YBu2iCUtNTLJs9i)_