### PR TITLE
Fix desktop wheel, AppView stacking, scrapbook cropping, Projects tab, Toolbelt defaults

### DIFF
--- a/src/components/features/scrapbook/DomeGallery/DomeGallery.module.css
+++ b/src/components/features/scrapbook/DomeGallery/DomeGallery.module.css
@@ -164,10 +164,14 @@ main.sphere-main {
   box-shadow: 0 10px 30px rgba(0, 0, 0, .35);
 }
 
+.viewer .enlarge {
+  background: #000;
+}
+
 .viewer .enlarge img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   filter: var(--image-filter, none);
 }
 

--- a/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
+++ b/src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx
@@ -213,9 +213,7 @@ const ToolbeltGraph: React.FC<ToolbeltGraphProps> = ({
   // reusing the same object across updates carries d3's mutated x/y/vx/vy over.
   const nodesRef = useRef(new Map<string, SimNode>());
 
-  const [collapsed, setCollapsed] = useState<Set<string>>(
-    () => new Set(buildToolbeltTree(tools, orderedCategories, signatureStack).map((root) => root.name))
-  );
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
   const [selectedTool, setSelectedTool] = useState<SelectedTool | null>(null);
   const toolUsage = useMemo(() => buildToolUsageIndex(services, projects), [services, projects]);
   // Read synchronously so there is no post-mount state flip (which used to force

--- a/src/components/layout/LandingPage/LandingPage.css
+++ b/src/components/layout/LandingPage/LandingPage.css
@@ -235,39 +235,6 @@
   pointer-events: none;
 }
 
-/* Per-app position markers (see desktop-wheel-tick below), sharing the rail's
-   own box so a tick's percentage-based (left, top) lands on the exact curve
-   point RAIL_PATH draws through. */
-.desktop-wheel-rail-ticks {
-  position: absolute;
-  top: 0;
-  right: 90px;
-  height: 100%;
-  width: 130px;
-  pointer-events: none;
-}
-
-.desktop-wheel-tick {
-  position: absolute;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.5);
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
-  transform: translate(-50%, -50%);
-}
-
-/* The active tick sits almost exactly under its (much bigger) icon — sized up
-   and lit with the app's own accent color so it reads as the glowing "anchor"
-   the icon rests on, rather than vanishing underneath it. */
-.desktop-wheel-tick.is-active {
-  width: 11px;
-  height: 11px;
-  background: var(--tick-accent, #ffffff);
-  box-shadow: 0 0 12px 3px var(--tick-accent, rgba(255, 255, 255, 0.85)),
-    0 0 0 2px rgba(255, 255, 255, 0.65);
-}
-
 .desktop-wheel-row {
   /* top/right are set inline per row (see DesktopIcons.tsx) — deliberately
      not transform, which would force a stacking context here and trap the

--- a/src/components/layout/LandingPage/components/DesktopIcons.tsx
+++ b/src/components/layout/LandingPage/components/DesktopIcons.tsx
@@ -347,35 +347,6 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
           />
         </svg>
 
-        {/* Per-app position markers riding the same curve as the rows
-            themselves (see getRowMetrics), so the rail reads as a live "N
-            items, you are here" indicator instead of pure decoration. */}
-        <div className="desktop-wheel-rail-ticks" aria-hidden="true">
-          {DESKTOP_APPS.map((app, index) => {
-            const { continuous, t } = getRowMetrics(index, active, dragY);
-            const railX = 8 + 87 * easeRound(t);
-            const railY = 50 + Math.sign(continuous) * t * 50;
-            const isActive = index === active;
-            return (
-              <span
-                key={app.name}
-                className={`desktop-wheel-tick${isActive ? " is-active" : ""}`}
-                style={
-                  {
-                    left: `${railX}%`,
-                    top: `${railY}%`,
-                    "--tick-accent": app.color,
-                    transition:
-                      isDragging || isWheeling || prefersReducedMotion
-                        ? "none"
-                        : "left 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), top 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s ease, box-shadow 0.3s ease, width 0.3s ease, height 0.3s ease",
-                  } as CSSProperties
-                }
-              />
-            );
-          })}
-        </div>
-
         {DESKTOP_APPS.map((app, index) => {
           const { translateY, t, curveX, opacity, scale } = getRowMetrics(index, active, dragY);
           const isActive = index === active;

--- a/src/components/layout/LandingPage/components/DesktopIcons.tsx
+++ b/src/components/layout/LandingPage/components/DesktopIcons.tsx
@@ -21,6 +21,7 @@ const ACTIVE_ICON_SIZE = 84; // px
 const BASE_ICON_SIZE = 64; // px, before the recede scale is applied
 const WHEEL_SETTLE_MS = 140; // pause in wheel events before snapping to a row
 const FLING_PROJECTION_MS = 120; // how far a fast drag release "carries" past the drop point
+const WHEEL_JITTER_PX = 8; // below this, a settled wheel offset is noise, not an intended scroll
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
@@ -105,10 +106,16 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
     maybePreloadByPath(DESKTOP_APPS[active].path);
   }, [active, maybePreloadByPath]);
 
+  // A positive dragY/offset (drag or scroll "down") walks toward earlier
+  // rows, so it's bounded by how many rows precede `active`; a negative one
+  // walks toward later rows and is bounded by how many follow it. Getting
+  // this backwards (as it was) starves the direction with more rows left to
+  // reach — clamping the gesture after just one row — while letting the
+  // other direction over-travel past the last real row before snapping back.
   const bounds = useMemo(
     () => ({
-      min: -active * ROW_HEIGHT,
-      max: (DESKTOP_APPS.length - 1 - active) * ROW_HEIGHT,
+      min: -(DESKTOP_APPS.length - 1 - active) * ROW_HEIGHT,
+      max: active * ROW_HEIGHT,
     }),
     [active],
   );
@@ -242,7 +249,16 @@ const DesktopIcons: React.FC<DesktopIconsProps> = ({
 
     function settle() {
       setIsWheeling(false);
-      const rowsMoved = Math.round(offset / ROW_HEIGHT);
+      // A single real scroll notch (mouse wheel, or a short trackpad swipe)
+      // is often well under one row's worth of pixels, which rounded to the
+      // nearest row used to collapse to 0 and settle back in place — so a
+      // deliberate, isolated scroll did nothing. Any offset past the jitter
+      // floor now commits at least one row in the direction scrolled;
+      // rounding still takes over once a gesture spans multiple rows.
+      const rowsMoved =
+        Math.abs(offset) < WHEEL_JITTER_PX
+          ? 0
+          : Math.sign(offset) * Math.max(1, Math.round(Math.abs(offset) / ROW_HEIGHT));
       offset = 0;
       setDragY(0);
       if (rowsMoved !== 0) {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -83,11 +83,12 @@ const projectData: Project[] = [
     iconWidth: 1024,
     iconHeight: 1024,
     iconScale: 1.3,
+    archived: true,
   },
   {
     id: 1,
     slug: "payback",
-    name: "Payback",
+    name: "Payback Own",
     yearRange: "2025-2026",
     description:
       "Privacy-first consumer intelligence platform that processes personal data on-device and generates secure behavioral analytics.",
@@ -144,6 +145,7 @@ const projectData: Project[] = [
     iconWidth: 1536,
     iconHeight: 1024,
     iconScale: 1.55,
+    archived: true,
   },
   {
     id: 8,

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -29,8 +29,20 @@ export function useModalState() {
         setModalState(prev => ({ ...prev, showWelcomeWindow: show }));
     }, []);
 
+    // The four full-screen AppViews (About/Skillset/Projects/Scrapbook) are
+    // meant to be mutually exclusive — only one takeover is ever "open" at a
+    // time — but each used to be an independent boolean, so opening one while
+    // another was already open left both true. Since every AppView shares the
+    // same z-index and renders in a fixed DOM order (see AppViews.tsx), the
+    // newly opened one didn't reliably land on top; it could paint underneath
+    // whichever view happens to sit later in that fixed order. Closing the
+    // others here (and clearing their own selection ids, matching what each
+    // view's own onClose already does) keeps exactly one AppView open and its
+    // state clean, regardless of which nav path the user takes to open it.
     const setShowAboutMe = useCallback((show: boolean) => {
-        setModalState(prev => ({ ...prev, showAboutMe: show }));
+        setModalState(prev => (show
+            ? { ...prev, showAboutMe: true, showSkillset: false, showProjects: false, showScrapbook: false, selectedServiceId: null, selectedProjectId: null }
+            : { ...prev, showAboutMe: false }));
     }, []);
 
     const setShowResume = useCallback((show: boolean) => {
@@ -38,11 +50,15 @@ export function useModalState() {
     }, []);
 
     const setShowSkillset = useCallback((show: boolean) => {
-        setModalState(prev => ({ ...prev, showSkillset: show }));
+        setModalState(prev => (show
+            ? { ...prev, showSkillset: true, showAboutMe: false, showProjects: false, showScrapbook: false, selectedProjectId: null }
+            : { ...prev, showSkillset: false }));
     }, []);
 
     const setShowProjects = useCallback((show: boolean) => {
-        setModalState(prev => ({ ...prev, showProjects: show }));
+        setModalState(prev => (show
+            ? { ...prev, showProjects: true, showAboutMe: false, showSkillset: false, showScrapbook: false, selectedServiceId: null }
+            : { ...prev, showProjects: false }));
     }, []);
 
     const setShowDocumentary = useCallback((show: boolean) => {
@@ -50,7 +66,9 @@ export function useModalState() {
     }, []);
 
     const setShowScrapbook = useCallback((show: boolean) => {
-        setModalState(prev => ({ ...prev, showScrapbook: show }));
+        setModalState(prev => (show
+            ? { ...prev, showScrapbook: true, showAboutMe: false, showSkillset: false, showProjects: false, selectedServiceId: null, selectedProjectId: null }
+            : { ...prev, showScrapbook: false }));
     }, []);
 
     const setShowContactNotification = useCallback((show: boolean) => {


### PR DESCRIPTION
## Summary

Six UI/UX fixes, each verified live with Playwright before/after.

**1. Desktop wheel (side nav "wheel") drag/scroll**

`src/components/layout/LandingPage/components/DesktopIcons.tsx`

- The drag/scroll clamp `bounds` had `min`/`max` swapped: `min` (which limits how far you can drag/scroll *toward later rows*) was computed from the count of rows *before* the active one, and `max` was computed from the count *after* — backwards. In practice this meant a gesture toward the direction with more rows left to reach got clamped dead after just one row, while the opposite direction was allowed to over-travel well past the last real row before snapping back. Fixed by swapping the two formulas.
- `settle()` rounded the accumulated wheel offset to the nearest row (`Math.round(offset / ROW_HEIGHT)`). A single real scroll-wheel notch is often well under half a row's worth of pixels, which rounds to 0 — so an isolated, deliberate scroll (the common case for a physical mouse wheel) silently did nothing. Fixed so any offset past a small jitter floor commits at least one row in the scrolled direction; multi-row gestures still round normally.

**2. Projects view burying other nav views**

`src/hooks/useModalState.ts`

The four full-screen AppViews (About/Skillset/Projects/Scrapbook) are meant to be mutually exclusive, but each was toggled by an independent boolean. Opening one while another was already open (e.g. clicking "About" in the top nav while Projects was open) left both `true`. Since all AppViews share the same z-index and render in a fixed DOM order, the newly opened view didn't reliably land on top — it could paint underneath whichever view sits later in that order (Projects, in particular, since it's third). Fixed by having each `setShowX(true)` close the other three (and clear their own selection ids, matching what each view's `onClose` already does), so exactly one AppView is ever open.

**3. Colored dots on the wheel rail**

`src/components/layout/LandingPage/components/DesktopIcons.tsx`, `LandingPage.css`

Removed the per-app colored position-marker dots strung along the wheel's decorative rail; the rail line itself is untouched.

**4. Scrapbook enlarged image cropping**

`src/components/features/scrapbook/DomeGallery/DomeGallery.module.css`

The enlarged/opened image view used `object-fit: cover` inside a fixed square frame, cropping any non-square photo to fill it. Switched to `object-fit: contain` (with a black letterbox background) so the full image is always visible.

**5. Projects "Featured" tab curation**

`src/data/projects.ts`

Featured now shows exactly: Pinpoint, The Yap App, Payback Own (renamed from "Payback"), Unmasked Coaching, and The Reckoning. STLMNT and Feng Shui were moved to the "More" tab (marked `archived: true`) along with the rest.

**6. Toolbelt categories default state**

`src/components/features/skills/SkillsetAppView/ToolbeltGraph.tsx`

Categories now start expanded instead of collapsed.

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no errors/warnings
- [x] Manual verification via Playwright against the running dev server for each fix:
  - Drag/scroll the wheel in both directions from various starting rows; confirm it reaches every row and clamps correctly at both ends; confirm the rail no longer shows colored dots
  - Open Projects, then open About/Services/Scrapbook via the top nav; confirm the new view fully replaces Projects instead of rendering underneath it
  - Open a scrapbook photo; confirm the full (non-square) image displays letterboxed instead of cropped
  - Open Projects; confirm Featured (5) / More (10) tab counts and exact project membership
  - Open Services → Toolbelt; confirm all categories render expanded by default
