### PR TITLE
Add Tiny Planet at /tiny-planet

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@react-three/drei": "^10.7.8",
+    "@react-three/fiber": "^9.7.0",
     "@use-gesture/react": "^10.3.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
@@ -24,7 +26,8 @@
     "next": "15.4.10",
     "ogl": "^1.0.11",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "three": "^0.169.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -33,6 +36,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.169.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.2",
     "tailwindcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@fortawesome/react-fontawesome':
         specifier: ^0.2.2
         version: 0.2.6(@fortawesome/fontawesome-svg-core@7.2.0)(react@19.1.0)
+      '@react-three/drei':
+        specifier: ^10.7.8
+        version: 10.7.8(@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0))(@types/react@19.2.14)(@types/three@0.169.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0)
+      '@react-three/fiber':
+        specifier: ^9.7.0
+        version: 9.7.0(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0)
       '@use-gesture/react':
         specifier: ^10.3.1
         version: 10.3.1(react@19.1.0)
@@ -56,6 +62,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      three:
+        specifier: ^0.169.0
+        version: 0.169.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -75,6 +84,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.169.0
+        version: 0.169.0
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -361,6 +373,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -437,6 +457,42 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@react-three/drei@10.7.8':
+    resolution: {integrity: sha512-rJXyuzLm2Xq0kafHuR47ajDGbOe/pEhzIr4m8E8zwzQs0iNjloFDqBwRhrXmP/w+onLeYyN3EYPFW/cwWK/4yA==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  '@react-three/fiber@9.7.0':
+    resolution: {integrity: sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -539,6 +595,9 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -635,6 +694,9 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -650,6 +712,9 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
   '@types/pako@2.0.4':
     resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
 
@@ -661,11 +726,25 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.169.0':
+    resolution: {integrity: sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -886,6 +965,9 @@ packages:
       vue-router:
         optional: true
 
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -972,6 +1054,12 @@ packages:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -982,6 +1070,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -998,6 +1089,12 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
+    peerDependencies:
+      three: '>=0.126.1'
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
@@ -1029,6 +1126,11 @@ packages:
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1213,6 +1315,9 @@ packages:
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1223,6 +1328,9 @@ packages:
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1419,6 +1527,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.6.11:
+    resolution: {integrity: sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -1504,6 +1615,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1541,6 +1655,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hls.js@1.7.0:
+    resolution: {integrity: sha512-NnQpT6Z//+2IB2qovSUbKbrlXY1MOpi0JynZ9L2NNOuTJiNCyMSQj9k2laEj1v7CxU/Hb8oTWR98eT3mVpPQVQ==}
+
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
     engines: {node: '>=8.0.0'}
@@ -1549,6 +1666,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1556,6 +1676,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -1643,6 +1766,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1689,6 +1815,11 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -1733,6 +1864,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1819,6 +1953,12 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1829,6 +1969,14 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1986,9 +2134,15 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -2011,6 +2165,15 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -2025,6 +2188,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2077,6 +2244,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2138,6 +2308,15 @@ packages:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
     engines: {node: '>=0.1.14'}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -2194,6 +2373,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   svg-pathdata@6.0.3:
     resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
     engines: {node: '>=12.0.0'}
@@ -2208,6 +2392,19 @@ packages:
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
+
+  three@0.169.0:
+    resolution: {integrity: sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2215,6 +2412,19 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  troika-three-text@0.52.5:
+    resolution: {integrity: sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.5:
+    resolution: {integrity: sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2227,6 +2437,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2266,8 +2479,23 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
+
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2297,6 +2525,39 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+  zustand@5.0.15:
+    resolution: {integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2517,6 +2778,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@monogrid/gainmap-js@3.4.0(three@0.169.0)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.169.0
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.1
@@ -2567,6 +2835,59 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@react-three/drei@10.7.8(@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0))(@types/react@19.2.14)(@types/three@0.169.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.169.0)
+      '@react-three/fiber': 9.7.0(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0)
+      '@use-gesture/react': 10.3.1(react@19.1.0)
+      camera-controls: 3.1.2(three@0.169.0)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.7.0
+      maath: 0.10.8(@types/three@0.169.0)(three@0.169.0)
+      meshline: 3.3.1(three@0.169.0)
+      react: 19.1.0
+      stats-gl: 2.4.2(@types/three@0.169.0)(three@0.169.0)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.1.0)
+      three: 0.169.0
+      three-mesh-bvh: 0.8.3(three@0.169.0)
+      three-stdlib: 2.36.1(three@0.169.0)
+      troika-three-text: 0.52.5(three@0.169.0)
+      tunnel-rat: 0.1.2(@types/react@19.2.14)(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
+      utility-types: 3.11.0
+      zustand: 5.0.15(@types/react@19.2.14)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+
+  '@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(three@0.169.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.14)(react@19.1.0)
+      react: 19.1.0
+      react-use-measure: 2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.1.0)
+      three: 0.169.0
+      use-sync-external-store: 1.6.0(react@19.1.0)
+      zustand: 5.0.15(@types/react@19.2.14)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
 
   '@rtsao/scc@1.1.0': {}
 
@@ -2644,6 +2965,8 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.8
       tailwindcss: 4.2.2
+
+  '@tweenjs/tween.js@23.1.3': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -2767,6 +3090,8 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
@@ -2779,6 +3104,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/pako@2.0.4': {}
 
   '@types/raf@3.4.3':
@@ -2788,12 +3115,29 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
+  '@types/react-reconciler@0.28.9(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.169.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.71
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
+
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2962,6 +3306,8 @@ snapshots:
       next: 15.4.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
+  '@webgpu/types@0.1.71': {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3068,6 +3414,12 @@ snapshots:
 
   base64-arraybuffer@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3080,6 +3432,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3099,6 +3456,10 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  camera-controls@3.1.2(three@0.169.0):
+    dependencies:
+      three: 0.169.0
 
   caniuse-lite@1.0.30001780: {}
 
@@ -3133,6 +3494,10 @@ snapshots:
 
   core-js@3.49.0:
     optional: true
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3344,6 +3709,10 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
@@ -3354,6 +3723,8 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
     optional: true
+
+  draco3d@1.5.7: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3698,6 +4069,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.6.11: {}
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -3791,6 +4164,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  glsl-noise@0.0.0: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3819,6 +4194,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hls.js@1.7.0: {}
+
   html2canvas@1.4.1:
     dependencies:
       css-line-break: 2.1.0
@@ -3828,9 +4205,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immediate@3.0.6: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -3922,6 +4303,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-promise@2.2.2: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3974,6 +4357,13 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  its-fine@2.0.0(@types/react@19.2.14)(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
@@ -4024,6 +4414,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4084,6 +4478,11 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  maath@0.10.8(@types/three@0.169.0)(three@0.169.0):
+    dependencies:
+      '@types/three': 0.169.0
+      three: 0.169.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4091,6 +4490,12 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
+
+  meshline@3.3.1(three@0.169.0):
+    dependencies:
+      three: 0.169.0
+
+  meshoptimizer@0.18.1: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -4253,7 +4658,14 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@1.0.2: {}
+
   prelude-ls@1.2.1: {}
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   prop-types@15.8.1:
     dependencies:
@@ -4276,6 +4688,12 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
+
+  react-use-measure@2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 
@@ -4301,6 +4719,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -4356,6 +4776,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.26.0: {}
+
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
@@ -4456,6 +4878,13 @@ snapshots:
   stackblur-canvas@2.7.0:
     optional: true
 
+  stats-gl@2.4.2(@types/three@0.169.0)(three@0.169.0):
+    dependencies:
+      '@types/three': 0.169.0
+      three: 0.169.0
+
+  stats.js@0.17.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -4526,6 +4955,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  suspend-react@0.1.3(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   svg-pathdata@6.0.3:
     optional: true
 
@@ -4537,6 +4970,22 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
+  three-mesh-bvh@0.8.3(three@0.169.0):
+    dependencies:
+      three: 0.169.0
+
+  three-stdlib@2.36.1(three@0.169.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.24
+      draco3d: 1.5.7
+      fflate: 0.6.11
+      potpack: 1.0.2
+      three: 0.169.0
+
+  three@0.169.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4545,6 +4994,20 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  troika-three-text@0.52.5(three@0.169.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.169.0
+      troika-three-utils: 0.52.5(three@0.169.0)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.5(three@0.169.0):
+    dependencies:
+      three: 0.169.0
+
+  troika-worker-utils@0.52.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4558,6 +5021,14 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.1.0):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   type-check@0.4.0:
     dependencies:
@@ -4635,9 +5106,19 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  utility-types@3.11.0: {}
+
   utrie@1.0.2:
     dependencies:
       base64-arraybuffer: 1.0.2
+
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4687,3 +5168,16 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.1.0):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.1.0
+
+  zustand@5.0.15(@types/react@19.2.14)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.1.0
+      use-sync-external-store: 1.6.0(react@19.1.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 allowBuilds:
-  core-js: set this to true or false
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false
+  # Postinstall is only a funding message wrapped in try/catch — nothing to run.
+  core-js: false
+  # Both ship prebuilt binaries, so their install scripts normally just verify and exit.
+  # Allowed so the source-build fallback stays available on a platform that has no
+  # prebuilt match (musl, arm, a future Node ABI).
+  sharp: true
+  unrs-resolver: true

--- a/src/app/tiny-planet/layout.tsx
+++ b/src/app/tiny-planet/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+// The page itself is a Client Component (it mounts WebGL), and a client module
+// cannot export metadata — so the route's metadata lives here instead.
+export const metadata: Metadata = {
+  title: "Tiny Planet · Demaceo Vincent",
+  description:
+    "A tiny hand-built world that curls away at the horizon. Walk around, bend the planet, and run the sun from dawn to midnight.",
+  openGraph: {
+    title: "Tiny Planet · Demaceo Vincent",
+    description:
+      "A tiny hand-built world that curls away at the horizon. Walk around, bend the planet, and run the sun from dawn to midnight.",
+  },
+};
+
+export default function TinyPlanetLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/tiny-planet/page.tsx
+++ b/src/app/tiny-planet/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import styles from "./tiny-planet.module.css";
+
+// The world is generated procedurally, so without a seed every visitor would
+// land in a different village. Pinning one means the layout you see is the
+// layout everyone sees.
+const WORLD_SEED = 20260814;
+
+// WebGL only ever runs in the browser, so the whole experience is loaded
+// client-side. That keeps three.js out of every other route's bundle and means
+// there is no server render to mismatch against on hydration.
+const TinyPlanetShowcase = dynamic(
+  () => import("@/components/features/tinyPlanet").then((m) => m.TinyPlanetShowcase),
+  {
+    ssr: false,
+    loading: () => <div className={styles.placeholder} aria-hidden="true" />,
+  }
+);
+
+export default function TinyPlanetPage() {
+  return (
+    <main className={styles.container}>
+      <TinyPlanetShowcase
+        className={styles.themed}
+        seed={WORLD_SEED}
+        title="Tiny Planet"
+        subtitle="Drag to spin a tiny hand-built world."
+      />
+    </main>
+  );
+}

--- a/src/app/tiny-planet/tiny-planet.module.css
+++ b/src/app/tiny-planet/tiny-planet.module.css
@@ -1,0 +1,44 @@
+/*
+ * Full-bleed shell for the Tiny Planet route.
+ *
+ * globals.css paints a wallpaper on html/body with min-height: 100dvh and no
+ * overflow rule, so this container has to cover that background and stop the
+ * page scrolling behind the canvas.
+ */
+
+.container {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+  /* Matches the world's daytime horizon, so the first paint and the loading
+     state read as sky rather than as the site wallpaper flashing through. */
+  background-color: #cfe7e6;
+}
+
+/* Shown while the WebGL chunk loads. Deliberately plain — the sunrise
+   animation starts as soon as the real thing mounts. */
+.placeholder {
+  position: absolute;
+  inset: 0;
+  background-color: #cfe7e6;
+}
+
+/*
+ * Chrome theming.
+ *
+ * TinyPlanet.module.css exposes every colour and font as a custom property, so
+ * a host restyles by overriding variables instead of forking the stylesheet.
+ * Here that is fonts only: the cream glass was tuned against this pastel world
+ * and reads as part of the artwork, but the type should be the site's.
+ *
+ * The doubled class is deliberate. TinyPlanetShowcase renders
+ * `${styles.root} ${className}`, and .root declares these same variables — at
+ * equal specificity the winner would come down to CSS source order in the
+ * bundle, which is not something to leave to chance. 0,2,0 beats 0,1,0.
+ */
+.themed.themed {
+  --tp-font-ui: var(--font-primary);
+  --tp-font-display: var(--font-display);
+}

--- a/src/components/features/tinyPlanet/README.md
+++ b/src/components/features/tinyPlanet/README.md
@@ -1,0 +1,48 @@
+# Tiny Planet (vendored)
+
+The 3D experience mounted at `/tiny-planet`. Copied verbatim from
+[demaceo/tiny-planet](https://github.com/demaceo/tiny-planet) at commit `517686f`.
+
+**Edit upstream, not here.** Changes belong in `tiny-planet/src/`, then get re-copied over this
+folder so the two stay diffable. The upstream repo is where the experience can be run standalone
+and where the shader-parity check lives.
+
+## Layout
+
+Subfolder depth mirrors upstream exactly, which is what lets every relative import (`../world/palette`,
+`../r3f/TinyPlanet`) stay unedited:
+
+| Path | Upstream origin |
+|---|---|
+| `world/` | `src/world/` — shaders, palette, RNG, materials, geometry cache, generator |
+| `r3f/` | `src/r3f/` — the scene graph, the single `useFrame`, input hooks |
+| `components/` | `src/components/` — control panel, d-pad, overlay, showcase wrapper, CSS Module |
+
+## Deliberate divergences from upstream
+
+Only two, both additive:
+
+1. **`"use client"`** is prepended to `TinyPlanetShowcase.tsx` and `r3f/TinyPlanet.tsx`. Not
+   strictly required — the route that imports them is already a Client Component, so the boundary
+   is inherited — but it makes the boundary explicit and stops a future Server Component import
+   from failing confusingly.
+2. **`index.ts`** (this folder's barrel) and this README are additions; upstream has neither.
+
+Everything else is byte-identical, so `diff -r` against the upstream `src/` is meaningful.
+
+## Notes
+
+- `world/engine.js` is **not** vendored. It is the original imperative Three.js implementation,
+  kept upstream as a reference; nothing here depends on it.
+- Comments in `world/shaders.ts` refer to `scripts/verify-shaders.mjs`, which lives upstream. That
+  script asserts the GLSL still matches `engine.js` byte-for-byte as part of the upstream build.
+- The GLSL is the effect and must not be edited: the world is a flat plane, and the "planet" is
+  entirely a vertex-shader displacement (`wp.y -= d * d * uCurvature`) applied by every world
+  material.
+
+## Theming
+
+`TinyPlanet.module.css` declares all of its colours and fonts as custom properties on `.root`. A
+host restyles by overriding those variables rather than forking the stylesheet — see
+`src/app/tiny-planet/tiny-planet.module.css`, which overrides only the two font variables so the
+chrome uses the site's typography while keeping the cream glass the world was tuned for.

--- a/src/components/features/tinyPlanet/README.md
+++ b/src/components/features/tinyPlanet/README.md
@@ -1,7 +1,7 @@
 # Tiny Planet (vendored)
 
 The 3D experience mounted at `/tiny-planet`. Copied verbatim from
-[demaceo/tiny-planet](https://github.com/demaceo/tiny-planet) at commit `517686f`.
+[demaceo/tiny-planet](https://github.com/demaceo/tiny-planet) at commit `a7d2ce2`.
 
 **Edit upstream, not here.** Changes belong in `tiny-planet/src/`, then get re-copied over this
 folder so the two stay diffable. The upstream repo is where the experience can be run standalone

--- a/src/components/features/tinyPlanet/components/ControlPanel.tsx
+++ b/src/components/features/tinyPlanet/components/ControlPanel.tsx
@@ -28,7 +28,7 @@ export function ControlPanel({
 }: Props) {
   return (
     <>
-      <button className={styles.toggle} onClick={onToggle} aria-expanded={open}>
+      <button type="button" className={styles.toggle} onClick={onToggle} aria-expanded={open}>
         {open ? 'Hide controls' : 'Controls'}
       </button>
 

--- a/src/components/features/tinyPlanet/components/ControlPanel.tsx
+++ b/src/components/features/tinyPlanet/components/ControlPanel.tsx
@@ -1,0 +1,96 @@
+import { phaseLabel } from '../world/palette';
+import styles from './TinyPlanet.module.css';
+
+type Props = {
+  open: boolean;
+  onToggle: () => void;
+  curvature: number;
+  onCurvature: (value: number) => void;
+  timeOfDay: number;
+  onTime: (value: number) => void;
+  cameraDistance: number;
+  onDistance: (value: number) => void;
+  autoWander: boolean;
+  onWander: (value: boolean) => void;
+};
+
+export function ControlPanel({
+  open,
+  onToggle,
+  curvature,
+  onCurvature,
+  timeOfDay,
+  onTime,
+  cameraDistance,
+  onDistance,
+  autoWander,
+  onWander,
+}: Props) {
+  return (
+    <>
+      <button className={styles.toggle} onClick={onToggle} aria-expanded={open}>
+        {open ? 'Hide controls' : 'Controls'}
+      </button>
+
+      {open && (
+        <div className={styles.panel}>
+          <div className={styles.panelHeading}>Controls</div>
+
+          <div className={styles.row}>
+            <div className={styles.label}>
+              <label htmlFor="tp-cur">Curvature</label>
+              <span className={styles.value}>{curvature.toFixed(4)}</span>
+            </div>
+            <input
+              id="tp-cur"
+              type="range"
+              min={0}
+              max={0.005}
+              step={0.0001}
+              value={curvature}
+              onChange={(e) => onCurvature(parseFloat(e.target.value))}
+            />
+            <div className={styles.subHint}>0 = flat world · higher = smaller planet</div>
+          </div>
+
+          <div className={styles.row}>
+            <div className={styles.label}>
+              <label htmlFor="tp-time">Time of day</label>
+              <span className={styles.value}>{phaseLabel(timeOfDay)}</span>
+            </div>
+            <input
+              id="tp-time"
+              type="range"
+              min={0}
+              max={1}
+              step={0.005}
+              value={timeOfDay}
+              onChange={(e) => onTime(parseFloat(e.target.value))}
+            />
+            <div className={styles.subHint}>dawn · noon · dusk · night</div>
+          </div>
+
+          <div className={styles.row}>
+            <div className={styles.label}>
+              <label htmlFor="tp-dist">Camera distance</label>
+              <span className={styles.value}>{cameraDistance.toFixed(1)}</span>
+            </div>
+            <input
+              id="tp-dist"
+              type="range"
+              min={6}
+              max={28}
+              step={0.5}
+              value={cameraDistance}
+              onChange={(e) => onDistance(parseFloat(e.target.value))}
+            />
+          </div>
+
+          <label className={styles.check}>
+            <input type="checkbox" checked={autoWander} onChange={(e) => onWander(e.target.checked)} /> Auto-wander
+          </label>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/features/tinyPlanet/components/Dpad.tsx
+++ b/src/components/features/tinyPlanet/components/Dpad.tsx
@@ -1,0 +1,40 @@
+import type { Dir } from '../world/constants';
+import styles from './TinyPlanet.module.css';
+
+type Props = {
+  onPress: (dir: Dir, down: boolean) => void;
+};
+
+const BUTTONS: { dir: Dir; label: string; area: string; glyph: string }[] = [
+  { dir: 'f', label: 'Walk forward', area: '1 / 2', glyph: '▲' },
+  { dir: 'l', label: 'Walk left', area: '2 / 1', glyph: '◀' },
+  { dir: 'r', label: 'Walk right', area: '2 / 3', glyph: '▶' },
+  { dir: 'b', label: 'Walk backward', area: '3 / 2', glyph: '▼' },
+];
+
+/** Touch equivalent of WASD — writes the same movement flags the keyboard does. */
+export function Dpad({ onPress }: Props) {
+  return (
+    <div className={styles.dpad}>
+      {BUTTONS.map((b) => (
+        <button
+          key={b.dir}
+          aria-label={b.label}
+          style={{ gridArea: b.area }}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            onPress(b.dir, true);
+          }}
+          onPointerUp={(e) => {
+            e.preventDefault();
+            onPress(b.dir, false);
+          }}
+          onPointerLeave={() => onPress(b.dir, false)}
+          onPointerCancel={() => onPress(b.dir, false)}
+        >
+          {b.glyph}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/tinyPlanet/components/Dpad.tsx
+++ b/src/components/features/tinyPlanet/components/Dpad.tsx
@@ -19,6 +19,7 @@ export function Dpad({ onPress }: Props) {
       {BUTTONS.map((b) => (
         <button
           key={b.dir}
+          type="button"
           aria-label={b.label}
           style={{ gridArea: b.area }}
           onPointerDown={(e) => {

--- a/src/components/features/tinyPlanet/components/Overlay.tsx
+++ b/src/components/features/tinyPlanet/components/Overlay.tsx
@@ -1,0 +1,28 @@
+import styles from './TinyPlanet.module.css';
+
+type Props = {
+  hintVisible: boolean;
+  title?: string;
+  subtitle?: string;
+  credit?: string;
+};
+
+export function Overlay({ hintVisible, title, subtitle, credit }: Props) {
+  return (
+    <>
+      {(title || subtitle) && (
+        <div className={styles.title}>
+          {title && <h1>{title}</h1>}
+          {subtitle && <p>{subtitle}</p>}
+        </div>
+      )}
+
+      {credit && <div className={styles.credit}>{credit}</div>}
+
+      {/* Device-neutral wording: this renders on touch as well, where WASD means nothing. */}
+      <div className={styles.hint} style={{ opacity: hintVisible ? 1 : 0 }}>
+        drag to look around · d-pad or WASD to walk
+      </div>
+    </>
+  );
+}

--- a/src/components/features/tinyPlanet/components/TinyPlanet.module.css
+++ b/src/components/features/tinyPlanet/components/TinyPlanet.module.css
@@ -1,0 +1,282 @@
+/*
+ * Chrome for the Tiny Planet showcase.
+ *
+ * Scoped as a CSS Module so nothing leaks into a host page, and positioned
+ * against the component's own container (absolute, not fixed) so it can be
+ * embedded in a section rather than owning the viewport.
+ *
+ * Every colour and font is a custom property declared on .root. A host can
+ * restyle the whole panel by overriding these on its own wrapper — no need to
+ * fork this file.
+ */
+
+.root {
+  --tp-accent: #e8643c;
+  --tp-ink: #4a3a26;
+  --tp-ink-soft: #a8916f;
+  --tp-value: #c9502f;
+  --tp-glass: rgba(255, 247, 232, 0.62);
+  --tp-glass-soft: rgba(255, 247, 232, 0.55);
+  --tp-glass-button: rgba(255, 247, 232, 0.6);
+  --tp-glass-border: rgba(255, 255, 255, 0.5);
+  --tp-glass-shadow: 0 10px 34px rgba(60, 40, 20, 0.18);
+  --tp-blur: blur(14px);
+  --tp-title-color: #fff8ec;
+  --tp-title-shadow: 0 3px 18px rgba(40, 30, 10, 0.4), 0 1px 0 rgba(0, 0, 0, 0.15);
+  --tp-hint-color: #2f4a3a;
+  --tp-hint-shadow: 0 1px 3px rgba(255, 255, 255, 0.6);
+  --tp-font-ui: "Quicksand", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --tp-font-display: "Baloo 2", ui-rounded, system-ui, sans-serif;
+  --tp-radius: 22px;
+
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--tp-font-ui);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+  animation: tp-fade 1000ms ease both;
+}
+
+/* Chrome sits above the canvas and is click-through except on real controls. */
+.overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.title {
+  position: absolute;
+  top: 8%;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+  animation: tp-fade 1100ms ease 200ms both;
+}
+.title h1 {
+  margin: 0;
+  font-family: var(--tp-font-display);
+  font-weight: 700;
+  font-size: clamp(38px, 6vw, 64px);
+  color: var(--tp-title-color);
+  text-shadow: var(--tp-title-shadow);
+  letter-spacing: 0.3px;
+}
+.title p {
+  margin: 8px 0 0;
+  font-weight: 600;
+  font-size: clamp(14px, 1.7vw, 18px);
+  color: var(--tp-title-color);
+  text-shadow: 0 2px 10px rgba(40, 30, 10, 0.35);
+  opacity: 0.92;
+}
+
+.credit {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: var(--tp-glass-soft);
+  backdrop-filter: var(--tp-blur);
+  -webkit-backdrop-filter: var(--tp-blur);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--tp-ink);
+  white-space: nowrap;
+}
+
+.hint {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--tp-hint-color);
+  text-shadow: var(--tp-hint-shadow);
+  white-space: nowrap;
+  transition: opacity 500ms ease;
+}
+
+/* --- controls --- */
+.toggle {
+  position: absolute;
+  bottom: 18px;
+  left: 18px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: none;
+  background: var(--tp-glass);
+  backdrop-filter: var(--tp-blur);
+  -webkit-backdrop-filter: var(--tp-blur);
+  box-shadow: var(--tp-glass-shadow);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--tp-ink);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.panel {
+  position: absolute;
+  bottom: 76px;
+  left: 18px;
+  width: 238px;
+  padding: 16px 16px 14px;
+  border-radius: var(--tp-radius);
+  background: var(--tp-glass);
+  backdrop-filter: var(--tp-blur);
+  -webkit-backdrop-filter: var(--tp-blur);
+  box-shadow: var(--tp-glass-shadow);
+  border: 1px solid var(--tp-glass-border);
+  pointer-events: auto;
+  animation: tp-pop 200ms ease both;
+}
+.panelHeading {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tp-ink-soft);
+  margin-bottom: 12px;
+}
+.row {
+  margin: 11px 0;
+}
+.row:first-of-type {
+  margin-top: 0;
+}
+.label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 5px;
+}
+.label label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--tp-ink);
+  white-space: nowrap;
+}
+.value {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--tp-value);
+  font-variant-numeric: tabular-nums;
+}
+.subHint {
+  font-size: 10.5px;
+  color: var(--tp-ink-soft);
+  margin-top: 4px;
+}
+.panel input[type="range"] {
+  width: 100%;
+  cursor: pointer;
+  accent-color: var(--tp-accent);
+}
+.check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 13px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--tp-ink);
+  cursor: pointer;
+}
+.check input {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  accent-color: var(--tp-accent);
+}
+
+/* --- d-pad (touch) --- */
+.dpad {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, 48px);
+  grid-template-rows: repeat(3, 48px);
+  gap: 7px;
+  pointer-events: auto;
+}
+.dpad button {
+  border: none;
+  border-radius: 50%;
+  font-size: 17px;
+  color: var(--tp-ink);
+  background: var(--tp-glass-button);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  touch-action: none;
+}
+.dpad button:active {
+  background: rgba(232, 100, 60, 0.45);
+}
+
+@keyframes tp-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes tp-pop {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas,
+  .title,
+  .panel {
+    animation: none;
+  }
+  .hint {
+    transition: none;
+  }
+}
+
+/* Keep the chrome usable on small screens. */
+@media (max-width: 480px) {
+  .panel {
+    width: min(238px, calc(100vw - 36px));
+  }
+  .dpad {
+    grid-template-columns: repeat(3, 42px);
+    grid-template-rows: repeat(3, 42px);
+  }
+  /* Centred and nowrap, the hint runs straight through the Controls button and
+     the d-pad at this width. Tuck it above the button on the left instead, and
+     cap its width so it stops short of the d-pad column. */
+  .hint {
+    left: 18px;
+    bottom: 64px;
+    transform: none;
+    text-align: left;
+    white-space: normal;
+    max-width: calc(100% - 190px);
+    line-height: 1.35;
+  }
+}

--- a/src/components/features/tinyPlanet/components/TinyPlanetShowcase.tsx
+++ b/src/components/features/tinyPlanet/components/TinyPlanetShowcase.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { TinyPlanet, type TinyPlanetHandle } from '../r3f/TinyPlanet';
+import { usePrefersReducedMotion } from '../r3f/usePrefersReducedMotion';
+import { Overlay } from './Overlay';
+import { ControlPanel } from './ControlPanel';
+import { Dpad } from './Dpad';
+import type { Dir } from '../world/constants';
+import styles from './TinyPlanet.module.css';
+
+/**
+ * `<TinyPlanet>` plus its chrome: the control panel, the touch d-pad, and the
+ * title/hint overlay.
+ *
+ * Kept separate from the experience itself so `<TinyPlanet>` stays a pure,
+ * prop-driven component with no UI opinions. Everything here is scoped to a CSS
+ * Module and positioned inside the component's own box, so this can be dropped
+ * into a page section as readily as it fills a viewport.
+ */
+
+export interface TinyPlanetShowcaseProps {
+  className?: string;
+  /** Fixes the generated layout so every visitor sees the same world. */
+  seed?: number;
+  title?: string;
+  subtitle?: string;
+  credit?: string;
+  showControls?: boolean;
+  showDpad?: boolean;
+}
+
+// The load-in "sunrise": ease the day from dawn up to noon.
+const INTRO_FROM = 0.3;
+const INTRO_TO = 0.5;
+const INTRO_MS = 4200;
+
+const easeInOut = (p: number) => (p < 0.5 ? 2 * p * p : 1 - Math.pow(-2 * p + 2, 2) / 2);
+
+export function TinyPlanetShowcase({
+  className,
+  seed,
+  title,
+  subtitle,
+  credit,
+  showControls = true,
+  showDpad = true,
+}: TinyPlanetShowcaseProps) {
+  const reduced = usePrefersReducedMotion();
+  const planet = useRef<TinyPlanetHandle>(null);
+
+  const [curvature, setCurvature] = useState(0.0016);
+  const [timeOfDay, setTimeOfDay] = useState(INTRO_FROM);
+  const [cameraDistance, setCameraDistance] = useState(12);
+  const [autoWander, setAutoWander] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [hintVisible, setHintVisible] = useState(true);
+
+  const onPress = useCallback((dir: Dir, down: boolean) => {
+    planet.current?.press(dir, down);
+  }, []);
+
+  // Sunrise on load. Skipped entirely under reduced motion, which starts at noon.
+  useEffect(() => {
+    if (reduced) {
+      setTimeOfDay(INTRO_TO);
+      return;
+    }
+    let raf = 0;
+    let start = 0;
+    const step = (t: number) => {
+      if (!start) start = t;
+      const p = Math.min(1, (t - start) / INTRO_MS);
+      setTimeOfDay(INTRO_FROM + (INTRO_TO - INTRO_FROM) * easeInOut(p));
+      if (p < 1) raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [reduced]);
+
+  // Hide the hint after the first interaction.
+  useEffect(() => {
+    const hide = () => setHintVisible(false);
+    window.addEventListener('pointerdown', hide, { once: true });
+    window.addEventListener('keydown', hide, { once: true });
+    return () => {
+      window.removeEventListener('pointerdown', hide);
+      window.removeEventListener('keydown', hide);
+    };
+  }, []);
+
+  const rootClass = className ? `${styles.root} ${className}` : styles.root;
+
+  return (
+    <div className={rootClass}>
+      <TinyPlanet
+        ref={planet}
+        className={styles.canvas}
+        curvature={curvature}
+        timeOfDay={timeOfDay}
+        cameraDistance={cameraDistance}
+        autoWander={autoWander}
+        seed={seed}
+      />
+
+      <div className={styles.overlay}>
+        <Overlay hintVisible={hintVisible} title={title} subtitle={subtitle} credit={credit} />
+
+        {showControls && (
+          <ControlPanel
+            open={panelOpen}
+            onToggle={() => setPanelOpen((o) => !o)}
+            curvature={curvature}
+            onCurvature={setCurvature}
+            timeOfDay={timeOfDay}
+            onTime={setTimeOfDay}
+            cameraDistance={cameraDistance}
+            onDistance={setCameraDistance}
+            autoWander={autoWander}
+            onWander={setAutoWander}
+          />
+        )}
+
+        {showDpad && <Dpad onPress={onPress} />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/tinyPlanet/index.ts
+++ b/src/components/features/tinyPlanet/index.ts
@@ -1,0 +1,7 @@
+// Tiny Planet feature barrel exports
+export { TinyPlanetShowcase } from './components/TinyPlanetShowcase';
+export type { TinyPlanetShowcaseProps } from './components/TinyPlanetShowcase';
+
+// The bare experience, for embedding without the control panel / d-pad chrome.
+export { TinyPlanet } from './r3f/TinyPlanet';
+export type { TinyPlanetProps, TinyPlanetHandle } from './r3f/TinyPlanet';

--- a/src/components/features/tinyPlanet/r3f/Avatar.tsx
+++ b/src/components/features/tinyPlanet/r3f/Avatar.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from 'react';
+import * as THREE from 'three';
+import { useWorld } from './WorldContext';
+
+/**
+ * The walker. Positioned and turned by the frame loop, which is why the group
+ * and its shadow are exposed as refs rather than driven by props — their
+ * transforms change every frame and must not go through React.
+ */
+export const Avatar = forwardRef<THREE.Group>(function Avatar(_props, ref) {
+  const { materials: m, geo } = useWorld();
+  return (
+    <group ref={ref}>
+      <mesh geometry={geo.cylinder(0.32, 0.42, 1.0, 10)} material={m.lit('#e8643c')} position={[0, 0.7, 0]} />
+      <mesh geometry={geo.sphere(0.36, 14, 10)} material={m.lit('#f0c9a8')} position={[0, 1.45, 0]} />
+      <mesh geometry={geo.box(0.5, 0.5, 0.3)} material={m.lit('#c63f2c')} position={[0, 0.85, -0.38]} />
+    </group>
+  );
+});
+
+export const AvatarShadow = forwardRef<THREE.Mesh>(function AvatarShadow(_props, ref) {
+  const { materials: m, geo } = useWorld();
+  return <mesh ref={ref} geometry={geo.circleXZ(0.55, 16)} material={m.flat('#2a1f14', 0.26)} />;
+});

--- a/src/components/features/tinyPlanet/r3f/Clouds.tsx
+++ b/src/components/features/tinyPlanet/r3f/Clouds.tsx
@@ -1,0 +1,41 @@
+import { useCallback, type MutableRefObject } from 'react';
+import * as THREE from 'three';
+import { useWorld } from './WorldContext';
+
+/**
+ * Drifting clouds.
+ *
+ * Deliberately the one part of the world that does *not* bend: they use a plain
+ * unlit material with no curvature vertex shader, so they read as sky rather
+ * than as scenery sitting on the planet. Drift is applied by the frame loop
+ * through the collected refs, and skipped entirely under reduced motion.
+ */
+export function Clouds({ groupsRef }: { groupsRef: MutableRefObject<THREE.Group[]> }) {
+  const { materials: m, geo, world } = useWorld();
+
+  // Collect each cloud group into a flat array the frame loop can walk.
+  const collect = useCallback(
+    (index: number) => (node: THREE.Group | null) => {
+      if (node) groupsRef.current[index] = node;
+    },
+    [groupsRef],
+  );
+
+  return (
+    <>
+      {world.clouds.map((c, i) => (
+        <group key={i} ref={collect(i)} position={[c.x, c.y, c.z]}>
+          {c.puffs.map((p, j) => (
+            <mesh
+              key={j}
+              geometry={geo.icosahedron(p.r, 0)}
+              material={m.cloud}
+              position={[p.x, p.y, p.z]}
+              scale={[1, 0.6, 1]}
+            />
+          ))}
+        </group>
+      ))}
+    </>
+  );
+}

--- a/src/components/features/tinyPlanet/r3f/Ground.tsx
+++ b/src/components/features/tinyPlanet/r3f/Ground.tsx
@@ -1,0 +1,20 @@
+import * as THREE from 'three';
+import { useWorld } from './WorldContext';
+
+/**
+ * The world floor — a genuinely flat 720x720 plane.
+ *
+ * The 200x200 subdivision exists solely so the curvature displacement in the
+ * vertex shader has enough vertices to bend smoothly; the ground itself is
+ * never anything but flat, and all gameplay treats it as a plane.
+ */
+export function Ground() {
+  const { materials, geo } = useWorld();
+  const geometry = geo.get('ground', () => {
+    const g = new THREE.PlaneGeometry(720, 720, 200, 200);
+    g.rotateX(-Math.PI / 2);
+    return g;
+  });
+
+  return <mesh geometry={geometry} material={materials.ground()} />;
+}

--- a/src/components/features/tinyPlanet/r3f/PathMesh.tsx
+++ b/src/components/features/tinyPlanet/r3f/PathMesh.tsx
@@ -1,0 +1,24 @@
+import * as THREE from 'three';
+import { useWorld } from './WorldContext';
+
+/**
+ * The dirt road.
+ *
+ * A triangle ribbon carrying a custom `aEdge` attribute that runs -1..1 across
+ * the width, which the path fragment shader feathers into soft edges. It uses
+ * its own vertex shader — identical to the shared one apart from passing that
+ * attribute through — so it curves with the rest of the world.
+ */
+export function PathMesh() {
+  const { materials, geo, world } = useWorld();
+
+  const geometry = geo.get('path', () => {
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(world.path.positions, 3));
+    g.setAttribute('aEdge', new THREE.BufferAttribute(world.path.edges, 1));
+    g.setIndex(new THREE.BufferAttribute(world.path.index, 1));
+    return g;
+  });
+
+  return <mesh geometry={geometry} material={materials.path()} />;
+}

--- a/src/components/features/tinyPlanet/r3f/Props.tsx
+++ b/src/components/features/tinyPlanet/r3f/Props.tsx
@@ -1,0 +1,174 @@
+import { useWorld } from './WorldContext';
+import type { HouseSpec, TreeSpec } from '../world/generate';
+
+/**
+ * Every piece of static scenery, transcribed from the builder functions in
+ * `world/engine.js`. Dimensions, colours and offsets are unchanged.
+ *
+ * All geometry and materials come from the shared caches, so the 46 trees
+ * between them use a handful of buffers and a handful of materials rather than
+ * one of each per mesh — which is what keeps the per-frame uniform sweep cheap.
+ */
+
+function BroadTree({ spec }: { spec: TreeSpec }) {
+  const { materials: m, geo } = useWorld();
+  const foliage = m.lit(spec.foliageHex);
+  return (
+    <group position={[spec.x, 0, spec.z]} rotation={[0, spec.rotY, 0]} scale={spec.scale}>
+      <mesh geometry={geo.cylinder(0.16, 0.28, 1.5, 8)} material={m.lit('#8a674a')} position={[0, 0.75, 0]} />
+      <mesh geometry={geo.icosahedron(1.3, 1)} material={foliage} position={[0, 2.25, 0]} rotation={spec.blobRot} />
+      <mesh geometry={geo.icosahedron(1.0, 1)} material={foliage} position={[0.75, 2.7, 0.25]} />
+      <mesh geometry={geo.icosahedron(0.95, 1)} material={foliage} position={[-0.65, 2.6, -0.3]} />
+      <mesh geometry={geo.icosahedron(0.7, 1)} material={foliage} position={[0.1, 3.15, -0.5]} />
+    </group>
+  );
+}
+
+function PineTree({ spec }: { spec: TreeSpec }) {
+  const { materials: m, geo } = useWorld();
+  return (
+    <group position={[spec.x, 0, spec.z]} rotation={[0, spec.rotY, 0]} scale={spec.scale}>
+      <mesh geometry={geo.cylinder(0.18, 0.26, 1.2, 8)} material={m.lit('#7a5a3e')} position={[0, 0.6, 0]} />
+      <mesh geometry={geo.cone(1.3, 1.8, 10)} material={m.lit('#3f7d3a')} position={[0, 1.8, 0]} />
+      <mesh geometry={geo.cone(1.0, 1.5, 10)} material={m.lit('#458a40')} position={[0, 2.7, 0]} />
+      <mesh geometry={geo.cone(0.7, 1.2, 10)} material={m.lit('#4d9647')} position={[0, 3.5, 0]} />
+    </group>
+  );
+}
+
+function House({ spec }: { spec: HouseSpec }) {
+  const { materials: m, geo } = useWorld();
+  const { w, dp, hh } = spec;
+  const frame = m.lit('#6a5138');
+  // The one emissive material in the village: cool glass by day, warm lamplight
+  // after dusk, blended entirely by the uGlow uniform.
+  const windowMat = m.glow('#bfe6ef', '#ffdf8a');
+  const winX = w / 2 - 0.55;
+
+  return (
+    <group position={[spec.x, 0, spec.z]} rotation={[0, spec.rotY, 0]}>
+      <mesh geometry={geo.box(w, hh, dp)} material={m.lit(spec.wallHex)} position={[0, hh / 2, 0]} />
+      <mesh geometry={geo.box(w + 0.06, 0.22, dp + 0.06)} material={frame} position={[0, 0.11, 0]} />
+      <mesh
+        geometry={geo.cone(Math.max(w, dp) * 0.72, 1.3, 4)}
+        material={m.lit(spec.roofHex)}
+        position={[0, hh + 0.55, 0]}
+        rotation={[0, Math.PI / 4, 0]}
+      />
+      <mesh geometry={geo.box(0.5, 0.9, 0.1)} material={m.lit('#5a3a2a')} position={[0, 0.45, dp / 2 + 0.02]} />
+
+      <mesh geometry={geo.box(0.58, 0.58, 0.06)} material={frame} position={[winX, hh * 0.6, dp / 2 + 0.01]} />
+      <mesh geometry={geo.box(0.42, 0.42, 0.08)} material={windowMat} position={[winX, hh * 0.6, dp / 2 + 0.03]} />
+      <mesh geometry={geo.box(0.58, 0.58, 0.06)} material={frame} position={[-winX, hh * 0.6, dp / 2 + 0.01]} />
+      <mesh geometry={geo.box(0.42, 0.42, 0.08)} material={windowMat} position={[-winX, hh * 0.6, dp / 2 + 0.03]} />
+
+      <mesh
+        geometry={geo.box(0.3, 0.7, 0.3)}
+        material={m.lit('#8a6a5a')}
+        position={[w / 2 - 0.5, hh + 0.7, -(dp / 2 - 0.5)]}
+      />
+    </group>
+  );
+}
+
+function Torii({ x, z, rotY }: { x: number; z: number; rotY: number }) {
+  const { materials: m, geo } = useWorld();
+  const red = m.lit('#d94b3a');
+  return (
+    <group position={[x, 0, z]} rotation={[0, rotY, 0]}>
+      <mesh geometry={geo.cylinder(0.18, 0.2, 4, 10)} material={red} position={[-1.4, 2, 0]} />
+      <mesh geometry={geo.cylinder(0.18, 0.2, 4, 10)} material={red} position={[1.4, 2, 0]} />
+      <mesh geometry={geo.box(4.3, 0.35, 0.5)} material={red} position={[0, 4.1, 0]} />
+      <mesh geometry={geo.box(3.4, 0.25, 0.4)} material={red} position={[0, 3.4, 0]} />
+    </group>
+  );
+}
+
+function Mailbox({ x, z, rotY }: { x: number; z: number; rotY: number }) {
+  const { materials: m, geo } = useWorld();
+  return (
+    <group position={[x, 0, z]} rotation={[0, rotY, 0]}>
+      <mesh geometry={geo.cylinder(0.07, 0.07, 1.0, 8)} material={m.lit('#6a4f3a')} position={[0, 0.5, 0]} />
+      <mesh geometry={geo.box(0.5, 0.35, 0.3)} material={m.lit('#cf4636')} position={[0, 1.1, 0]} />
+    </group>
+  );
+}
+
+function Lamp({ x, z }: { x: number; z: number }) {
+  const { materials: m, geo } = useWorld();
+  return (
+    <group position={[x, 0, z]}>
+      <mesh geometry={geo.cylinder(0.08, 0.1, 2.6, 8)} material={m.lit('#3a3f44')} position={[0, 1.3, 0]} />
+      <mesh geometry={geo.sphere(0.22, 12, 10)} material={m.glow('#7a7252', '#ffe6a0')} position={[0, 2.65, 0]} />
+    </group>
+  );
+}
+
+/** Every prop's contact shadow — a translucent disc lying just above the ground. */
+export function Shadows() {
+  const { materials: m, geo, world } = useWorld();
+  const material = m.flat('#2a1f14', 0.22);
+  return (
+    <>
+      {world.shadows.map((s, i) => (
+        <mesh key={i} geometry={geo.circleXZ(s.r, 16)} material={material} position={[s.x, 0.02, s.z]} />
+      ))}
+    </>
+  );
+}
+
+export function Scenery() {
+  const { materials: m, geo, world } = useWorld();
+
+  return (
+    <>
+      {world.houses.map((h, i) => (
+        <House key={`house-${i}`} spec={h} />
+      ))}
+      {world.mailboxes.map((b, i) => (
+        <Mailbox key={`mail-${i}`} {...b} />
+      ))}
+      {world.lamps.map((l, i) => (
+        <Lamp key={`lamp-${i}`} {...l} />
+      ))}
+      {world.torii.map((t, i) => (
+        <Torii key={`torii-${i}`} {...t} />
+      ))}
+      {world.trees.map((t, i) =>
+        t.kind === 'broad' ? <BroadTree key={`tree-${i}`} spec={t} /> : <PineTree key={`tree-${i}`} spec={t} />,
+      )}
+
+      {world.ponds.map((p, i) => (
+        <group key={`pond-${i}`}>
+          <mesh
+            geometry={geo.circleXZ(p.r, 28)}
+            material={m.flat('#5aa6c8', 0.6)}
+            position={[p.x, 0.06, p.z]}
+          />
+          {p.lilies.map((l, j) => (
+            <mesh
+              key={j}
+              geometry={geo.circleXZ(0.35, 10)}
+              material={m.lit('#5fae57')}
+              position={[l.x, 0.08, l.z]}
+            />
+          ))}
+        </group>
+      ))}
+
+      {world.flowers.map((f, i) => (
+        <mesh key={`flower-${i}`} geometry={geo.sphere(0.16, 8, 6)} material={m.lit(f.hex)} position={[f.x, 0.15, f.z]} />
+      ))}
+
+      {world.rocks.map((r, i) => (
+        <mesh
+          key={`rock-${i}`}
+          geometry={geo.icosahedron(r.r, 0)}
+          material={m.lit('#9aa3a0')}
+          position={[r.x, 0.2, r.z]}
+          rotation={[0, r.rotY, 0]}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/features/tinyPlanet/r3f/Scene.tsx
+++ b/src/components/features/tinyPlanet/r3f/Scene.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useRef, type RefObject } from 'react';
+import * as THREE from 'three';
+import { WorldProvider, type WorldResources } from './WorldContext';
+import { Sky } from './Sky';
+import { Ground } from './Ground';
+import { PathMesh } from './PathMesh';
+import { Scenery, Shadows } from './Props';
+import { Clouds } from './Clouds';
+import { Avatar, AvatarShadow } from './Avatar';
+import { useInput } from './useInput';
+import { useFrameDriver } from './useFrameDriver';
+import { createMaterials } from '../world/materials';
+import { createGeometryCache } from '../world/geometry';
+import { generateWorld } from '../world/generate';
+import type { Controls, InputState } from './state';
+
+/**
+ * The declarative scene graph, plus the single frame loop that animates it.
+ *
+ * Everything below is built once and then only mutated through uniforms and a
+ * handful of refs. Changing `timeOfDay` or `curvature` re-renders nothing here:
+ * those props are read straight off a ref inside `useFrameDriver`.
+ */
+
+interface Resources extends WorldResources {
+  dispose(): void;
+}
+
+function createResources(seed?: number): Resources {
+  const materials = createMaterials();
+  const geo = createGeometryCache();
+  const world = generateWorld(seed);
+  return {
+    materials,
+    geo,
+    world,
+    dispose() {
+      materials.dispose();
+      geo.dispose();
+    },
+  };
+}
+
+/**
+ * Build the world once per seed.
+ *
+ * Disposal only runs when the seed actually changes and a *new* set replaces the
+ * old one. Teardown of the whole canvas is left to r3f, which disposes the
+ * renderer and forces context loss — that frees these GPU resources too, and
+ * skipping an unmount-time dispose keeps StrictMode's simulated remount from
+ * pulling the materials out from under a still-live scene.
+ */
+function useResources(seed?: number): Resources {
+  const resources = useMemo(() => createResources(seed), [seed]);
+  const previous = useRef(resources);
+
+  useEffect(() => {
+    if (previous.current !== resources) {
+      previous.current.dispose();
+      previous.current = resources;
+    }
+  }, [resources]);
+
+  return resources;
+}
+
+export interface SceneProps {
+  controls: RefObject<Controls>;
+  input: InputState;
+  wander: RefObject<number>;
+  seed?: number;
+}
+
+export function Scene({ controls, input, wander, seed }: SceneProps) {
+  const resources = useResources(seed);
+
+  const avatar = useRef<THREE.Group>(null);
+  const avatarShadow = useRef<THREE.Mesh>(null);
+  const sky = useRef<THREE.Mesh>(null);
+  const clouds = useRef<THREE.Group[]>([]);
+
+  useInput(input);
+  useFrameDriver({
+    controls,
+    input,
+    materials: resources.materials,
+    wander,
+    refs: { avatar, avatarShadow, sky, clouds },
+  });
+
+  return (
+    <WorldProvider value={resources}>
+      <Sky ref={sky} />
+      <Ground />
+      <PathMesh />
+      <Shadows />
+      <Scenery />
+      <Clouds groupsRef={clouds} />
+      <Avatar ref={avatar} />
+      <AvatarShadow ref={avatarShadow} />
+    </WorldProvider>
+  );
+}

--- a/src/components/features/tinyPlanet/r3f/Scene.tsx
+++ b/src/components/features/tinyPlanet/r3f/Scene.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, type RefObject } from 'react';
+import { memo, useEffect, useMemo, useRef, type RefObject } from 'react';
 import * as THREE from 'three';
 import { WorldProvider, type WorldResources } from './WorldContext';
 import { Sky } from './Sky';
@@ -71,7 +71,14 @@ export interface SceneProps {
   seed?: number;
 }
 
-export function Scene({ controls, input, wander, seed }: SceneProps) {
+/**
+ * Memoized deliberately. Every prop here is a stable ref except `seed`, while
+ * the host re-renders on every `timeOfDay` change — once per frame during the
+ * intro sunrise and on every slider drag. Without this, each of those would
+ * reconcile all several hundred scenery components for no visual change; the
+ * uniform sweep in the frame loop is what actually moves the world.
+ */
+export const Scene = memo(function Scene({ controls, input, wander, seed }: SceneProps) {
   const resources = useResources(seed);
 
   const avatar = useRef<THREE.Group>(null);
@@ -100,4 +107,4 @@ export function Scene({ controls, input, wander, seed }: SceneProps) {
       <AvatarShadow ref={avatarShadow} />
     </WorldProvider>
   );
-}
+});

--- a/src/components/features/tinyPlanet/r3f/Sky.tsx
+++ b/src/components/features/tinyPlanet/r3f/Sky.tsx
@@ -1,0 +1,18 @@
+import { forwardRef } from 'react';
+import * as THREE from 'three';
+import { useWorld } from './WorldContext';
+
+/**
+ * Sky dome.
+ *
+ * The only material that does *not* use the shared curvature vertex shader —
+ * it is drawn on the inside of a large sphere that the frame loop re-centres on
+ * the camera every tick, so it behaves as a backdrop at infinity. `renderOrder`
+ * of -1 keeps it behind everything else despite not writing depth.
+ */
+export const Sky = forwardRef<THREE.Mesh>(function Sky(_props, ref) {
+  const { materials, geo } = useWorld();
+  const geometry = geo.get('sky', () => new THREE.SphereGeometry(1200, 32, 16));
+
+  return <mesh ref={ref} geometry={geometry} material={materials.sky} renderOrder={-1} />;
+});

--- a/src/components/features/tinyPlanet/r3f/TinyPlanet.tsx
+++ b/src/components/features/tinyPlanet/r3f/TinyPlanet.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { Scene } from './Scene';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { createInputState, type Controls } from './state';
+import {
+  DEFAULT_CAMERA_DISTANCE,
+  DEFAULT_CURVATURE,
+  DEFAULT_TIME_OF_DAY,
+  type Dir,
+} from '../world/constants';
+
+/**
+ * The Tiny Planet experience as one prop-driven component.
+ *
+ * Fills its parent box — size the container, not this — and brings no global
+ * CSS with it, so it can be dropped into any layout. All chrome (controls,
+ * d-pad, titles) lives outside; see `TinyPlanetShowcase` for the full demo.
+ */
+
+export interface TinyPlanetProps {
+  /** Cosmetic curvature. 0 is a flat world; higher reads as a smaller planet. */
+  curvature?: number;
+  /** 0..1 through dawn, noon, dusk, night. Drives every colour uniform. */
+  timeOfDay?: number;
+  /** Third-person camera distance. */
+  cameraDistance?: number;
+  /** Walk a lazy loop on its own, ignoring input. */
+  autoWander?: boolean;
+  /** Force ambient motion off. Defaults to the OS `prefers-reduced-motion` setting. */
+  reducedMotion?: boolean;
+  /** Fixes the generated layout. Omit for a different world every mount. */
+  seed?: number;
+  className?: string;
+}
+
+export interface TinyPlanetHandle {
+  /** Set a movement flag, for on-screen controls. Keyboard writes the same flags. */
+  press(dir: Dir, down: boolean): void;
+}
+
+export const TinyPlanet = forwardRef<TinyPlanetHandle, TinyPlanetProps>(function TinyPlanet(
+  {
+    curvature = DEFAULT_CURVATURE,
+    timeOfDay = DEFAULT_TIME_OF_DAY,
+    cameraDistance = DEFAULT_CAMERA_DISTANCE,
+    autoWander = false,
+    reducedMotion,
+    seed,
+    className,
+  },
+  ref,
+) {
+  const systemReducedMotion = usePrefersReducedMotion();
+  const resolvedReducedMotion = reducedMotion ?? systemReducedMotion;
+
+  const input = useRef(createInputState()).current;
+  const wander = useRef(0);
+
+  // Props are mirrored into a ref rather than passed down, so the frame loop
+  // always sees the latest values without the scene re-rendering to deliver them.
+  const controls = useRef<Controls>({
+    curvature,
+    timeOfDay,
+    cameraDistance,
+    autoWander,
+    reducedMotion: resolvedReducedMotion,
+  });
+  controls.current.curvature = curvature;
+  controls.current.timeOfDay = timeOfDay;
+  controls.current.cameraDistance = cameraDistance;
+  controls.current.autoWander = autoWander;
+  controls.current.reducedMotion = resolvedReducedMotion;
+
+  // Restart the wander path whenever the toggle flips, as the engine did.
+  useEffect(() => {
+    wander.current = 0;
+  }, [autoWander]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      press(dir, down) {
+        input.keys[dir] = down;
+      },
+    }),
+    [input],
+  );
+
+  return (
+    <div className={className} style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Canvas
+        // `flat` is load-bearing: it selects NoToneMapping, matching the original
+        // renderer. Without it r3f's default ACES tone mapping washes out the
+        // whole palette.
+        flat
+        gl={{ antialias: true, alpha: false }}
+        dpr={[1, 2]}
+        camera={{ fov: 55, near: 0.1, far: 2000 }}
+        onCreated={({ gl }) => {
+          // Set here rather than in a stylesheet so the component stays free of
+          // any global CSS requirement.
+          gl.domElement.style.touchAction = 'none';
+          gl.domElement.style.cursor = 'grab';
+        }}
+      >
+        <Scene controls={controls} input={input} wander={wander} seed={seed} />
+      </Canvas>
+    </div>
+  );
+});

--- a/src/components/features/tinyPlanet/r3f/WorldContext.tsx
+++ b/src/components/features/tinyPlanet/r3f/WorldContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { Materials } from '../world/materials';
+import type { GeometryCache } from '../world/geometry';
+import type { WorldData } from '../world/generate';
+
+/**
+ * Shared, build-once resources for the scene: the material set, the geometry
+ * cache, and the generated layout. Created in a single `useMemo` and handed
+ * down so every prop component can pull cached instances instead of allocating.
+ */
+export interface WorldResources {
+  materials: Materials;
+  geo: GeometryCache;
+  world: WorldData;
+}
+
+const WorldContext = createContext<WorldResources | null>(null);
+
+export function WorldProvider({ value, children }: { value: WorldResources; children: ReactNode }) {
+  return <WorldContext.Provider value={value}>{children}</WorldContext.Provider>;
+}
+
+export function useWorld(): WorldResources {
+  const value = useContext(WorldContext);
+  if (!value) throw new Error('useWorld must be used inside <WorldProvider>');
+  return value;
+}

--- a/src/components/features/tinyPlanet/r3f/state.ts
+++ b/src/components/features/tinyPlanet/r3f/state.ts
@@ -1,0 +1,30 @@
+import type { Dir } from '../world/constants';
+
+/**
+ * The two mutable objects the frame loop reads.
+ *
+ * Both are plain objects held in refs rather than React state: they change every
+ * frame (or on every pointer move) and must never trigger a re-render, because
+ * a re-render of the scene would mean rebuilding it — the exact thing the
+ * uniform-driven design exists to avoid.
+ */
+
+/** Prop values, mirrored into a ref each render so the loop sees them without re-subscribing. */
+export interface Controls {
+  curvature: number;
+  timeOfDay: number;
+  cameraDistance: number;
+  autoWander: boolean;
+  reducedMotion: boolean;
+}
+
+/** Live input. Keyboard and the on-screen d-pad write to the same movement flags. */
+export interface InputState {
+  keys: Record<Dir, boolean>;
+  camYaw: number;
+  camPitch: number;
+}
+
+export function createInputState(): InputState {
+  return { keys: { f: false, b: false, l: false, r: false }, camYaw: 0.0, camPitch: 0.4 };
+}

--- a/src/components/features/tinyPlanet/r3f/useFrameDriver.ts
+++ b/src/components/features/tinyPlanet/r3f/useFrameDriver.ts
@@ -1,0 +1,152 @@
+import { useRef, type RefObject } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { createSkyState, updateSkyState } from '../world/palette';
+import { MOVE_SPEED, WORLD_R } from '../world/constants';
+import type { Materials } from '../world/materials';
+import type { Controls, InputState } from './state';
+
+/**
+ * The one and only per-frame callback.
+ *
+ * Everything that moves happens here, in the same order as the reference
+ * engine's `animate()`: resolve the sun, integrate movement, push uniforms,
+ * drift the clouds, then place the camera. Nothing in this loop touches React
+ * state, allocates, or rebuilds anything — it only mutates existing objects.
+ *
+ * Note that movement is entirely flat 2D. `player` has no height and the world
+ * is a plane; the curvature that makes it look like a planet exists only in the
+ * vertex shader, and no gameplay maths is aware of it.
+ */
+
+export interface FrameRefs {
+  avatar: RefObject<THREE.Group | null>;
+  avatarShadow: RefObject<THREE.Mesh | null>;
+  sky: RefObject<THREE.Mesh | null>;
+  clouds: RefObject<THREE.Group[]>;
+}
+
+export interface FrameDriverOptions {
+  controls: RefObject<Controls>;
+  input: InputState;
+  materials: Materials;
+  refs: FrameRefs;
+  /** Elapsed auto-wander time. Reset externally when the toggle flips. */
+  wander: RefObject<number>;
+}
+
+export function useFrameDriver({ controls, input, materials, refs, wander }: FrameDriverOptions) {
+  const sky = useRef(createSkyState()).current;
+  const player = useRef(new THREE.Vector3(0, 0, 0)).current;
+  const bob = useRef({ phase: 0, amount: 0 }).current;
+
+  useFrame((state, rawDelta) => {
+    const { camera, gl } = state;
+    const c = controls.current;
+    const dt = Math.min(rawDelta, 0.05);
+
+    // --- 1. time of day -> sun, palette, fog, glow -------------------------
+    updateSkyState(sky, c.timeOfDay);
+
+    const skyMat = materials.sky;
+    skyMat.uSun.copy(sky.sunDir);
+    skyMat.uHorizon.copy(sky.horizon);
+    skyMat.uZenith.copy(sky.zenith);
+    skyMat.uSunCol.copy(sky.sunCol);
+    gl.setClearColor(sky.horizon, 1);
+
+    // --- 2. movement, in flat 2D ------------------------------------------
+    let mx = 0;
+    let mz = 0;
+    if (c.autoWander) {
+      wander.current += dt;
+      const t = wander.current;
+      const heading = t * 0.22 + Math.sin(t * 0.3) * 0.9;
+      mx = Math.sin(heading);
+      mz = Math.cos(heading);
+    } else {
+      // Walk relative to where the camera is looking, not to world axes.
+      const fX = -Math.sin(input.camYaw);
+      const fZ = -Math.cos(input.camYaw);
+      const rX = Math.cos(input.camYaw);
+      const rZ = -Math.sin(input.camYaw);
+      if (input.keys.f) {
+        mx += fX;
+        mz += fZ;
+      }
+      if (input.keys.b) {
+        mx -= fX;
+        mz -= fZ;
+      }
+      if (input.keys.r) {
+        mx += rX;
+        mz += rZ;
+      }
+      if (input.keys.l) {
+        mx -= rX;
+        mz -= rZ;
+      }
+    }
+
+    const len = Math.hypot(mx, mz);
+    const moving = len > 1e-4;
+    if (moving) {
+      mx /= len;
+      mz /= len;
+      player.x += mx * MOVE_SPEED * dt;
+      player.z += mz * MOVE_SPEED * dt;
+      const pr = Math.hypot(player.x, player.z);
+      if (pr > WORLD_R) {
+        player.x *= WORLD_R / pr;
+        player.z *= WORLD_R / pr;
+      }
+      if (refs.avatar.current) refs.avatar.current.rotation.y = Math.atan2(mx, mz);
+    }
+    refs.avatar.current?.position.set(player.x, 0, player.z);
+    refs.avatarShadow.current?.position.set(player.x, 0.03, player.z);
+
+    // --- 3. one uniform sweep across every world material ------------------
+    for (const m of materials.registry) {
+      const u = m.uniforms;
+      u.uPlayer.value.set(player.x, 0, player.z);
+      u.uCurvature.value = c.curvature;
+      if (u.uFog) u.uFog.value.copy(sky.horizon);
+      if (u.uLightDir) u.uLightDir.value.copy(sky.sunDir);
+      if (u.uLightColor) u.uLightColor.value.copy(sky.light);
+      if (u.uAmbient) u.uAmbient.value.copy(sky.ambient);
+      if (u.uGlow) u.uGlow.value = sky.glow;
+      if (u.uTint) u.uTint.value.copy(sky.tint);
+    }
+
+    // --- 4. ambient motion --------------------------------------------------
+    if (!c.reducedMotion) {
+      for (const cloud of refs.clouds.current) {
+        if (!cloud) continue;
+        cloud.position.x += 1.2 * dt;
+        if (cloud.position.x > 200) cloud.position.x = -200;
+      }
+    }
+
+    // --- 5. third-person rig, with footstep bob ----------------------------
+    bob.amount += ((moving && !c.reducedMotion ? 1 : 0) - bob.amount) * Math.min(1, dt * 8);
+    if (moving) bob.phase += dt * 8.2;
+    const bobY = Math.sin(bob.phase) * 0.08 * bob.amount;
+    const bobS = Math.cos(bob.phase * 0.5) * 0.05 * bob.amount;
+
+    const cp = Math.cos(input.camPitch);
+    const sp = Math.sin(input.camPitch);
+    const tx = player.x;
+    const ty = 1.2;
+    const tz = player.z;
+    const dist = c.cameraDistance;
+
+    camera.position.set(tx + Math.sin(input.camYaw) * cp * dist, ty + sp * dist, tz + Math.cos(input.camYaw) * cp * dist);
+    camera.position.y += bobY;
+    camera.position.x += Math.cos(input.camYaw) * bobS;
+    camera.position.z += -Math.sin(input.camYaw) * bobS;
+    camera.lookAt(tx, ty, tz);
+
+    // Keep the dome centred on the camera so it reads as sky at infinity.
+    refs.sky.current?.position.copy(camera.position);
+  });
+}

--- a/src/components/features/tinyPlanet/r3f/useInput.ts
+++ b/src/components/features/tinyPlanet/r3f/useInput.ts
@@ -23,11 +23,32 @@ const KEY_MAP: Record<string, Dir> = {
   ArrowRight: 'r',
 };
 
+/**
+ * True when the key belongs to whatever the user is actually typing in.
+ *
+ * Listening on `window` is what lets the world respond immediately, without
+ * making the visitor click the canvas first. The cost is that WASD and the
+ * arrow keys would otherwise be taken from every other control on the page —
+ * including this component's own sliders, where arrow keys are the native way
+ * to nudge a value, and any text field on a host page, where `preventDefault`
+ * would swallow the character outright.
+ */
+function isTypingTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.tagName !== 'string') return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  // Buttons are deliberately absent: they have no native use for these keys, so
+  // walking still works right after clicking the controls toggle or the d-pad.
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
 export function useInput(input: InputState) {
   const gl = useThree((s) => s.gl);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target)) return;
       const dir = KEY_MAP[e.code];
       if (dir) {
         input.keys[dir] = true;
@@ -36,6 +57,8 @@ export function useInput(input: InputState) {
       }
     };
     const onKeyUp = (e: KeyboardEvent) => {
+      // Deliberately unguarded: releasing a key can never hijack anything, and
+      // skipping it would strand the walker if focus moved mid-stride.
       const dir = KEY_MAP[e.code];
       if (dir) input.keys[dir] = false;
     };

--- a/src/components/features/tinyPlanet/r3f/useInput.ts
+++ b/src/components/features/tinyPlanet/r3f/useInput.ts
@@ -1,0 +1,94 @@
+import { useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+import type { InputState } from './state';
+import type { Dir } from '../world/constants';
+
+/**
+ * Keyboard and pointer input, matching `world/engine.js`.
+ *
+ * Both WASD/arrows and the on-screen d-pad write the same movement flags on the
+ * shared `InputState`, so the two are interchangeable. Pointer drag on the
+ * canvas rotates the camera rig directly — no React state is involved anywhere
+ * in here, because all of it is read by the frame loop.
+ */
+
+const KEY_MAP: Record<string, Dir> = {
+  KeyW: 'f',
+  ArrowUp: 'f',
+  KeyS: 'b',
+  ArrowDown: 'b',
+  KeyA: 'l',
+  ArrowLeft: 'l',
+  KeyD: 'r',
+  ArrowRight: 'r',
+};
+
+export function useInput(input: InputState) {
+  const gl = useThree((s) => s.gl);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const dir = KEY_MAP[e.code];
+      if (dir) {
+        input.keys[dir] = true;
+        // Stops the arrow keys scrolling the host page out from under the canvas.
+        e.preventDefault();
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      const dir = KEY_MAP[e.code];
+      if (dir) input.keys[dir] = false;
+    };
+    /** Losing focus mid-stride would otherwise leave the walker running forever. */
+    const releaseAll = () => {
+      input.keys.f = input.keys.b = input.keys.l = input.keys.r = false;
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', releaseAll);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', releaseAll);
+      releaseAll();
+    };
+  }, [input]);
+
+  useEffect(() => {
+    const el = gl.domElement;
+    let dragging = false;
+    let lx = 0;
+    let ly = 0;
+
+    const onPointerDown = (e: PointerEvent) => {
+      dragging = true;
+      lx = e.clientX;
+      ly = e.clientY;
+      el.style.cursor = 'grabbing';
+      if (el.setPointerCapture) el.setPointerCapture(e.pointerId);
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      input.camYaw -= (e.clientX - lx) * 0.005;
+      input.camPitch = Math.min(1.15, Math.max(0.08, input.camPitch + (e.clientY - ly) * 0.004));
+      lx = e.clientX;
+      ly = e.clientY;
+    };
+    const onPointerUp = () => {
+      dragging = false;
+      el.style.cursor = 'grab';
+    };
+
+    el.addEventListener('pointerdown', onPointerDown);
+    el.addEventListener('pointermove', onPointerMove);
+    el.addEventListener('pointerup', onPointerUp);
+    el.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown);
+      el.removeEventListener('pointermove', onPointerMove);
+      el.removeEventListener('pointerup', onPointerUp);
+      el.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [gl, input]);
+}

--- a/src/components/features/tinyPlanet/r3f/usePrefersReducedMotion.ts
+++ b/src/components/features/tinyPlanet/r3f/usePrefersReducedMotion.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks the OS `prefers-reduced-motion` setting.
+ *
+ * Resolved lazily and guarded on `window`, so importing this is safe in an SSR
+ * bundle; it simply reports false until it runs on the client.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduced(query.matches);
+    sync();
+    query.addEventListener('change', sync);
+    return () => query.removeEventListener('change', sync);
+  }, []);
+
+  return reduced;
+}

--- a/src/components/features/tinyPlanet/world/constants.ts
+++ b/src/components/features/tinyPlanet/world/constants.ts
@@ -1,0 +1,22 @@
+import * as THREE from 'three';
+
+/** Movement clamp: the player can never walk further than this from the origin. */
+export const WORLD_R = 178;
+/** Walk speed, world units per second. */
+export const MOVE_SPEED = 14;
+/** Half-width of the dirt path ribbon. */
+export const PATH_HW = 1.7;
+
+/** Cosmetic curvature. 0 is a flat world; higher reads as a smaller planet. */
+export const DEFAULT_CURVATURE = 0.0016;
+export const DEFAULT_TIME_OF_DAY = 0.5;
+export const DEFAULT_CAMERA_DISTANCE = 12;
+
+/** Baked-in sun direction used as the materials' initial uLightDir. */
+export const SUN = new THREE.Vector3(0.45, 0.6, 0.5).normalize();
+
+export const FOG_COLOR = '#cfe7e6';
+export const FOG_NEAR = 60;
+export const FOG_FAR = 270;
+
+export type Dir = 'f' | 'b' | 'l' | 'r';

--- a/src/components/features/tinyPlanet/world/generate.ts
+++ b/src/components/features/tinyPlanet/world/generate.ts
@@ -1,0 +1,316 @@
+import * as THREE from 'three';
+import { createRng, type Rng } from './rng';
+import { PATH_HW, WORLD_R } from './constants';
+
+/**
+ * Procedural layout for the village, ported from `world/engine.js`.
+ *
+ * This produces plain data only — no THREE objects beyond the path curve maths,
+ * no scene mutation. The r3f scene calls `generateWorld` once inside a `useMemo`
+ * and maps the result to JSX, so nothing here ever re-runs on a re-render, let
+ * alone per frame.
+ *
+ * Random draws happen in the same order as the reference engine, so a given
+ * seed produces a layout of the same character (and no seed reproduces today's
+ * every-load-is-different behaviour exactly).
+ */
+
+export interface TreeSpec {
+  kind: 'broad' | 'pine';
+  x: number;
+  z: number;
+  rotY: number;
+  scale: number;
+  /** Broad-leaf foliage colour; unused by pines, which have fixed tiers. */
+  foliageHex: string;
+  /** Random euler for the main foliage blob (broad-leaf only). */
+  blobRot: [number, number, number];
+}
+
+export interface HouseSpec {
+  x: number;
+  z: number;
+  rotY: number;
+  w: number;
+  dp: number;
+  hh: number;
+  wallHex: string;
+  roofHex: string;
+}
+
+export interface ToriiSpec {
+  x: number;
+  z: number;
+  rotY: number;
+}
+
+export interface MailboxSpec {
+  x: number;
+  z: number;
+  rotY: number;
+}
+
+export interface LampSpec {
+  x: number;
+  z: number;
+}
+
+export interface ShadowSpec {
+  x: number;
+  z: number;
+  r: number;
+}
+
+export interface PondSpec {
+  x: number;
+  z: number;
+  r: number;
+  lilies: { x: number; z: number }[];
+}
+
+export interface FlowerSpec {
+  x: number;
+  z: number;
+  hex: string;
+}
+
+export interface RockSpec {
+  x: number;
+  z: number;
+  rotY: number;
+  r: number;
+}
+
+export interface CloudSpec {
+  x: number;
+  y: number;
+  z: number;
+  puffs: { x: number; y: number; z: number; r: number }[];
+}
+
+export interface PathData {
+  positions: Float32Array;
+  edges: Float32Array;
+  index: Uint16Array;
+}
+
+export interface WorldData {
+  path: PathData;
+  houses: HouseSpec[];
+  mailboxes: MailboxSpec[];
+  lamps: LampSpec[];
+  torii: ToriiSpec[];
+  trees: TreeSpec[];
+  ponds: PondSpec[];
+  flowers: FlowerSpec[];
+  rocks: RockSpec[];
+  clouds: CloudSpec[];
+  shadows: ShadowSpec[];
+}
+
+const HOUSE_WALLS = ['#e8b4a0', '#ecd49b', '#a9cbe3', '#cdb4e0', '#e6c0b0'] as const;
+const HOUSE_ROOFS = ['#6b4a3a', '#8a5a42', '#5f6e46'] as const;
+const BROAD_FOLIAGE = ['#4f9a48', '#5aa84f', '#46913f'] as const;
+const FLOWER_COLORS = ['#e8643c', '#f0c64a', '#f4f4f4', '#e86ca0'] as const;
+
+/** Control points of the village road. Fixed — the road is authored, not random. */
+const PATH_POINTS: [number, number][] = [
+  [-130, -60],
+  [-85, -78],
+  [-48, -42],
+  [-18, -58],
+  [12, -26],
+  [26, 16],
+  [-6, 46],
+  [-36, 66],
+  [-14, 96],
+  [36, 112],
+  [80, 98],
+  [122, 124],
+];
+
+/** Perpendicular to a tangent, in the ground plane. */
+function perpXZ(t: THREE.Vector3): THREE.Vector3 {
+  return new THREE.Vector3(t.z, 0, -t.x).normalize();
+}
+
+/** Ribbon of triangles following the road, with an `aEdge` attribute for the soft edges. */
+function buildPath(curve: THREE.CatmullRomCurve3): PathData {
+  const N = 240;
+  const pos: number[] = [];
+  const edge: number[] = [];
+  const idx: number[] = [];
+  for (let i = 0; i <= N; i++) {
+    const t = i / N;
+    const p = curve.getPoint(t);
+    const tan = curve.getTangent(t);
+    tan.y = 0;
+    tan.normalize();
+    const pp = perpXZ(tan);
+    pos.push(p.x + pp.x * PATH_HW, 0.04, p.z + pp.z * PATH_HW, p.x - pp.x * PATH_HW, 0.04, p.z - pp.z * PATH_HW);
+    edge.push(-1, 1);
+  }
+  for (let i = 0; i < N; i++) {
+    const a = i * 2;
+    const b = i * 2 + 1;
+    const c = i * 2 + 2;
+    const d = i * 2 + 3;
+    idx.push(a, b, d, a, d, c);
+  }
+  return { positions: new Float32Array(pos), edges: new Float32Array(edge), index: new Uint16Array(idx) };
+}
+
+export function generateWorld(seed?: number): WorldData {
+  const rng: Rng = createRng(seed);
+  const { range, pick, next, scatter } = rng;
+
+  const curve = new THREE.CatmullRomCurve3(
+    PATH_POINTS.map(([x, z]) => new THREE.Vector3(x, 0, z)),
+    false,
+    'centripetal',
+  );
+
+  /** Coarse samples of the road, used to keep scattered props off it. */
+  const pathSamples: THREE.Vector3[] = [];
+  for (let i = 0; i <= 120; i++) pathSamples.push(curve.getPoint(i / 120));
+
+  const distToPath = (x: number, z: number) => {
+    let m = 1e9;
+    for (const p of pathSamples) {
+      const dx = x - p.x;
+      const dz = z - p.z;
+      const d = dx * dx + dz * dz;
+      if (d < m) m = d;
+    }
+    return Math.sqrt(m);
+  };
+
+  const houses: HouseSpec[] = [];
+  const mailboxes: MailboxSpec[] = [];
+  const lamps: LampSpec[] = [];
+  const torii: ToriiSpec[] = [];
+  const trees: TreeSpec[] = [];
+  const ponds: PondSpec[] = [];
+  const flowers: FlowerSpec[] = [];
+  const rocks: RockSpec[] = [];
+  const clouds: CloudSpec[] = [];
+  const shadows: ShadowSpec[] = [];
+
+  // Houses along the road, alternating sides, each turned to face it.
+  const nH = 11;
+  for (let k = 0; k < nH; k++) {
+    const t = Math.min(0.97, Math.max(0.03, (k + 0.5) / nH + range(-0.02, 0.02)));
+    const p = curve.getPoint(t);
+    const tan = curve.getTangent(t);
+    tan.y = 0;
+    tan.normalize();
+    const pp = perpXZ(tan);
+    const side = k % 2 ? 1 : -1;
+    const off = PATH_HW + range(2.2, 3.0);
+    const hx = p.x + pp.x * off * side;
+    const hz = p.z + pp.z * off * side;
+
+    const wallHex = pick(HOUSE_WALLS);
+    const roofHex = pick(HOUSE_ROOFS);
+    const w = range(2.2, 2.8);
+    const dp = range(2.0, 2.6);
+    const hh = range(1.8, 2.4);
+
+    const dir = new THREE.Vector3(p.x - hx, 0, p.z - hz).normalize();
+    const rotY = Math.atan2(dir.x, dir.z);
+
+    houses.push({ x: hx, z: hz, rotY, w, dp, hh, wallHex, roofHex });
+    shadows.push({ x: hx, z: hz, r: Math.max(w, dp) * 0.85 });
+
+    if (k % 2 === 0) {
+      const mx = hx + dir.x * (off - 1.0);
+      const mz = hz + dir.z * (off - 1.0);
+      mailboxes.push({ x: mx, z: mz, rotY });
+      shadows.push({ x: mx, z: mz, r: 0.4 });
+    }
+  }
+
+  // Street lamps, also alternating sides.
+  for (let s = 0; s < 7; s++) {
+    const t = (s + 0.5) / 7;
+    const p = curve.getPoint(t);
+    const tan = curve.getTangent(t);
+    tan.y = 0;
+    tan.normalize();
+    const pp = perpXZ(tan);
+    const side = s % 2 ? 1 : -1;
+    const lx = p.x + pp.x * (PATH_HW + 0.5) * side;
+    const lz = p.z + pp.z * (PATH_HW + 0.5) * side;
+    lamps.push({ x: lx, z: lz });
+    shadows.push({ x: lx, z: lz, r: 0.5 });
+  }
+
+  // A torii gate at each end of the road.
+  for (const t of [0.06, 0.94]) {
+    const p = curve.getPoint(t);
+    const tan = curve.getTangent(t);
+    tan.y = 0;
+    tan.normalize();
+    torii.push({ x: p.x, z: p.z, rotY: Math.atan2(tan.x, tan.z) });
+    shadows.push({ x: p.x, z: p.z, r: 2.4 });
+  }
+
+  // Trees, rejection-sampled so none land on the road.
+  let placed = 0;
+  let tries = 0;
+  while (placed < 46 && tries < 3000) {
+    tries++;
+    const [x, z] = scatter(8, WORLD_R);
+    if (distToPath(x, z) < 6) continue;
+    const kind: TreeSpec['kind'] = next() < 0.65 ? 'broad' : 'pine';
+    const foliageHex = kind === 'broad' ? pick(BROAD_FOLIAGE) : '';
+    const blobRot: [number, number, number] =
+      kind === 'broad' ? [next(), next(), next()] : [0, 0, 0];
+    const scale = range(0.8, 1.3);
+    const rotY = next() * 6.28;
+    trees.push({ kind, x, z, rotY, scale, foliageHex, blobRot });
+    shadows.push({ x, z, r: 1.5 * scale });
+    placed++;
+  }
+
+  // Two ponds, each with a few lily pads.
+  for (const [minR, maxR] of [
+    [26, 70],
+    [30, 100],
+  ]) {
+    const [x, z] = scatter(minR, maxR);
+    const r = range(3, 4.5);
+    const lilies: { x: number; z: number }[] = [];
+    for (let i = 0; i < 4; i++) {
+      const a = next() * 6.28;
+      const lr = range(0.5, 2.2);
+      lilies.push({ x: x + Math.cos(a) * lr, z: z + Math.sin(a) * lr });
+    }
+    ponds.push({ x, z, r, lilies });
+  }
+
+  for (let i = 0; i < 34; i++) {
+    const hex = pick(FLOWER_COLORS);
+    const [x, z] = scatter(4, WORLD_R);
+    flowers.push({ x, z, hex });
+  }
+
+  for (let i = 0; i < 10; i++) {
+    const r = range(0.4, 0.9);
+    const [x, z] = scatter(8, WORLD_R);
+    rocks.push({ x, z, rotY: next() * 6.28, r });
+  }
+
+  for (let i = 0; i < 7; i++) {
+    const [x, z] = scatter(20, 150);
+    const y = range(34, 58);
+    const puffs = [];
+    for (let j = 0; j < 4; j++) {
+      const r = range(2, 3.4);
+      puffs.push({ x: range(-3, 3), y: range(-0.6, 0.6), z: range(-2, 2), r });
+    }
+    clouds.push({ x, y, z, puffs });
+  }
+
+  return { path: buildPath(curve), houses, mailboxes, lamps, torii, trees, ponds, flowers, rocks, clouds, shadows };
+}

--- a/src/components/features/tinyPlanet/world/geometry.ts
+++ b/src/components/features/tinyPlanet/world/geometry.ts
@@ -1,0 +1,58 @@
+import * as THREE from 'three';
+
+/**
+ * Keyed geometry cache.
+ *
+ * The scene is declarative, so a mesh's geometry is read on every render pass.
+ * Allocating `new THREE.ConeGeometry(...)` inline there would leak a fresh
+ * buffer each time, so all geometry is pulled from one cache built alongside
+ * the materials and disposed with them. It also collapses the repeats — 46
+ * trees share a handful of buffers instead of minting 200-odd.
+ */
+export interface GeometryCache {
+  get(key: string, make: () => THREE.BufferGeometry): THREE.BufferGeometry;
+  cylinder(rTop: number, rBottom: number, height: number, radial: number): THREE.BufferGeometry;
+  cone(radius: number, height: number, radial: number): THREE.BufferGeometry;
+  sphere(radius: number, width: number, height: number): THREE.BufferGeometry;
+  icosahedron(radius: number, detail: number): THREE.BufferGeometry;
+  box(w: number, h: number, d: number): THREE.BufferGeometry;
+  /** A circle laid flat on the ground plane (rotated onto XZ), as the engine's shadows are. */
+  circleXZ(radius: number, segments: number): THREE.BufferGeometry;
+  dispose(): void;
+}
+
+export function createGeometryCache(): GeometryCache {
+  const cache = new Map<string, THREE.BufferGeometry>();
+
+  const get = (key: string, make: () => THREE.BufferGeometry) => {
+    let g = cache.get(key);
+    if (!g) {
+      g = make();
+      cache.set(key, g);
+    }
+    return g;
+  };
+
+  /** Geometry dimensions are floats; round the key so near-identical props still share. */
+  const k = (n: number) => n.toFixed(4);
+
+  return {
+    get,
+    cylinder: (rt, rb, h, radial) =>
+      get(`cyl:${k(rt)}:${k(rb)}:${k(h)}:${radial}`, () => new THREE.CylinderGeometry(rt, rb, h, radial)),
+    cone: (r, h, radial) => get(`cone:${k(r)}:${k(h)}:${radial}`, () => new THREE.ConeGeometry(r, h, radial)),
+    sphere: (r, w, h) => get(`sph:${k(r)}:${w}:${h}`, () => new THREE.SphereGeometry(r, w, h)),
+    icosahedron: (r, detail) => get(`ico:${k(r)}:${detail}`, () => new THREE.IcosahedronGeometry(r, detail)),
+    box: (w, h, d) => get(`box:${k(w)}:${k(h)}:${k(d)}`, () => new THREE.BoxGeometry(w, h, d)),
+    circleXZ: (r, segments) =>
+      get(`circ:${k(r)}:${segments}`, () => {
+        const g = new THREE.CircleGeometry(r, segments);
+        g.rotateX(-Math.PI / 2);
+        return g;
+      }),
+    dispose() {
+      for (const g of cache.values()) g.dispose();
+      cache.clear();
+    },
+  };
+}

--- a/src/components/features/tinyPlanet/world/materials.ts
+++ b/src/components/features/tinyPlanet/world/materials.ts
@@ -1,0 +1,169 @@
+import * as THREE from 'three';
+import { shaderMaterial } from '@react-three/drei';
+import { vert, vertPath, fragLit, fragGround, fragFlat, fragGlow, fragPath, skyVert, skyFrag } from './shaders';
+import { SUN, FOG_COLOR, FOG_NEAR, FOG_FAR, DEFAULT_CURVATURE } from './constants';
+
+/**
+ * The six world materials, defined with drei's `shaderMaterial` helper.
+ *
+ * Every material except the sky shares the same vertex shader, which is what
+ * makes the curvature read as one continuous world rather than per-object
+ * warping. Instances are handed out through the caches in `createMaterials`
+ * below — the reference engine cached by colour too — and the frame loop walks
+ * the resulting registry once per frame to refresh uniforms.
+ *
+ * Note on construction: drei applies constructor parameters inside `super()`,
+ * *before* it installs the per-uniform accessors. So constructor args are for
+ * material properties only (transparent / depthWrite / side); uniform values
+ * are assigned afterwards through the generated accessors.
+ */
+
+/** Uniforms every world material carries: player position, curvature, and fog. */
+const common = () => ({
+  uPlayer: new THREE.Vector3(),
+  uCurvature: DEFAULT_CURVATURE,
+  uFog: new THREE.Color(FOG_COLOR),
+  uFogNear: FOG_NEAR,
+  uFogFar: FOG_FAR,
+});
+
+/** Uniforms shared by the two directionally-lit materials. */
+const lighting = () => ({
+  uLightDir: SUN.clone(),
+  uLightColor: new THREE.Color(1, 1, 1),
+  uAmbient: new THREE.Color(0.4, 0.45, 0.5),
+});
+
+const LitMaterial = shaderMaterial({ ...common(), ...lighting(), uColor: new THREE.Color('#ffffff') }, vert, fragLit);
+const GroundMaterial = shaderMaterial({ ...common(), ...lighting() }, vert, fragGround);
+const FlatMaterial = shaderMaterial({ ...common(), uColor: new THREE.Color('#ffffff'), uAlpha: 1 }, vert, fragFlat);
+const GlowMaterial = shaderMaterial(
+  { ...common(), uDayColor: new THREE.Color('#ffffff'), uNightColor: new THREE.Color('#ffffff'), uGlow: 0 },
+  vert,
+  fragGlow,
+);
+const PathMaterial = shaderMaterial({ ...common(), uTint: new THREE.Color(1, 1, 1) }, vertPath, fragPath);
+const SkyMaterial = shaderMaterial(
+  {
+    uHorizon: new THREE.Color('#cfe7e6'),
+    uZenith: new THREE.Color('#6ea7d6'),
+    uSun: SUN.clone(),
+    uSunCol: new THREE.Color('#fff2cf'),
+  },
+  skyVert,
+  skyFrag,
+);
+
+export type SkyMaterialImpl = InstanceType<typeof SkyMaterial>;
+
+export interface Materials {
+  /**
+   * Every material the frame loop refreshes each tick. The sky is deliberately
+   * absent — it has its own uniform set and is updated directly.
+   */
+  registry: THREE.ShaderMaterial[];
+  /** Solid, directionally-lit colour. Cached per hex, as in the reference engine. */
+  lit(hex: string): THREE.ShaderMaterial;
+  /** The procedurally-tinted ground. One instance. */
+  ground(): THREE.ShaderMaterial;
+  /** Unlit flat colour, optionally translucent. Cached per hex+alpha. */
+  flat(hex: string, alpha: number): THREE.ShaderMaterial;
+  /** Emissive blend that lifts from `dayHex` to `nightHex` as dusk falls. Cached per pair. */
+  glow(dayHex: string, nightHex: string): THREE.ShaderMaterial;
+  /** The dirt path ribbon. One instance. */
+  path(): THREE.ShaderMaterial;
+  sky: SkyMaterialImpl;
+  /**
+   * Clouds are plain unlit basic material, exactly as in the reference engine —
+   * deliberately outside the registry, so they neither curve with the world nor
+   * pick up the day/night tint. They read as distant sky, not as scenery.
+   */
+  cloud: THREE.MeshBasicMaterial;
+  dispose(): void;
+}
+
+/**
+ * Build one material set. Call once per mounted world (inside a `useMemo`) —
+ * never per frame, and never per mesh.
+ */
+export function createMaterials(): Materials {
+  const registry: THREE.ShaderMaterial[] = [];
+  const litCache = new Map<string, THREE.ShaderMaterial>();
+  const flatCache = new Map<string, THREE.ShaderMaterial>();
+  const glowCache = new Map<string, THREE.ShaderMaterial>();
+  let groundMat: THREE.ShaderMaterial | null = null;
+  let pathMat: THREE.ShaderMaterial | null = null;
+
+  const track = <T extends THREE.ShaderMaterial>(m: T): T => {
+    registry.push(m);
+    return m;
+  };
+
+  const sky = new SkyMaterial({ side: THREE.BackSide, depthWrite: false });
+  const cloud = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.92 });
+
+  return {
+    registry,
+    sky,
+    cloud,
+
+    lit(hex) {
+      let m = litCache.get(hex);
+      if (!m) {
+        const created = new LitMaterial();
+        created.uColor = new THREE.Color(hex);
+        m = track(created);
+        litCache.set(hex, m);
+      }
+      return m;
+    },
+
+    ground() {
+      groundMat ??= track(new GroundMaterial());
+      return groundMat;
+    },
+
+    flat(hex, alpha) {
+      const key = `${hex}_${alpha}`;
+      let m = flatCache.get(key);
+      if (!m) {
+        const created = new FlatMaterial({ transparent: alpha < 1.0, depthWrite: alpha >= 1.0 });
+        created.uColor = new THREE.Color(hex);
+        created.uAlpha = alpha;
+        m = track(created);
+        flatCache.set(key, m);
+      }
+      return m;
+    },
+
+    glow(dayHex, nightHex) {
+      const key = `${dayHex}_${nightHex}`;
+      let m = glowCache.get(key);
+      if (!m) {
+        const created = new GlowMaterial();
+        created.uDayColor = new THREE.Color(dayHex);
+        created.uNightColor = new THREE.Color(nightHex);
+        m = track(created);
+        glowCache.set(key, m);
+      }
+      return m;
+    },
+
+    path() {
+      pathMat ??= track(new PathMaterial({ transparent: true, depthWrite: false, side: THREE.DoubleSide }));
+      return pathMat;
+    },
+
+    dispose() {
+      for (const m of registry) m.dispose();
+      registry.length = 0;
+      litCache.clear();
+      flatCache.clear();
+      glowCache.clear();
+      groundMat = null;
+      pathMat = null;
+      sky.dispose();
+      cloud.dispose();
+    },
+  };
+}

--- a/src/components/features/tinyPlanet/world/palette.ts
+++ b/src/components/features/tinyPlanet/world/palette.ts
@@ -1,0 +1,99 @@
+import * as THREE from 'three';
+
+/**
+ * The day/night cycle, lifted from `world/engine.js`.
+ *
+ * One scalar — `timeOfDay` in 0..1 — drives everything: sun direction, sky
+ * gradient, light and ambient colour, fog, the path tint, and the emissive
+ * "glow" that lifts lamps and windows at dusk. Nothing here rebuilds geometry
+ * or swaps materials; the frame loop just copies these values into uniforms.
+ */
+
+/** Shared so the control label and the actual sun agree on the current phase. */
+export function phaseLabel(timeT: number): 'Dawn' | 'Day' | 'Dusk' | 'Night' {
+  const up = -Math.cos(timeT * Math.PI * 2.0);
+  if (up > 0.2) return 'Day';
+  if (up < -0.08) return 'Night';
+  return timeT < 0.5 ? 'Dawn' : 'Dusk';
+}
+
+/** Smoothstep. Also runs backwards (e0 > e1), which is how `glow` inverts. */
+const ss = (e0: number, e1: number, x: number) => {
+  const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return t * t * (3 - 2 * t);
+};
+
+/** Day / twilight / night stops for one blended channel. */
+interface Stops {
+  d: THREE.Color;
+  t: THREE.Color;
+  n: THREE.Color;
+}
+
+const P: Record<'horizon' | 'zenith' | 'sunCol' | 'light' | 'ambient', Stops> = {
+  horizon: { d: new THREE.Color('#cfe7e6'), t: new THREE.Color('#f3c89a'), n: new THREE.Color('#16223c') },
+  zenith: { d: new THREE.Color('#6ea7d6'), t: new THREE.Color('#8a6f9e'), n: new THREE.Color('#0a1024') },
+  sunCol: { d: new THREE.Color('#fff2cf'), t: new THREE.Color('#ffb060'), n: new THREE.Color('#9fb0cf') },
+  light: { d: new THREE.Color(0.97, 0.93, 0.82), t: new THREE.Color(0.95, 0.55, 0.3), n: new THREE.Color(0.1, 0.13, 0.22) },
+  ambient: { d: new THREE.Color(0.45, 0.48, 0.46), t: new THREE.Color(0.32, 0.27, 0.3), n: new THREE.Color(0.11, 0.13, 0.2) },
+};
+
+function blend(field: keyof typeof P, out: THREE.Color, wN: number, wT: number, wD: number) {
+  const a = P[field].n;
+  const b = P[field].t;
+  const c = P[field].d;
+  out.setRGB(a.r * wN + b.r * wT + c.r * wD, a.g * wN + b.g * wT + c.g * wD, a.b * wN + b.b * wT + c.b * wD);
+}
+
+/** Everything `timeOfDay` resolves to. Mutated in place each frame — never reallocated. */
+export interface SkyState {
+  sunDir: THREE.Vector3;
+  horizon: THREE.Color;
+  zenith: THREE.Color;
+  sunCol: THREE.Color;
+  light: THREE.Color;
+  ambient: THREE.Color;
+  tint: THREE.Color;
+  /** 0 by day, 1 at night — drives the emissive lamp/window blend. */
+  glow: number;
+}
+
+export function createSkyState(): SkyState {
+  return {
+    sunDir: new THREE.Vector3(),
+    horizon: new THREE.Color(),
+    zenith: new THREE.Color(),
+    sunCol: new THREE.Color(),
+    light: new THREE.Color(),
+    ambient: new THREE.Color(),
+    tint: new THREE.Color(),
+    glow: 0,
+  };
+}
+
+/** Resolve `timeT` (0..1) into `state`, in place. */
+export function updateSkyState(state: SkyState, timeT: number): void {
+  const ang = timeT * Math.PI * 2.0;
+  state.sunDir.set(Math.sin(ang) * 0.6, -Math.cos(ang), 0.32).normalize();
+  const up = state.sunDir.y;
+
+  let wD = ss(0.1, 0.4, up);
+  let wN = 1.0 - ss(-0.28, 0.06, up);
+  let wT = Math.max(0, 1.0 - wD - wN);
+  const sum = wD + wN + wT || 1;
+  wD /= sum;
+  wN /= sum;
+  wT /= sum;
+
+  blend('horizon', state.horizon, wN, wT, wD);
+  blend('zenith', state.zenith, wN, wT, wD);
+  blend('sunCol', state.sunCol, wN, wT, wD);
+  blend('light', state.light, wN, wT, wD);
+  blend('ambient', state.ambient, wN, wT, wD);
+  state.tint.setRGB(
+    Math.min(1, state.ambient.r + state.light.r * 0.6),
+    Math.min(1, state.ambient.g + state.light.g * 0.6),
+    Math.min(1, state.ambient.b + state.light.b * 0.6),
+  );
+  state.glow = ss(0.15, -0.1, up);
+}

--- a/src/components/features/tinyPlanet/world/rng.ts
+++ b/src/components/features/tinyPlanet/world/rng.ts
@@ -1,0 +1,46 @@
+/**
+ * Random-number source for world generation.
+ *
+ * The reference engine calls `Math.random()` directly, so every load builds a
+ * different village. That is still the default here — pass no seed and you get
+ * exactly that behaviour. Passing a seed makes the layout reproducible, which is
+ * what an embedder wants when every visitor should see the same curated world.
+ */
+
+export interface Rng {
+  /** Uniform in [0, 1), the `Math.random()` contract. */
+  next(): number;
+  /** Uniform in [a, b) — the engine's `rand(a, b)`. */
+  range(a: number, b: number): number;
+  /** Uniform choice from a non-empty list — the engine's `arr[(Math.random()*n)|0]`. */
+  pick<T>(items: readonly T[]): T;
+  /** A point in the annulus between `minR` and `maxR`, uniform by area. */
+  scatter(minR: number, maxR: number): [number, number];
+}
+
+/** Mulberry32 — small, fast, and good enough for scattering trees. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createRng(seed?: number): Rng {
+  const next = seed == null ? Math.random : mulberry32(seed);
+  const range = (a: number, b: number) => a + next() * (b - a);
+  return {
+    next,
+    range,
+    pick: (items) => items[(next() * items.length) | 0],
+    scatter: (minR, maxR) => {
+      const a = next() * Math.PI * 2;
+      const r = Math.sqrt(range(minR * minR, maxR * maxR));
+      return [Math.cos(a) * r, Math.sin(a) * r];
+    },
+  };
+}

--- a/src/components/features/tinyPlanet/world/shaders.ts
+++ b/src/components/features/tinyPlanet/world/shaders.ts
@@ -1,0 +1,104 @@
+/**
+ * GLSL for the Tiny Planet world, lifted verbatim from `world/engine.js`.
+ *
+ * These strings are the effect and are copied byte-for-byte — `verify-shaders.mjs`
+ * asserts they still match the reference engine. The shared `vert` snippet is what
+ * makes the planet: the world is a flat plane, and every vertex is simply lowered
+ * by the square of its horizontal distance from the player. Because the same
+ * snippet runs in every world material, the whole scene bends as one.
+ */
+export const vert = `
+    uniform vec3 uPlayer; uniform float uCurvature;
+    varying vec3 vNormalW; varying vec3 vWorldPos; varying float vFogDepth; varying float vUp;
+    void main(){
+      vec4 wp = modelMatrix * vec4(position, 1.0);
+      float d = distance(wp.xz, uPlayer.xz);
+      wp.y -= d * d * uCurvature;
+      vWorldPos = wp.xyz;
+      vNormalW = normalize((modelMatrix * vec4(normal, 0.0)).xyz);
+      vUp = vNormalW.y;
+      vec4 mv = viewMatrix * wp; vFogDepth = -mv.z;
+      gl_Position = projectionMatrix * mv;
+    }`;
+export const fragLit = `
+    precision highp float;
+    uniform vec3 uColor, uLightDir, uLightColor, uAmbient, uFog; uniform float uFogNear, uFogFar;
+    varying vec3 vNormalW; varying float vFogDepth; varying float vUp;
+    void main(){
+      vec3 N = normalize(vNormalW); float diff = max(dot(N, normalize(uLightDir)), 0.0);
+      float light = smoothstep(0.12, 0.5, diff);
+      vec3 col = uColor * (uAmbient * (0.78 + 0.22*vUp) + uLightColor * light);
+      col = col / (1.0 + col * 0.6);
+      float lum = dot(col, vec3(0.299, 0.587, 0.114));
+      col = clamp(mix(vec3(lum), col, 1.35), 0.0, 1.0);
+      float f = clamp((vFogDepth - uFogNear)/(uFogFar - uFogNear), 0.0, 1.0);
+      gl_FragColor = vec4(mix(col, uFog, f), 1.0);
+    }`;
+export const fragGround = `
+    precision highp float;
+    uniform vec3 uLightDir, uLightColor, uAmbient, uFog; uniform float uFogNear, uFogFar;
+    varying vec3 vNormalW; varying vec3 vWorldPos; varying float vFogDepth; varying float vUp;
+    void main(){
+      vec3 N = normalize(vNormalW); float diff = max(dot(N, normalize(uLightDir)), 0.0);
+      float light = smoothstep(0.12, 0.55, diff);
+      float n = sin(vWorldPos.x*0.06)*sin(vWorldPos.z*0.06) + 0.5*sin(vWorldPos.x*0.13+1.3)*sin(vWorldPos.z*0.11-0.7);
+      vec3 base = mix(vec3(0.49,0.71,0.39), vec3(0.60,0.80,0.47), clamp(n*0.5+0.5, 0.0, 1.0));
+      vec3 col = base * (uAmbient * (0.85 + 0.15*vUp) + uLightColor * light);
+      col = col / (1.0 + col * 0.6);
+      float lum = dot(col, vec3(0.299, 0.587, 0.114));
+      col = clamp(mix(vec3(lum), col, 1.35), 0.0, 1.0);
+      float f = clamp((vFogDepth - uFogNear)/(uFogFar - uFogNear), 0.0, 1.0);
+      gl_FragColor = vec4(mix(col, uFog, f), 1.0);
+    }`;
+export const fragFlat = `
+    precision highp float;
+    uniform vec3 uColor; uniform float uAlpha; uniform vec3 uFog; uniform float uFogNear, uFogFar;
+    varying float vFogDepth;
+    void main(){
+      float f = clamp((vFogDepth - uFogNear)/(uFogFar - uFogNear), 0.0, 1.0);
+      gl_FragColor = vec4(mix(uColor, uFog, f), uAlpha);
+    }`;
+export const fragGlow = `
+    precision highp float;
+    uniform vec3 uDayColor, uNightColor, uFog; uniform float uGlow, uFogNear, uFogFar;
+    varying float vFogDepth;
+    void main(){
+      vec3 c = mix(uDayColor, uNightColor, uGlow);
+      float f = clamp((vFogDepth - uFogNear)/(uFogFar - uFogNear), 0.0, 1.0);
+      gl_FragColor = vec4(mix(c, uFog, f), 1.0);
+    }`;
+export const vertPath = `
+    uniform vec3 uPlayer; uniform float uCurvature;
+    attribute float aEdge;
+    varying vec3 vWorldPos; varying float vFogDepth; varying float vEdge;
+    void main(){
+      vec4 wp = modelMatrix * vec4(position, 1.0);
+      float d = distance(wp.xz, uPlayer.xz);
+      wp.y -= d * d * uCurvature;
+      vWorldPos = wp.xyz; vEdge = aEdge;
+      vec4 mv = viewMatrix * wp; vFogDepth = -mv.z;
+      gl_Position = projectionMatrix * mv;
+    }`;
+export const fragPath = `
+    precision highp float;
+    uniform vec3 uTint, uFog; uniform float uFogNear, uFogFar;
+    varying vec3 vWorldPos; varying float vFogDepth; varying float vEdge;
+    void main(){
+      float a = smoothstep(1.0, 0.72, abs(vEdge));
+      float v = 0.5 + 0.5*sin(vWorldPos.x*0.35)*sin(vWorldPos.z*0.35);
+      vec3 dirt = mix(vec3(0.60,0.48,0.33), vec3(0.70,0.57,0.40), v) * uTint;
+      float f = clamp((vFogDepth - uFogNear)/(uFogFar - uFogNear), 0.0, 1.0);
+      gl_FragColor = vec4(mix(dirt, uFog, f), a * 0.97);
+    }`;
+export const skyVert = `varying vec3 vDir; void main(){ vDir = position; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`;
+export const skyFrag = `
+    precision highp float;
+    uniform vec3 uHorizon, uZenith, uSun, uSunCol;
+    varying vec3 vDir;
+    void main(){
+      vec3 d = normalize(vDir);
+      vec3 col = mix(uHorizon, uZenith, pow(clamp(d.y*0.5+0.5, 0.0, 1.0), 0.9));
+      float s = max(dot(d, normalize(uSun)), 0.0);
+      col += uSunCol * pow(s, 300.0) * 1.3 + uSunCol * pow(s, 7.0) * 0.12;
+      gl_FragColor = vec4(col, 1.0);
+    }`;


### PR DESCRIPTION
Embeds the [Tiny Planet](https://github.com/demaceo/tiny-planet) r3f experience as a standalone route at **`/tiny-planet`**.

Pairs with demaceo/tiny-planet#1, which rewrote the experience from imperative Three.js into react-three-fiber and shipped it as a self-contained component.

## What's here

- `src/app/tiny-planet/` — the route: `page.tsx`, `layout.tsx`, `tiny-planet.module.css`
- `src/components/features/tinyPlanet/` — the vendored component + a `README.md` recording provenance
- `package.json` / `pnpm-lock.yaml` — three, fiber, drei, `@types/three`
- `pnpm-workspace.yaml` — fills in the `allowBuilds` placeholders (see the last section)

**No existing source file is modified.** `git diff main` outside those two new directories touches only the dependency manifests and `pnpm-workspace.yaml`, so `/` and `/woozyx3` cannot be affected.

## Decisions

**Standalone route, not a desktop app.** `/woozyx3` is the precedent — a real Next route, unlinked from the Macintosh shell, no back affordance. `DESKTOP_APPS` and `projects.ts` are untouched, so this is reachable by direct URL only. Linking it later is a one-line change.

**Vendored, not a shared package.** `pnpm-workspace.yaml` declares no `packages:`, so this repo isn't a monorepo and a local package would be more machinery than it's worth. The copy mirrors upstream's subfolder depth exactly, which lets every relative import stay unedited — it is byte-identical to upstream apart from two `"use client"` directives on the component entry points, so `diff -r` stays meaningful. Documented in the folder's README.

**SSR.** The page is a Client Component and pulls the experience in via `next/dynamic` with `ssr: false` (the same shape `Modals.tsx` already uses). WebGL never runs on the server, three.js stays out of every other route's bundle, and there is no server render to mismatch on hydration. Metadata lives in `layout.tsx` because a client page can't export it.

**Theming: fonts only.** The vendored CSS Module exposes every colour and font as a custom property, so the route overrides variables rather than forking the stylesheet — and overrides only `--tp-font-ui` / `--tp-font-display` to your Poppins and Sora. The cream glass is kept deliberately: it was tuned against this pastel world and reads as part of the artwork, where the dark Liquid Glass tokens were designed against a very different background. Confirmed applied — computed styles resolve to `Poppins, Inter, …` and `Sora, Poppins, …`.

The override selector is `.themed.themed`. That doubling is intentional: `TinyPlanetShowcase` renders `${styles.root} ${className}`, and `.root` declares those same variables, so at equal specificity the winner would come down to CSS source order in the bundle.

**Fixed seed.** The world is generated procedurally; without a seed every visitor would land in a different village. `WORLD_SEED` pins it.

## Two fixes made upstream and re-vendored

1. A local `const window` in the house builder shadowed the global — harmless in the Vite build, wrong to carry next to an SSR boundary.
2. At 390px the overlay hint was centred and `nowrap`, so it ran straight through the Controls button *and* the d-pad. It now tucks above the button, wraps, and stops short of the d-pad. Also reworded, since "WASD to walk" isn't useful advice on a touch device.

## Verification

`pnpm lint` clean (no warnings or errors). `pnpm build` succeeds.

Bundle impact is confined to the route:

| Route | First Load JS |
|---|---|
| `/` | 230 kB (unchanged) |
| `/tiny-planet` | **103 kB** |

three.js loads as a separate on-demand chunk — 669 kB raw, **166 kB gzipped** — only when someone visits the route. drei tree-shook cleanly: the build contains zero references to `OrbitControls`, `troika`, `MeshBVH`, `GLTFLoader`, or `useGLTF`; only the ~17-line `shaderMaterial` helper is actually pulled in.

Driven in headless Chromium against the production build:

- **Zero hydration warnings** on `/tiny-planet`, `/`, and `/woozyx3`
- Canvas fills its container exactly at 1440×900 and 390×844; no vertical or horizontal page scroll
- Panel sliders drive curvature and the full day/night sweep; keyboard, pointer-drag, and touch d-pad all move the world
- d-pad fully on-screen at 42px on a 390px viewport
- **Seed is deterministic** — under reduced-motion emulation (which freezes cloud drift, bob, and the intro sunrise) two separate page loads render byte-identical frames

The only console output on `/tiny-planet` is a Google Fonts connection failure and a 404 for `/_vercel/speed-insights/script.js`. Both appear identically on `/` and `/woozyx3` in the sandbox this was tested in — they're environmental (no outbound font CDN, and Speed Insights only exists on Vercel), not introduced here.

## The pnpm build-script warning

An earlier revision of this description claimed that sharp going unbuilt "can affect image optimization on deploy." **That was wrong** — correcting it here.

`pnpm install` was warning `Ignored build scripts: core-js, sharp, unrs-resolver`. Nothing was broken by it:

- **sharp was fully functional.** Its install script is `node install/check.js || npm run build` — verify the prebuilt binary, else compile from source. The prebuilt `@img/sharp-linux-x64@0.34.5` and `@img/sharp-libvips-linux-x64@1.2.4` were already installed, so the check is a no-op. Resolved the way Next does and exercised directly: sharp 0.34.5 / libvips 8.17.3, encodes a PNG fine. sharp arrives transitively from `next@15.4.10`, not from this PR.
- **core-js**'s postinstall is `node -e "try{require('./postinstall')}catch(e){}"` — the funding message, in a try/catch that swallows everything.
- **unrs-resolver** had its prebuilt napi binding, and lint passed throughout.

The real defect was that `pnpm-workspace.yaml` held the literal string `"set this to true or false"` for each entry. `allowBuilds` is a valid pnpm 10 setting — pnpm's own `approve-builds` writes it — but it takes **booleans**, so pnpm discarded the placeholders and kept warning. That file predates this work (`859a0c4`).

Now set to `sharp: true`, `unrs-resolver: true`, `core-js: false` — the two real scripts are allowed so their source-build fallback stays available on a platform without a prebuilt match, and core-js stays off since its script does nothing. Verified from a scratch `rm -rf node_modules && pnpm install --frozen-lockfile`: no warning, sharp still encodes, lint clean, build output byte-for-byte the same route sizes.