### PR TITLE
Give Featured Projects a spinning 3D carousel

### DIFF
--- a/src/components/features/portfolio/ProjectsAppView/ProjectCoverflow.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectCoverflow.tsx
@@ -3,29 +3,15 @@
 import React, { useEffect, useRef, useState, type CSSProperties } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useGesture } from "@use-gesture/react";
-import * as d3 from "d3";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { Project } from "@/lib/types";
 import ProjectMedia from "../shared/ProjectMedia";
+import { cornerColorFor, DOC_CORNER_COLOR } from "../shared/cornerColor";
 import styles from "./ProjectCoverflow.module.css";
-
-// Documentary projects keep the fixed green corner used by the "Documentary"
-// tag elsewhere in the app; every other project gets its own color from a
-// hue rotation anchored at --noir-accent's hue — same pattern already used
-// for per-item coloring in SkillsetAppView/ToolbeltGraph.tsx.
-const DOC_CORNER_COLOR = "#0f9d6b"; // --noir-doc
-const CORNER_HUE_START = 21; // --noir-accent's own hue (#d4845a)
-const CORNER_SATURATION = 0.48;
-const CORNER_LIGHTNESS = 0.6;
 
 // Minimum horizontal drag (px) to advance the carousel on release.
 const SWIPE_DISTANCE = 40;
-
-function cornerColorFor(index: number, count: number): string {
-  const hue = (CORNER_HUE_START + index * (360 / count)) % 360;
-  return d3.hsl(hue, CORNER_SATURATION, CORNER_LIGHTNESS).formatHex();
-}
 
 interface ProjectCoverflowProps {
   projects: Project[];

--- a/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
@@ -183,6 +183,7 @@ carousel
 .item {
   --_width: var(--_item-width);
   --_height: var(--_item-height);
+  --_corner: calc(var(--_width) * 0.22);
   --_rotation: calc(360 / var(--_num-elements) * var(--_index) * 1deg);
   left: calc(var(--_radius) - var(--_item-width) / 2);
   top: calc(var(--_radius) - var(--_item-height) / 2);
@@ -191,13 +192,14 @@ carousel
   width: var(--_width);
   height: var(--_height);
   transition: all var(--carousel-transition-duration) var(--carousel-transition-ease);
-  box-shadow: 0 0 var(--carousel-item-glow-size) transparent;
+  box-shadow: 0 0 var(--carousel-item-glow-size) transparent, 0 0.7rem 1.6rem rgba(0, 0, 0, 0.4);
   position: absolute;
 }
 
 .item:hover,
 .item:focus-within {
-  box-shadow: 0 0 var(--carousel-item-glow-size) rgb(var(--carousel-item-glow-color-rgb));
+  box-shadow: 0 0 var(--carousel-item-glow-size) var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))),
+    0 1.4rem 3.2rem rgba(0, 0, 0, 0.55);
   transform: rotateY(var(--_rotation)) translateZ(calc(var(--_radius) * var(--carousel-item-hover-effect)));
 }
 
@@ -209,78 +211,131 @@ carousel
   height: inherit;
   margin: 0;
   padding: 0;
-  border: 0;
   font: inherit;
   color: inherit;
   cursor: pointer;
   position: relative;
   overflow: hidden;
+  border: 1px solid var(--lg-edge, rgba(255, 220, 180, 0.16));
+  border-radius: 0.4rem;
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - var(--_corner)),
+    calc(100% - var(--_corner)) 100%,
+    0 100%
+  );
   background-color: rgb(var(--carousel-item-empty-color-rgb));
   background-image: var(--_image-url);
   background-repeat: no-repeat;
   background-position: center;
   background-size: var(--_bg-size, cover);
-  transition: filter var(--carousel-transition-duration) var(--carousel-transition-ease);
+  transition: filter var(--carousel-transition-duration) var(--carousel-transition-ease),
+    border-color var(--carousel-transition-duration) var(--carousel-transition-ease);
   filter: grayscale(100%);
+}
+
+@supports (corner-shape: bevel) {
+  .face {
+    clip-path: none;
+    corner-shape: bevel;
+    border-bottom-right-radius: var(--_corner);
+  }
 }
 
 .item:hover .face,
 .item:focus-within .face {
   filter: grayscale(0%);
+  border-color: var(--corner-color, var(--lg-edge-bright, rgba(255, 220, 180, 0.28)));
+}
+
+/* Diagonal glass sheen, same top-left highlight language as the app's
+   Liquid Glass surfaces (--lg-sheen), so a bare icon plate reads as a card
+   facet catching light rather than a flat cutout. */
+.face::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 45%);
+  mix-blend-mode: overlay;
+  pointer-events: none;
 }
 
 .faIcon {
   position: absolute;
   inset: 0;
+  z-index: 1;
   margin: auto;
   width: 30%;
   height: 30%;
-  color: rgba(var(--carousel-control-color-rgb), 0.55);
+  color: var(--corner-color, rgba(var(--carousel-control-color-rgb), 0.55));
+  opacity: 0.7;
   pointer-events: none;
 }
 
 /* Accent-color corner triangle — same "view this project" affordance as the
-   Featured coverflow's cards. Lives on ::after (not ::before, which the
-   reflection below already owns on .item). */
+   Featured coverflow's cards. Lives on ::after (::before above owns the
+   sheen, and the reflection below owns ::before on the parent .item). */
 .face::after {
   content: "";
   position: absolute;
   z-index: 2;
   bottom: 0;
   right: 0;
-  width: calc(var(--_width) * 0.22);
+  width: var(--_corner);
   aspect-ratio: 1 / 1;
   background-image: linear-gradient(135deg, var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))) 51%, transparent 0);
   pointer-events: none;
 }
 
 .face:focus-visible {
-  outline: 2px solid rgb(var(--carousel-item-glow-color-rgb));
+  outline: 2px solid var(--corner-color, rgb(var(--carousel-item-glow-color-rgb)));
   outline-offset: 3px;
 }
 
 .caption {
   position: relative;
-  z-index: 1;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
   width: 100%;
   padding: 0.5rem 0.55rem calc(0.4rem + var(--_width) * 0.05);
-  background: linear-gradient(to top, rgba(var(--carousel-bg-color-rgb), 0.92) 15%, rgba(var(--carousel-bg-color-rgb), 0) 100%);
-  color: rgb(var(--carousel-control-color-rgb));
-  font-family: var(--font-display), inherit;
-  font-size: clamp(0.6rem, calc(var(--_width) * 0.088), 0.8rem);
-  font-weight: 700;
-  line-height: 1.25;
+  background-image:
+    linear-gradient(to top, rgba(var(--carousel-bg-color-rgb), 0.94) 25%, rgba(var(--carousel-bg-color-rgb), 0) 100%),
+    linear-gradient(to right, transparent, var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))) 50%, transparent);
+  background-repeat: no-repeat, no-repeat;
+  background-size: 100% 100%, 100% 1px;
+  background-position: 0 0, top;
   text-align: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
   opacity: 0;
   transform: translateY(4px);
   transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease),
     transform var(--carousel-transition-duration) var(--carousel-transition-ease);
   pointer-events: none;
+}
+
+.captionYear {
+  font-family: var(--font-display), inherit;
+  font-size: clamp(0.48rem, calc(var(--_width) * 0.058), 0.62rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--corner-color, rgb(var(--carousel-item-glow-color-rgb)));
+}
+
+.captionName {
+  color: rgb(var(--carousel-control-color-rgb));
+  font-family: var(--font-display), inherit;
+  font-size: clamp(0.6rem, calc(var(--_width) * 0.088), 0.8rem);
+  font-weight: 700;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .item:hover .caption,

--- a/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
@@ -1,0 +1,351 @@
+/* Ported from the codepenz "Spinning Photo Carousel": the ring, its rotation
+   keyframes, the direction-flip radios and the per-item hover/reflection
+   mechanics are unchanged. What's adapted for the app: .stage fills its
+   flex parent instead of a fixed demo-card height (matches ProjectCoverflow's
+   own .viewport sizing), the tuning variables are recolored to the Warm Noir
+   palette, `a` becomes a real `<button>` so a click can open the project
+   detail view, and each item gains a name caption + accent corner that
+   share the same hover/focus reveal as the photo's color/lift. */
+
+.stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  container-type: inline-size;
+
+  --carousel-transition-duration: 250ms;
+  --carousel-transition-ease: ease-out;
+  --carousel-bg-color-rgb: 13, 10, 9; /* --lg-tint-solid's base */
+  --carousel-shadow-color-rgb: 150, 120, 100;
+  --carousel-item-hover-effect: 1.075;
+  --carousel-item-reflection-blur: 0.25rem;
+  --carousel-item-empty-color-rgb: 13, 10, 9;
+  --carousel-item-glow-color-rgb: 212, 132, 90; /* --noir-accent */
+  --carousel-3d-perspective: 1000px;
+  --carousel-3d-perspective-origin: 50% 20%;
+  --carousel-control-button-width: 1.25rem;
+  --carousel-control-button-height: 4rem;
+  --carousel-control-color-rgb: 240, 236, 232; /* --noir-text */
+  --carousel-animation-duration: 32s;
+  --carousel-animation-play-state: running;
+  --carousel-direction-animation-play-state: paused;
+}
+
+.stage button {
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+
+/*
+carousel
+*/
+.carousel {
+  /* Scale sits on .carousel, not .stage: an element is never its own query
+     container, so a @container rule could not re-scale .stage from here. */
+  --_scale: 0.78;
+  --carousel-item-width: calc(11.5rem * var(--_scale));
+  --carousel-item-height: calc(17.5rem * var(--_scale));
+  --carousel-diameter: calc(50rem * var(--_scale));
+  --carousel-item-glow-size: calc(5rem * var(--_scale));
+
+  --_diameter: var(--carousel-diameter);
+  --_radius: calc(var(--_diameter) / 2);
+  --_item-width: var(--carousel-item-width);
+  --_item-height: var(--carousel-item-height);
+  perspective: var(--carousel-3d-perspective);
+  perspective-origin: var(--carousel-3d-perspective-origin);
+  width: var(--_diameter);
+  height: var(--_diameter);
+  position: relative;
+}
+
+@container (max-width: 42rem) {
+  .carousel {
+    --_scale: 0.42;
+  }
+}
+
+@container (max-width: 28rem) {
+  .carousel {
+    --_scale: 0.32;
+  }
+}
+
+.controlButton {
+  --_width: var(--carousel-control-button-width);
+  --_height: var(--carousel-control-button-height);
+  z-index: 1;
+  width: var(--_width);
+  height: var(--_height);
+  background-color: rgb(var(--carousel-control-color-rgb));
+  opacity: 0.2;
+  transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease);
+  position: absolute;
+}
+
+.controlButton:hover {
+  opacity: 0.4;
+}
+
+.controlButton:has(input:checked) {
+  opacity: 0.8;
+}
+
+.controlButton input {
+  appearance: none;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.controlButton input:focus-visible {
+  opacity: 1;
+  outline: 2px solid rgb(var(--carousel-control-color-rgb));
+  outline-offset: 2px;
+}
+
+.left {
+  clip-path: polygon(0% 50%, 100% 0%, 100% 100%);
+  top: calc(var(--_radius) - var(--_height) / 2);
+  left: 0;
+}
+
+.right {
+  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+  top: calc(var(--_radius) - var(--_height) / 2);
+  right: 0;
+}
+
+/* Selecting "left" starts a second, reversed rotation at half the duration;
+   the two compose into a net direction change without any script. */
+.carousel:has(.left input:checked) {
+  --carousel-direction-animation-play-state: running;
+}
+
+.carousel:has(.right input:checked) {
+  --carousel-direction-animation-play-state: paused;
+}
+
+.rotationDirection {
+  --_direction-animation-play-state: var(--carousel-direction-animation-play-state);
+  --_z: calc(var(--_radius) * -1);
+  transform: translateZ(var(--_z));
+  transform-style: preserve-3d;
+  animation: carousel-rotation-reverse calc(var(--carousel-animation-duration) / 2) reverse linear infinite
+    var(--_direction-animation-play-state);
+  transition: all var(--carousel-transition-duration) var(--carousel-transition-ease);
+}
+
+@keyframes carousel-rotation-reverse {
+  from {
+    transform: translateZ(var(--_z)) rotateY(0deg);
+  }
+  to {
+    transform: translateZ(var(--_z)) rotateY(360deg);
+  }
+}
+
+@keyframes carousel-rotation-normal {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+}
+
+.itemWrapper {
+  transform-style: inherit;
+  width: inherit;
+  height: inherit;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  animation: carousel-rotation-normal var(--carousel-animation-duration) normal linear infinite
+    var(--carousel-animation-play-state);
+  transition: all var(--carousel-transition-duration) var(--carousel-transition-ease);
+}
+
+.rotationDirection:has(.item:hover),
+.rotationDirection:has(.item:focus-within) {
+  --carousel-animation-play-state: paused;
+  --_direction-animation-play-state: paused;
+}
+
+.item {
+  --_width: var(--_item-width);
+  --_height: var(--_item-height);
+  --_rotation: calc(360 / var(--_num-elements) * var(--_index) * 1deg);
+  left: calc(var(--_radius) - var(--_item-width) / 2);
+  top: calc(var(--_radius) - var(--_item-height) / 2);
+  transform: rotateY(var(--_rotation)) translateZ(var(--_radius));
+  transform-style: inherit;
+  width: var(--_width);
+  height: var(--_height);
+  transition: all var(--carousel-transition-duration) var(--carousel-transition-ease);
+  box-shadow: 0 0 var(--carousel-item-glow-size) transparent;
+  position: absolute;
+}
+
+.item:hover,
+.item:focus-within {
+  box-shadow: 0 0 var(--carousel-item-glow-size) rgb(var(--carousel-item-glow-color-rgb));
+  transform: rotateY(var(--_rotation)) translateZ(calc(var(--_radius) * var(--carousel-item-hover-effect)));
+}
+
+.face {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  width: inherit;
+  height: inherit;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  background-color: rgb(var(--carousel-item-empty-color-rgb));
+  background-image: var(--_image-url);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: var(--_bg-size, cover);
+  transition: filter var(--carousel-transition-duration) var(--carousel-transition-ease);
+  filter: grayscale(100%);
+}
+
+.item:hover .face,
+.item:focus-within .face {
+  filter: grayscale(0%);
+}
+
+.faIcon {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 30%;
+  height: 30%;
+  color: rgba(var(--carousel-control-color-rgb), 0.55);
+  pointer-events: none;
+}
+
+/* Accent-color corner triangle — same "view this project" affordance as the
+   Featured coverflow's cards. Lives on ::after (not ::before, which the
+   reflection below already owns on .item). */
+.face::after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  bottom: 0;
+  right: 0;
+  width: calc(var(--_width) * 0.22);
+  aspect-ratio: 1 / 1;
+  background-image: linear-gradient(135deg, var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))) 51%, transparent 0);
+  pointer-events: none;
+}
+
+.face:focus-visible {
+  outline: 2px solid rgb(var(--carousel-item-glow-color-rgb));
+  outline-offset: 3px;
+}
+
+.caption {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding: 0.5rem 0.55rem calc(0.4rem + var(--_width) * 0.05);
+  background: linear-gradient(to top, rgba(var(--carousel-bg-color-rgb), 0.92) 15%, rgba(var(--carousel-bg-color-rgb), 0) 100%);
+  color: rgb(var(--carousel-control-color-rgb));
+  font-family: var(--font-display), inherit;
+  font-size: clamp(0.6rem, calc(var(--_width) * 0.088), 0.8rem);
+  font-weight: 700;
+  line-height: 1.25;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease),
+    transform var(--carousel-transition-duration) var(--carousel-transition-ease);
+  pointer-events: none;
+}
+
+.item:hover .caption,
+.item:focus-within .caption {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* The reflection: the same artwork flipped flat onto the ground plane. */
+.item::before {
+  content: "";
+  width: inherit;
+  height: inherit;
+  background-color: rgb(var(--carousel-item-empty-color-rgb));
+  background-image:
+    linear-gradient(to top, rgba(var(--carousel-bg-color-rgb), 0.25) 0%, rgba(var(--carousel-bg-color-rgb), 1) 75%),
+    var(--_image-url);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: var(--_bg-size, cover);
+  pointer-events: none;
+  filter: blur(var(--carousel-item-reflection-blur)) grayscale(100%);
+  transition: filter var(--carousel-transition-duration) var(--carousel-transition-ease);
+  transform-style: inherit;
+  transform-origin: center bottom;
+  transform: rotateX(90deg) rotateZ(180deg) rotateY(180deg);
+  position: absolute;
+}
+
+.item:hover::before,
+.item:focus-within::before {
+  filter: blur(var(--carousel-item-reflection-blur)) grayscale(0%);
+}
+
+.ground {
+  --_width: var(--_diameter);
+  --_height: var(--_diameter);
+  --_rotation: 90deg;
+  left: calc(var(--_radius) - var(--_width) / 2);
+  top: calc(var(--_radius) - var(--_height) / 2);
+  transform: rotateX(var(--_rotation)) translateZ(calc(var(--_item-height) / -2));
+  width: var(--_width);
+  height: var(--_height);
+  border-radius: 50%;
+  background: radial-gradient(
+    rgba(var(--carousel-shadow-color-rgb), 0.55) 15%,
+    rgba(var(--carousel-bg-color-rgb), 0) 60%
+  );
+  opacity: 0.5;
+  transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease);
+  position: absolute;
+}
+
+.itemWrapper:has(.item:hover) .ground,
+.itemWrapper:has(.item:focus-within) .ground {
+  opacity: 0.75;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stage {
+    --carousel-animation-play-state: paused;
+  }
+
+  .rotationDirection,
+  .itemWrapper {
+    animation: none;
+  }
+}

--- a/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.tsx
@@ -68,7 +68,12 @@ const ProjectSpinningCarousel: React.FC<ProjectSpinningCarouselProps> = ({ proje
                         aria-hidden="true"
                       />
                     )}
-                    <span className={styles.caption}>{project.name}</span>
+                    <span className={styles.caption}>
+                      {project.yearRange && (
+                        <span className={styles.captionYear}>{project.yearRange}</span>
+                      )}
+                      <span className={styles.captionName}>{project.name}</span>
+                    </span>
                   </button>
                 </li>
               );

--- a/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Project } from "@/lib/types";
+import { PROJECT_ICON_MAP, PROJECT_ICON_FALLBACK } from "@/lib/constants/projectIcons";
+import { resolveProjectMedia } from "../shared/resolveProjectMedia";
+import { cornerColorFor, DOC_CORNER_COLOR } from "../shared/cornerColor";
+import styles from "./ProjectSpinningCarousel.module.css";
+
+interface ProjectSpinningCarouselProps {
+  projects: Project[];
+  onOpen: (id: number) => void;
+}
+
+/**
+ * Adapted from the codepenz "Spinning Photo Carousel": the ring is still one
+ * keyframe rotating the whole set, with a reversed half-speed outer layer
+ * that the direction radios compose into a spin-direction flip — pure CSS,
+ * no script beyond the click handler that opens a project's detail view.
+ * Faces show each project's real artwork (screenshot/gif or icon-on-plate)
+ * in place of the source pen's photos, and gain a name caption + corner
+ * accent that reveal on the same hover/focus that lifts and colors the item.
+ */
+const ProjectSpinningCarousel: React.FC<ProjectSpinningCarouselProps> = ({ projects, onOpen }) => {
+  if (projects.length === 0) return null;
+
+  return (
+    <div className={styles.stage}>
+      <div className={styles.carousel}>
+        <div className={`${styles.controlButton} ${styles.left}`}>
+          <input type="radio" name="spinning-carousel-direction" aria-label="Spin counter-clockwise" />
+        </div>
+        <div className={`${styles.controlButton} ${styles.right}`}>
+          <input type="radio" name="spinning-carousel-direction" defaultChecked aria-label="Spin clockwise" />
+        </div>
+
+        <div className={styles.rotationDirection}>
+          <ul className={styles.itemWrapper} style={{ "--_num-elements": projects.length } as CSSProperties}>
+            {projects.map((project, i) => {
+              const { src, fit } = resolveProjectMedia(project);
+              const cornerColor =
+                project.type === "documentary" ? DOC_CORNER_COLOR : cornerColorFor(i, projects.length);
+
+              return (
+                <li
+                  key={project.id}
+                  className={styles.item}
+                  style={
+                    {
+                      "--_index": i + 1,
+                      "--_image-url": src ? `url('${src}')` : "none",
+                      "--_bg-size": fit,
+                      "--corner-color": cornerColor,
+                    } as CSSProperties
+                  }
+                >
+                  <button
+                    type="button"
+                    className={styles.face}
+                    onClick={() => onOpen(project.id)}
+                    aria-label={`${project.name}${project.yearRange ? `, ${project.yearRange}` : ""} — view project`}
+                  >
+                    {!src && (
+                      <FontAwesomeIcon
+                        icon={PROJECT_ICON_MAP[project.icon as string] || PROJECT_ICON_FALLBACK}
+                        className={styles.faIcon}
+                        aria-hidden="true"
+                      />
+                    )}
+                    <span className={styles.caption}>{project.name}</span>
+                  </button>
+                </li>
+              );
+            })}
+
+            <li className={styles.ground} aria-hidden="true" />
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectSpinningCarousel;

--- a/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
@@ -7,6 +7,7 @@ import { AppView } from "@/components/features/shell";
 import { FilterBar } from "@/components/ui";
 import { useProjects } from "@/hooks";
 import ProjectCoverflow from "./ProjectCoverflow";
+import ProjectSpinningCarousel from "./ProjectSpinningCarousel";
 import ProjectDetailModal from "../ProjectDetailModal/ProjectDetailModal";
 import ResumeHighlightsModal from "../ResumeHighlightsModal/ResumeHighlightsModal";
 import styles from "./ProjectsAppView.module.css";
@@ -77,12 +78,15 @@ const ProjectsAppView: React.FC<ProjectsAppViewProps> = ({
             aria-labelledby={`projects-panel-tab-${activeTab}`}
           >
             {visibleProjects.length > 0 ? (
-              <ProjectCoverflow
-                key={activeTab}
-                projects={visibleProjects}
-                onOpen={setSelectedProjectId}
-                initialProjectId={initialProjectId}
-              />
+              activeTab === "featured" ? (
+                <ProjectSpinningCarousel projects={visibleProjects} onOpen={setSelectedProjectId} />
+              ) : (
+                <ProjectCoverflow
+                  projects={visibleProjects}
+                  onOpen={setSelectedProjectId}
+                  initialProjectId={initialProjectId}
+                />
+              )
             ) : (
               <p className={styles.empty}>No projects match this filter.</p>
             )}

--- a/src/components/features/portfolio/shared/cornerColor.ts
+++ b/src/components/features/portfolio/shared/cornerColor.ts
@@ -1,0 +1,15 @@
+import * as d3 from "d3";
+
+// Documentary projects keep the fixed green corner used by the "Documentary"
+// tag elsewhere in the app; every other project gets its own color from a
+// hue rotation anchored at --noir-accent's hue — same pattern already used
+// for per-item coloring in SkillsetAppView/ToolbeltGraph.tsx.
+export const DOC_CORNER_COLOR = "#0f9d6b"; // --noir-doc
+const CORNER_HUE_START = 21; // --noir-accent's own hue (#d4845a)
+const CORNER_SATURATION = 0.48;
+const CORNER_LIGHTNESS = 0.6;
+
+export function cornerColorFor(index: number, count: number): string {
+  const hue = (CORNER_HUE_START + index * (360 / count)) % 360;
+  return d3.hsl(hue, CORNER_SATURATION, CORNER_LIGHTNESS).formatHex();
+}

--- a/src/components/features/portfolio/shared/resolveProjectMedia.ts
+++ b/src/components/features/portfolio/shared/resolveProjectMedia.ts
@@ -1,0 +1,27 @@
+import { Project } from "@/lib/types";
+import { isImageIcon } from "@/lib/constants/projectIcons";
+
+export interface ResolvedProjectMedia {
+  src: string | null;
+  fit: "cover" | "contain";
+}
+
+/**
+ * Mirrors ProjectMedia's own source-picking order (hero image string, then
+ * an image-path icon, then neither) so a CSS-background carousel can show
+ * the same artwork as the rest of the app without rendering a component.
+ * A hero image is a photo/gif meant to fill its frame (`cover`); an icon is
+ * a logo mark that needs breathing room around it (`contain`).
+ */
+export function resolveProjectMedia(project: Project): ResolvedProjectMedia {
+  const imageStr = typeof project.image === "string" ? project.image : undefined;
+  const iconIsImage = isImageIcon(project.icon);
+
+  if (iconIsImage && !imageStr) {
+    return { src: project.icon as string, fit: "contain" };
+  }
+  if (imageStr) {
+    return { src: imageStr, fit: "cover" };
+  }
+  return { src: null, fit: "contain" };
+}


### PR DESCRIPTION
## Summary
- Adapts the codepenz "Spinning Photo Carousel" scene for the Projects app's **Featured** tab: a pure-CSS 3D ring where the whole set rotates on one keyframe, with a reversed half-speed outer layer that the two direction radios compose into a spin-direction flip — no script beyond the click handler.
- Each item keeps the source pen's hover mechanics (pause the spin, lift toward the viewer, glow, grayscale → color) and floor reflection, but faces now show the project's real artwork (screenshot/gif, or icon-on-plate) via a new `resolveProjectMedia` helper, and reveal a name caption + the Featured coverflow's accent-corner triangle on that same hover/focus.
- Clicking a face opens that project's existing detail modal (`ProjectDetailModal`), same as the old coverflow.
- The **More** tab is untouched — it still renders the existing dock-style `ProjectCoverflow`.
- Extracted the per-project corner-color hue rotation (previously private to `ProjectCoverflow`) into `shared/cornerColor.ts` so both carousels use the same logic.

## New files
- `ProjectsAppView/ProjectSpinningCarousel.tsx` + `.module.css` — the adapted carousel.
- `shared/resolveProjectMedia.ts` — mirrors `ProjectMedia`'s own source-picking order (hero image → image-path icon → none) to pick the CSS background image and its fit (`cover` for photos/gifs, `contain` for logo icons).
- `shared/cornerColor.ts` — extracted from `ProjectCoverflow.tsx`.

## Test plan
- [x] `tsc --noEmit` and `next lint` both pass.
- [x] Verified in a running dev server (headless Chromium): Featured tab renders the 5 active projects as a spinning ring; hovering a face pauses the ring, lifts/glows/colorizes it, and reveals its name caption; clicking opens the correct project's detail modal.
- [x] Verified the direction-toggle arrows and the `prefers-reduced-motion` pause (ring holds still, matching the source pen's reduced-motion handling).
- [x] Verified the **More** tab still renders the original `ProjectCoverflow` unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKzggc4aCguQEsm8kUdc3A)_