### PR TITLE
Improve Featured carousel default look; double card size; add mobile list views

### DIFF
--- a/src/components/features/portfolio/ProjectsAppView/ProjectListView.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectListView.module.css
@@ -1,0 +1,148 @@
+/* Mobile-only list of project rows — the ≤480px stand-in for the two 3D
+   carousels (see ProjectsAppView.module.css's .desktopView/.mobileView
+   toggle). Row shell (divider list, full-width button, hover state) is
+   modeled on AboutAppView's .aboutIndexRow; the icon-plate + title/subtitle
+   arrangement is modeled on ToolbeltGraph's .toolCardHeader. */
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.row {
+  border-bottom: 1px solid var(--noir-border);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.rowButton {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.7rem 0.4rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 0.2s ease;
+}
+
+.rowButton:hover,
+.rowButton:active {
+  background-color: var(--noir-accent-soft);
+}
+
+.rowButton:focus-visible {
+  outline: 2px solid var(--noir-accent);
+  outline-offset: -2px;
+}
+
+.thumb {
+  position: relative;
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--lg-tint-strong);
+  border: 1px solid var(--lg-edge);
+}
+
+/* Small accent-corner echo of the carousels' own "view this project"
+   affordance, colored per-project via --corner-color (set inline). */
+.thumb::after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  bottom: 0;
+  right: 0;
+  width: 14px;
+  aspect-ratio: 1 / 1;
+  background-image: linear-gradient(135deg, var(--corner-color, var(--noir-accent)) 51%, transparent 0);
+  pointer-events: none;
+}
+
+.iconImg {
+  width: auto;
+  height: auto;
+  max-width: 70%;
+  max-height: 70%;
+  object-fit: contain;
+}
+
+.heroImg {
+  object-fit: cover;
+}
+
+.faIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 1.1rem;
+  color: rgba(212, 132, 90, 0.5);
+}
+
+.meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.nameRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.name {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-display), inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--noir-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.year {
+  flex-shrink: 0;
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--noir-faint);
+}
+
+.description {
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.35;
+  color: var(--noir-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rowButton {
+    transition: none;
+  }
+}

--- a/src/components/features/portfolio/ProjectsAppView/ProjectListView.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectListView.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { Project } from "@/lib/types";
+import ProjectMedia from "../shared/ProjectMedia";
+import { cornerColorFor, DOC_CORNER_COLOR } from "../shared/cornerColor";
+import styles from "./ProjectListView.module.css";
+
+interface ProjectListViewProps {
+  projects: Project[];
+  onOpen: (id: number) => void;
+}
+
+/**
+ * Mobile (≤480px) stand-in for the two 3D carousels: a plain scrollable
+ * list of rows, since a drag/hover-oriented carousel doesn't translate well
+ * to a small touchscreen. Shares the same projects/onOpen contract as
+ * ProjectSpinningCarousel and ProjectCoverflow, so it opens the same
+ * ProjectDetailModal via the same id-based callback.
+ */
+const ProjectListView: React.FC<ProjectListViewProps> = ({ projects, onOpen }) => {
+  if (projects.length === 0) return null;
+
+  return (
+    <ul className={styles.list}>
+      {projects.map((project, i) => {
+        const cornerColor =
+          project.type === "documentary" ? DOC_CORNER_COLOR : cornerColorFor(i, projects.length);
+
+        return (
+          <li key={project.id} className={styles.row}>
+            <button
+              type="button"
+              className={styles.rowButton}
+              onClick={() => onOpen(project.id)}
+              style={{ "--corner-color": cornerColor } as CSSProperties}
+            >
+              <span className={styles.thumb}>
+                <ProjectMedia
+                  project={project}
+                  iconImageClassName={styles.iconImg}
+                  heroImageClassName={styles.heroImg}
+                  faIconClassName={styles.faIcon}
+                  sizes="56px"
+                />
+              </span>
+              <span className={styles.meta}>
+                <span className={styles.nameRow}>
+                  <span className={styles.name}>{project.name}</span>
+                  {project.yearRange && <span className={styles.year}>{project.yearRange}</span>}
+                </span>
+                <span className={styles.description}>{project.description}</span>
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default ProjectListView;

--- a/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
@@ -53,6 +53,10 @@ carousel
   --carousel-item-height: calc(17.5rem * var(--_scale));
   --carousel-diameter: calc(50rem * var(--_scale));
   --carousel-item-glow-size: calc(5rem * var(--_scale));
+  --carousel-item-glow-size-rest: calc(var(--carousel-item-glow-size) * 0.3);
+  --carousel-item-glow-spread-rest: calc(var(--carousel-item-glow-size) * -0.14);
+  --carousel-item-glow-size-hover: calc(var(--carousel-item-glow-size) * 1.15);
+  --carousel-item-glow-spread-hover: calc(var(--carousel-item-glow-size) * 0.05);
 
   --_diameter: var(--carousel-diameter);
   --_radius: calc(var(--_diameter) / 2);
@@ -192,13 +196,16 @@ carousel
   width: var(--_width);
   height: var(--_height);
   transition: all var(--carousel-transition-duration) var(--carousel-transition-ease);
-  box-shadow: 0 0 var(--carousel-item-glow-size) transparent, 0 0.7rem 1.6rem rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 var(--carousel-item-glow-size-rest) var(--carousel-item-glow-spread-rest)
+      var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))),
+    0 0.7rem 1.6rem rgba(0, 0, 0, 0.4);
   position: absolute;
 }
 
 .item:hover,
 .item:focus-within {
-  box-shadow: 0 0 var(--carousel-item-glow-size) var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))),
+  box-shadow: 0 0 var(--carousel-item-glow-size-hover) var(--carousel-item-glow-spread-hover)
+      var(--corner-color, rgb(var(--carousel-item-glow-color-rgb))),
     0 1.4rem 3.2rem rgba(0, 0, 0, 0.55);
   transform: rotateY(var(--_rotation)) translateZ(calc(var(--_radius) * var(--carousel-item-hover-effect)));
 }
@@ -232,7 +239,7 @@ carousel
   background-size: var(--_bg-size, cover);
   transition: filter var(--carousel-transition-duration) var(--carousel-transition-ease),
     border-color var(--carousel-transition-duration) var(--carousel-transition-ease);
-  filter: grayscale(100%);
+  filter: saturate(1) brightness(1);
 }
 
 @supports (corner-shape: bevel) {
@@ -245,7 +252,7 @@ carousel
 
 .item:hover .face,
 .item:focus-within .face {
-  filter: grayscale(0%);
+  filter: saturate(1.18) brightness(1.06);
   border-color: var(--corner-color, var(--lg-edge-bright, rgba(255, 220, 180, 0.28)));
 }
 
@@ -309,10 +316,8 @@ carousel
   background-size: 100% 100%, 100% 1px;
   background-position: 0 0, top;
   text-align: center;
-  opacity: 0;
   transform: translateY(4px);
-  transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease),
-    transform var(--carousel-transition-duration) var(--carousel-transition-ease);
+  transition: transform var(--carousel-transition-duration) var(--carousel-transition-ease);
   pointer-events: none;
 }
 
@@ -323,6 +328,8 @@ carousel
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--corner-color, rgb(var(--carousel-item-glow-color-rgb)));
+  opacity: 0.65;
+  transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease);
 }
 
 .captionName {
@@ -336,12 +343,20 @@ carousel
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  opacity: 0.82;
+  transition: opacity var(--carousel-transition-duration) var(--carousel-transition-ease);
 }
 
 .item:hover .caption,
 .item:focus-within .caption {
-  opacity: 1;
   transform: translateY(0);
+}
+
+.item:hover .captionYear,
+.item:focus-within .captionYear,
+.item:hover .captionName,
+.item:focus-within .captionName {
+  opacity: 1;
 }
 
 /* The reflection: the same artwork flipped flat onto the ground plane. */
@@ -357,17 +372,11 @@ carousel
   background-position: center;
   background-size: var(--_bg-size, cover);
   pointer-events: none;
-  filter: blur(var(--carousel-item-reflection-blur)) grayscale(100%);
-  transition: filter var(--carousel-transition-duration) var(--carousel-transition-ease);
+  filter: blur(var(--carousel-item-reflection-blur));
   transform-style: inherit;
   transform-origin: center bottom;
   transform: rotateX(90deg) rotateZ(180deg) rotateY(180deg);
   position: absolute;
-}
-
-.item:hover::before,
-.item:focus-within::before {
-  filter: blur(var(--carousel-item-reflection-blur)) grayscale(0%);
 }
 
 .ground {

--- a/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectSpinningCarousel.module.css
@@ -48,11 +48,16 @@ carousel
 .carousel {
   /* Scale sits on .carousel, not .stage: an element is never its own query
      container, so a @container rule could not re-scale .stage from here. */
-  --_scale: 0.78;
-  --carousel-item-width: calc(11.5rem * var(--_scale));
-  --carousel-item-height: calc(17.5rem * var(--_scale));
-  --carousel-diameter: calc(50rem * var(--_scale));
-  --carousel-item-glow-size: calc(5rem * var(--_scale));
+  /* Ring footprint and card footprint are decoupled: --_ring-scale keeps
+     the ring's diameter identical at every tier (no new container-overflow
+     risk), while --_item-scale is pinned at 2x --_ring-scale so cards
+     double in both dimensions at every tier without the ring growing. */
+  --_ring-scale: 0.78;
+  --_item-scale: calc(var(--_ring-scale) * 2);
+  --carousel-item-width: calc(11.5rem * var(--_item-scale));
+  --carousel-item-height: calc(17.5rem * var(--_item-scale));
+  --carousel-diameter: calc(50rem * var(--_ring-scale));
+  --carousel-item-glow-size: calc(5rem * var(--_item-scale));
   --carousel-item-glow-size-rest: calc(var(--carousel-item-glow-size) * 0.3);
   --carousel-item-glow-spread-rest: calc(var(--carousel-item-glow-size) * -0.14);
   --carousel-item-glow-size-hover: calc(var(--carousel-item-glow-size) * 1.15);
@@ -71,13 +76,13 @@ carousel
 
 @container (max-width: 42rem) {
   .carousel {
-    --_scale: 0.42;
+    --_ring-scale: 0.42;
   }
 }
 
 @container (max-width: 28rem) {
   .carousel {
-    --_scale: 0.32;
+    --_ring-scale: 0.32;
   }
 }
 
@@ -323,7 +328,7 @@ carousel
 
 .captionYear {
   font-family: var(--font-display), inherit;
-  font-size: clamp(0.48rem, calc(var(--_width) * 0.058), 0.62rem);
+  font-size: clamp(0.48rem, calc(var(--_width) * 0.058), 1.15rem);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -335,7 +340,7 @@ carousel
 .captionName {
   color: rgb(var(--carousel-control-color-rgb));
   font-family: var(--font-display), inherit;
-  font-size: clamp(0.6rem, calc(var(--_width) * 0.088), 0.8rem);
+  font-size: clamp(0.6rem, calc(var(--_width) * 0.088), 1.65rem);
   font-weight: 700;
   line-height: 1.25;
   overflow: hidden;

--- a/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.module.css
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.module.css
@@ -20,8 +20,10 @@
   background: var(--noir-panel);
 }
 
-/* The coverflow carousel is a fixed 3D viewport, not a scrolling document —
-   it clips its own strip internally, so .stage no longer scrolls. */
+/* Desktop/tablet: the 3D carousel/coverflow clips its own strip internally,
+   so .stage stays non-scrolling here. Mobile (≤480px) swaps to a plain
+   scrolling list — see the media query below, which flips both which
+   child is visible and .stage's own overflow behavior. */
 .stage {
   flex: 1;
   min-height: 0;
@@ -29,6 +31,19 @@
   display: flex;
   flex-direction: column;
   padding: 1rem;
+}
+
+.desktopView {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.mobileView {
+  display: none;
 }
 
 .empty {
@@ -45,5 +60,20 @@
 
   .stage {
     padding: 0.75rem;
+    /* The list (unlike the carousel/coverflow) is a real scrolling
+       document, not a self-clipping 3D viewport. */
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .desktopView {
+    display: none;
+  }
+
+  .mobileView {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
   }
 }

--- a/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
+++ b/src/components/features/portfolio/ProjectsAppView/ProjectsAppView.tsx
@@ -8,6 +8,7 @@ import { FilterBar } from "@/components/ui";
 import { useProjects } from "@/hooks";
 import ProjectCoverflow from "./ProjectCoverflow";
 import ProjectSpinningCarousel from "./ProjectSpinningCarousel";
+import ProjectListView from "./ProjectListView";
 import ProjectDetailModal from "../ProjectDetailModal/ProjectDetailModal";
 import ResumeHighlightsModal from "../ResumeHighlightsModal/ResumeHighlightsModal";
 import styles from "./ProjectsAppView.module.css";
@@ -78,15 +79,22 @@ const ProjectsAppView: React.FC<ProjectsAppViewProps> = ({
             aria-labelledby={`projects-panel-tab-${activeTab}`}
           >
             {visibleProjects.length > 0 ? (
-              activeTab === "featured" ? (
-                <ProjectSpinningCarousel projects={visibleProjects} onOpen={setSelectedProjectId} />
-              ) : (
-                <ProjectCoverflow
-                  projects={visibleProjects}
-                  onOpen={setSelectedProjectId}
-                  initialProjectId={initialProjectId}
-                />
-              )
+              <>
+                <div className={styles.desktopView}>
+                  {activeTab === "featured" ? (
+                    <ProjectSpinningCarousel projects={visibleProjects} onOpen={setSelectedProjectId} />
+                  ) : (
+                    <ProjectCoverflow
+                      projects={visibleProjects}
+                      onOpen={setSelectedProjectId}
+                      initialProjectId={initialProjectId}
+                    />
+                  )}
+                </div>
+                <div className={styles.mobileView}>
+                  <ProjectListView projects={visibleProjects} onOpen={setSelectedProjectId} />
+                </div>
+              </>
             ) : (
               <p className={styles.empty}>No projects match this filter.</p>
             )}


### PR DESCRIPTION
## Summary

### Make Featured carousel cards colorful and legible by default
The Featured tab's spinning carousel looked less polished than the More tab's coverflow on first glance, because every card defaulted to grayscale, a `transparent` (invisible) accent glow, and a hidden caption — all revealed only on hover — while More's cards are always full color with visible text and real elevation.

- **Removes the grayscale-at-rest filter** on `.face` (`ProjectSpinningCarousel.module.css`). Cards now render in full color immediately; hover instead adds a modest `saturate()`/`brightness()` lift so hover still has a distinct payoff. Applied the same fix to the floor-reflection pseudo-element, which mirrored the same grayscale toggle.
- **Fixes the resting glow**, which was previously `box-shadow: 0 0 var(--carousel-item-glow-size) transparent` — i.e. zero visible glow until hover. Since `--corner-color` is a hex string (not an rgb-triplet), alpha-based dimming isn't available on it directly, so the "faint at rest → bold on hover" effect is achieved via blur radius/spread instead, staying fully opaque.
- **Shows the name + year caption by default**, at reduced opacity, brightening to full strength on hover/focus — mirroring the More tab's always-visible project name/description text.

### Double the Featured cards' size
Card size and the ring's diameter previously shared one `--_scale` variable, so doubling it would have doubled the ring's overall footprint too — overflowing the panel at common desktop widths well before the existing shrink tiers had reason to engage. Splits it into `--_ring-scale` (unchanged, so the ring's footprint doesn't grow) and `--_item-scale` (pinned at `2 × --_ring-scale`), so cards double at every breakpoint tier with no new overlap or clipping risk. Caption `clamp()` max bounds are raised so the bigger text isn't re-capped at the old ceiling.

### Add a mobile list view for both tabs
Neither 3D carousel is a good fit for a phone-sized touchscreen. Both "Featured" and "More" now render as a plain scrollable list of rows (thumbnail + name + year + description) at ≤480px — this app's own established mobile breakpoint, already used twice in this feature. New `ProjectListView` component, following the codebase's existing convention for this kind of swap (`DesktopIcons` vs `AppSwitcher`): both the list and the carousel/coverflow always mount, and a media query toggles which is visible, rather than a new JS mobile-detection branch. Tapping a row opens the same project detail modal via the same `onOpen(id)` contract both carousels already use.

## New files
- `ProjectsAppView/ProjectListView.tsx` + `.module.css` — the mobile list view, shared by both tabs.

## Test plan
- [x] `tsc --noEmit` and `next lint` both pass.
- [x] Verified in a running dev server (headless Chromium): Featured cards render in full color at rest with visible glow/captions; cards read as clearly ~2x larger at desktop widths without the ring overflowing its panel; hover still gives a distinct payoff (bigger glow, saturation/brightness pop, caption brightens).
- [x] Verified at ≤480px: both tabs show a scrollable list instead of their carousel; tapping a row opens the correct project's detail modal; live-resizing between desktop and mobile widths toggles cleanly with no residue.
- [x] Verified click-to-open, swipe next/prev in the detail modal, and the More tab's coverflow are all unaffected.